### PR TITLE
Restore new line after table output

### DIFF
--- a/internal/pkg/tables/tables.go
+++ b/internal/pkg/tables/tables.go
@@ -48,5 +48,5 @@ func (t *Table) Render(cmd *cobra.Command) {
 	t.table.Style().Options.SeparateRows = false
 	t.table.Style().Options.SeparateColumns = true
 	t.table.Style().Options.SeparateHeader = true
-	cmd.Printf("\n%s\n", t.table.Render())
+	cmd.Printf("\n%s\n\n", t.table.Render())
 }


### PR DESCRIPTION
Since #9, we are now using the returned value of the render method instead of writing directly to the output, and the render implementation does not return the `\n` printed at the end:

![image](https://github.com/stackitcloud/stackit-cli/assets/28832884/da23c5fa-ee31-4e60-a5f0-f6fd5c045d9c)
