### PR TITLE
Uniform command descriptions' format

### DIFF
--- a/docs/stackit.md
+++ b/docs/stackit.md
@@ -27,7 +27,7 @@ stackit [flags]
 
 * [stackit auth](./stackit_auth.md)	 - Provides authentication functionality
 * [stackit config](./stackit_config.md)	 - CLI configuration options
-* [stackit curl](./stackit_curl.md)	 - Execute an authenticated HTTP request to an endpoint
+* [stackit curl](./stackit_curl.md)	 - Executes an authenticated HTTP request to an endpoint
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
 * [stackit mongodbflex](./stackit_mongodbflex.md)	 - Provides functionality for MongoDB Flex
 * [stackit opensearch](./stackit_opensearch.md)	 - Provides functionality for OpenSearch

--- a/docs/stackit_auth.md
+++ b/docs/stackit_auth.md
@@ -4,7 +4,7 @@ Provides authentication functionality
 
 ### Synopsis
 
-Provides authentication functionality
+Provides authentication functionality.
 
 ```
 stackit auth [flags]

--- a/docs/stackit_auth.md
+++ b/docs/stackit_auth.md
@@ -28,6 +28,6 @@ stackit auth [flags]
 ### SEE ALSO
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
-* [stackit auth activate-service-account](./stackit_auth_activate-service-account.md)	 - Activate service account authentication
-* [stackit auth login](./stackit_auth_login.md)	 - Login to the STACKIT CLI
+* [stackit auth activate-service-account](./stackit_auth_activate-service-account.md)	 - Authenticates using a service account
+* [stackit auth login](./stackit_auth_login.md)	 - Logs in to the STACKIT CLI
 

--- a/docs/stackit_auth_activate-service-account.md
+++ b/docs/stackit_auth_activate-service-account.md
@@ -1,10 +1,10 @@
 ## stackit auth activate-service-account
 
-Activate service account authentication
+Authenticates using a service account
 
 ### Synopsis
 
-Activate authentication using service account credentials.
+Authenticates to the CLI using service account credentials.
 Subsequent commands will be authenticated using the service account credentials provided.
 For more details on how to configure your service account, check our Authentication guide at https://github.com/stackitcloud/stackit-cli/blob/main/AUTHENTICATION.md.
 

--- a/docs/stackit_auth_login.md
+++ b/docs/stackit_auth_login.md
@@ -1,10 +1,10 @@
 ## stackit auth login
 
-Login to the STACKIT CLI
+Logs in to the STACKIT CLI
 
 ### Synopsis
 
-Login to the STACKIT CLI.
+Logs in to the STACKIT CLI using a user account.
 
 ```
 stackit auth login [flags]

--- a/docs/stackit_auth_login.md
+++ b/docs/stackit_auth_login.md
@@ -4,7 +4,7 @@ Login to the STACKIT CLI
 
 ### Synopsis
 
-Login to the STACKIT CLI
+Login to the STACKIT CLI.
 
 ```
 stackit auth login [flags]

--- a/docs/stackit_config.md
+++ b/docs/stackit_config.md
@@ -4,7 +4,7 @@ CLI configuration options
 
 ### Synopsis
 
-CLI configuration options
+CLI configuration options.
 
 ```
 stackit config [flags]

--- a/docs/stackit_config.md
+++ b/docs/stackit_config.md
@@ -28,7 +28,7 @@ stackit config [flags]
 ### SEE ALSO
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
-* [stackit config list](./stackit_config_list.md)	 - List the current CLI configuration values
-* [stackit config set](./stackit_config_set.md)	 - Set CLI configuration options
-* [stackit config unset](./stackit_config_unset.md)	 - Unset CLI configuration options
+* [stackit config list](./stackit_config_list.md)	 - Lists the current CLI configuration values
+* [stackit config set](./stackit_config_set.md)	 - Sets CLI configuration options
+* [stackit config unset](./stackit_config_unset.md)	 - Unsets CLI configuration options
 

--- a/docs/stackit_config_list.md
+++ b/docs/stackit_config_list.md
@@ -4,7 +4,7 @@ List the current CLI configuration values
 
 ### Synopsis
 
-List the current CLI configuration values
+List the current CLI configuration values.
 
 ```
 stackit config list [flags]

--- a/docs/stackit_config_list.md
+++ b/docs/stackit_config_list.md
@@ -1,10 +1,10 @@
 ## stackit config list
 
-List the current CLI configuration values
+Lists the current CLI configuration values
 
 ### Synopsis
 
-List the current CLI configuration values.
+Lists the current CLI configuration values.
 
 ```
 stackit config list [flags]

--- a/docs/stackit_config_set.md
+++ b/docs/stackit_config_set.md
@@ -1,13 +1,13 @@
 ## stackit config set
 
-Set CLI configuration options
+Sets CLI configuration options
 
 ### Synopsis
 
-Set CLI configuration options. 
-All of the configuration options can be set using an environment variable, which takes precedence over what is configured. 
+Sets CLI configuration options.
+All of the configuration options can be set using an environment variable, which takes precedence over what is configured.
 The environment variable is the name of the flag, with underscores ("_") instead of dashes ("-") and the "STACKIT" prefix.
-Example: to set the project ID you can set the environment variable STACKIT_PROJECT_ID
+Example: to set the project ID you can set the environment variable STACKIT_PROJECT_ID.
 
 ```
 stackit config set [flags]

--- a/docs/stackit_config_unset.md
+++ b/docs/stackit_config_unset.md
@@ -4,7 +4,7 @@ Unset CLI configuration options
 
 ### Synopsis
 
-Unset CLI configuration options
+Unset CLI configuration options.
 
 ```
 stackit config unset [flags]

--- a/docs/stackit_config_unset.md
+++ b/docs/stackit_config_unset.md
@@ -1,10 +1,10 @@
 ## stackit config unset
 
-Unset CLI configuration options
+Unsets CLI configuration options
 
 ### Synopsis
 
-Unset CLI configuration options.
+Unsets CLI configuration options.
 
 ```
 stackit config unset [flags]

--- a/docs/stackit_curl.md
+++ b/docs/stackit_curl.md
@@ -4,7 +4,7 @@ Execute an authenticated HTTP request to an endpoint
 
 ### Synopsis
 
-Execute an HTTP request to an endpoint, using the authentication provided by the CLI
+Execute an HTTP request to an endpoint, using the authentication provided by the CLI.
 
 ```
 stackit curl URL [flags]

--- a/docs/stackit_curl.md
+++ b/docs/stackit_curl.md
@@ -1,10 +1,10 @@
 ## stackit curl
 
-Execute an authenticated HTTP request to an endpoint
+Executes an authenticated HTTP request to an endpoint
 
 ### Synopsis
 
-Execute an HTTP request to an endpoint, using the authentication provided by the CLI.
+Executes an HTTP request to an endpoint, using the authentication provided by the CLI.
 
 ```
 stackit curl URL [flags]

--- a/docs/stackit_dns.md
+++ b/docs/stackit_dns.md
@@ -4,7 +4,7 @@ Provides functionality for DNS
 
 ### Synopsis
 
-Provides functionality for DNS
+Provides functionality for DNS.
 
 ```
 stackit dns [flags]

--- a/docs/stackit_dns_record-set.md
+++ b/docs/stackit_dns_record-set.md
@@ -4,7 +4,7 @@ Provides functionality for DNS record set
 
 ### Synopsis
 
-Provides functionality for DNS record set
+Provides functionality for DNS record set.
 
 ```
 stackit dns record-set [flags]
@@ -28,9 +28,9 @@ stackit dns record-set [flags]
 ### SEE ALSO
 
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
-* [stackit dns record-set create](./stackit_dns_record-set_create.md)	 - Creates a DNS record set
+* [stackit dns record-set create](./stackit_dns_record-set_create.md)	 - Create a DNS record set
 * [stackit dns record-set delete](./stackit_dns_record-set_delete.md)	 - Delete a DNS record set
 * [stackit dns record-set describe](./stackit_dns_record-set_describe.md)	 - Get details of a DNS record set
 * [stackit dns record-set list](./stackit_dns_record-set_list.md)	 - List DNS record sets
-* [stackit dns record-set update](./stackit_dns_record-set_update.md)	 - Updates a DNS record set
+* [stackit dns record-set update](./stackit_dns_record-set_update.md)	 - Update a DNS record set
 

--- a/docs/stackit_dns_record-set.md
+++ b/docs/stackit_dns_record-set.md
@@ -28,9 +28,9 @@ stackit dns record-set [flags]
 ### SEE ALSO
 
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
-* [stackit dns record-set create](./stackit_dns_record-set_create.md)	 - Create a DNS record set
-* [stackit dns record-set delete](./stackit_dns_record-set_delete.md)	 - Delete a DNS record set
-* [stackit dns record-set describe](./stackit_dns_record-set_describe.md)	 - Get details of a DNS record set
+* [stackit dns record-set create](./stackit_dns_record-set_create.md)	 - Creates a DNS record set
+* [stackit dns record-set delete](./stackit_dns_record-set_delete.md)	 - Deletes a DNS record set
+* [stackit dns record-set describe](./stackit_dns_record-set_describe.md)	 - Shows details  of a DNS record set
 * [stackit dns record-set list](./stackit_dns_record-set_list.md)	 - List DNS record sets
-* [stackit dns record-set update](./stackit_dns_record-set_update.md)	 - Update a DNS record set
+* [stackit dns record-set update](./stackit_dns_record-set_update.md)	 - Updates a DNS record set
 

--- a/docs/stackit_dns_record-set_create.md
+++ b/docs/stackit_dns_record-set_create.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set create
 
-Create a DNS record set
+Creates a DNS record set
 
 ### Synopsis
 
-Create a DNS record set.
+Creates a DNS record set.
 
 ```
 stackit dns record-set create [flags]

--- a/docs/stackit_dns_record-set_create.md
+++ b/docs/stackit_dns_record-set_create.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set create
 
-Creates a DNS record set
+Create a DNS record set
 
 ### Synopsis
 
-Creates a DNS record set
+Create a DNS record set.
 
 ```
 stackit dns record-set create [flags]

--- a/docs/stackit_dns_record-set_delete.md
+++ b/docs/stackit_dns_record-set_delete.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set delete
 
-Delete a DNS record set
+Deletes a DNS record set
 
 ### Synopsis
 
-Delete a DNS record set.
+Deletes a DNS record set.
 
 ```
 stackit dns record-set delete RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_delete.md
+++ b/docs/stackit_dns_record-set_delete.md
@@ -4,7 +4,7 @@ Delete a DNS record set
 
 ### Synopsis
 
-Delete a DNS record set
+Delete a DNS record set.
 
 ```
 stackit dns record-set delete RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_describe.md
+++ b/docs/stackit_dns_record-set_describe.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set describe
 
-Get details of a DNS record set
+Shows details  of a DNS record set
 
 ### Synopsis
 
-Get details of a DNS record set.
+Shows details  of a DNS record set.
 
 ```
 stackit dns record-set describe RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_describe.md
+++ b/docs/stackit_dns_record-set_describe.md
@@ -4,7 +4,7 @@ Get details of a DNS record set
 
 ### Synopsis
 
-Get details of a DNS record set
+Get details of a DNS record set.
 
 ```
 stackit dns record-set describe RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_update.md
+++ b/docs/stackit_dns_record-set_update.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set update
 
-Update a DNS record set
+Updates a DNS record set
 
 ### Synopsis
 
-Update a DNS record set.
+Updates a DNS record set.
 
 ```
 stackit dns record-set update RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_update.md
+++ b/docs/stackit_dns_record-set_update.md
@@ -4,7 +4,7 @@ Update a DNS record set
 
 ### Synopsis
 
-Update a DNS record set. Performs a partial update, i.e., fields not provided are kept unchanged.
+Update a DNS record set.
 
 ```
 stackit dns record-set update RECORD_SET_ID [flags]

--- a/docs/stackit_dns_record-set_update.md
+++ b/docs/stackit_dns_record-set_update.md
@@ -1,10 +1,10 @@
 ## stackit dns record-set update
 
-Updates a DNS record set
+Update a DNS record set
 
 ### Synopsis
 
-Updates a DNS record set. Performs a partial update; fields not provided are kept unchanged
+Update a DNS record set. Performs a partial update, i.e., fields not provided are kept unchanged.
 
 ```
 stackit dns record-set update RECORD_SET_ID [flags]

--- a/docs/stackit_dns_zone.md
+++ b/docs/stackit_dns_zone.md
@@ -28,9 +28,9 @@ stackit dns zone [flags]
 ### SEE ALSO
 
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
-* [stackit dns zone create](./stackit_dns_zone_create.md)	 - Create a DNS zone
-* [stackit dns zone delete](./stackit_dns_zone_delete.md)	 - Delete a DNS zone
-* [stackit dns zone describe](./stackit_dns_zone_describe.md)	 - Get details of a DNS zone
+* [stackit dns zone create](./stackit_dns_zone_create.md)	 - Creates a DNS zone
+* [stackit dns zone delete](./stackit_dns_zone_delete.md)	 - Deletes a DNS zone
+* [stackit dns zone describe](./stackit_dns_zone_describe.md)	 - Shows details  of a DNS zone
 * [stackit dns zone list](./stackit_dns_zone_list.md)	 - List DNS zones
-* [stackit dns zone update](./stackit_dns_zone_update.md)	 - Update a DNS zone
+* [stackit dns zone update](./stackit_dns_zone_update.md)	 - Updates a DNS zone
 

--- a/docs/stackit_dns_zone.md
+++ b/docs/stackit_dns_zone.md
@@ -4,7 +4,7 @@ Provides functionality for DNS zones
 
 ### Synopsis
 
-Provides functionality for DNS zones
+Provides functionality for DNS zones.
 
 ```
 stackit dns zone [flags]
@@ -28,9 +28,9 @@ stackit dns zone [flags]
 ### SEE ALSO
 
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
-* [stackit dns zone create](./stackit_dns_zone_create.md)	 - Creates a DNS zone
+* [stackit dns zone create](./stackit_dns_zone_create.md)	 - Create a DNS zone
 * [stackit dns zone delete](./stackit_dns_zone_delete.md)	 - Delete a DNS zone
 * [stackit dns zone describe](./stackit_dns_zone_describe.md)	 - Get details of a DNS zone
 * [stackit dns zone list](./stackit_dns_zone_list.md)	 - List DNS zones
-* [stackit dns zone update](./stackit_dns_zone_update.md)	 - Updates a DNS zone
+* [stackit dns zone update](./stackit_dns_zone_update.md)	 - Update a DNS zone
 

--- a/docs/stackit_dns_zone_create.md
+++ b/docs/stackit_dns_zone_create.md
@@ -1,10 +1,10 @@
 ## stackit dns zone create
 
-Creates a DNS zone
+Create a DNS zone
 
 ### Synopsis
 
-Creates a DNS zone
+Create a DNS zone.
 
 ```
 stackit dns zone create [flags]

--- a/docs/stackit_dns_zone_create.md
+++ b/docs/stackit_dns_zone_create.md
@@ -1,10 +1,10 @@
 ## stackit dns zone create
 
-Create a DNS zone
+Creates a DNS zone
 
 ### Synopsis
 
-Create a DNS zone.
+Creates a DNS zone.
 
 ```
 stackit dns zone create [flags]

--- a/docs/stackit_dns_zone_delete.md
+++ b/docs/stackit_dns_zone_delete.md
@@ -4,7 +4,7 @@ Delete a DNS zone
 
 ### Synopsis
 
-Delete a DNS zone
+Delete a DNS zone.
 
 ```
 stackit dns zone delete ZONE_ID [flags]

--- a/docs/stackit_dns_zone_delete.md
+++ b/docs/stackit_dns_zone_delete.md
@@ -1,10 +1,10 @@
 ## stackit dns zone delete
 
-Delete a DNS zone
+Deletes a DNS zone
 
 ### Synopsis
 
-Delete a DNS zone.
+Deletes a DNS zone.
 
 ```
 stackit dns zone delete ZONE_ID [flags]

--- a/docs/stackit_dns_zone_describe.md
+++ b/docs/stackit_dns_zone_describe.md
@@ -1,10 +1,10 @@
 ## stackit dns zone describe
 
-Get details of a DNS zone
+Shows details  of a DNS zone
 
 ### Synopsis
 
-Get details of a DNS zone.
+Shows details  of a DNS zone.
 
 ```
 stackit dns zone describe ZONE_ID [flags]

--- a/docs/stackit_dns_zone_describe.md
+++ b/docs/stackit_dns_zone_describe.md
@@ -4,7 +4,7 @@ Get details of a DNS zone
 
 ### Synopsis
 
-Get details of a DNS zone
+Get details of a DNS zone.
 
 ```
 stackit dns zone describe ZONE_ID [flags]

--- a/docs/stackit_dns_zone_update.md
+++ b/docs/stackit_dns_zone_update.md
@@ -4,7 +4,7 @@ Update a DNS zone
 
 ### Synopsis
 
-Update a DNS zone. Performs a partial update, i.e., fields not provided are kept unchanged.
+Update a DNS zone.
 
 ```
 stackit dns zone update ZONE_ID [flags]

--- a/docs/stackit_dns_zone_update.md
+++ b/docs/stackit_dns_zone_update.md
@@ -1,10 +1,10 @@
 ## stackit dns zone update
 
-Update a DNS zone
+Updates a DNS zone
 
 ### Synopsis
 
-Update a DNS zone.
+Updates a DNS zone.
 
 ```
 stackit dns zone update ZONE_ID [flags]

--- a/docs/stackit_dns_zone_update.md
+++ b/docs/stackit_dns_zone_update.md
@@ -1,10 +1,10 @@
 ## stackit dns zone update
 
-Updates a DNS zone
+Update a DNS zone
 
 ### Synopsis
 
-Updates a DNS zone. Performs a partial update; fields not provided are kept unchanged
+Update a DNS zone. Performs a partial update, i.e., fields not provided are kept unchanged.
 
 ```
 stackit dns zone update ZONE_ID [flags]

--- a/docs/stackit_mongodbflex.md
+++ b/docs/stackit_mongodbflex.md
@@ -29,6 +29,6 @@ stackit mongodbflex [flags]
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
 * [stackit mongodbflex instance](./stackit_mongodbflex_instance.md)	 - Provides functionality for MongoDB Flex instances
-* [stackit mongodbflex options](./stackit_mongodbflex_options.md)	 - List MongoDB Flex options
+* [stackit mongodbflex options](./stackit_mongodbflex_options.md)	 - Lists MongoDB Flex options
 * [stackit mongodbflex user](./stackit_mongodbflex_user.md)	 - Provides functionality for MongoDB Flex users
 

--- a/docs/stackit_mongodbflex.md
+++ b/docs/stackit_mongodbflex.md
@@ -4,7 +4,7 @@ Provides functionality for MongoDB Flex
 
 ### Synopsis
 
-Provides functionality for MongoDB Flex
+Provides functionality for MongoDB Flex.
 
 ```
 stackit mongodbflex [flags]

--- a/docs/stackit_mongodbflex_instance.md
+++ b/docs/stackit_mongodbflex_instance.md
@@ -4,7 +4,7 @@ Provides functionality for MongoDB Flex instances
 
 ### Synopsis
 
-Provides functionality for MongoDB Flex instances
+Provides functionality for MongoDB Flex instances.
 
 ```
 stackit mongodbflex instance [flags]

--- a/docs/stackit_mongodbflex_instance.md
+++ b/docs/stackit_mongodbflex_instance.md
@@ -28,9 +28,9 @@ stackit mongodbflex instance [flags]
 ### SEE ALSO
 
 * [stackit mongodbflex](./stackit_mongodbflex.md)	 - Provides functionality for MongoDB Flex
-* [stackit mongodbflex instance create](./stackit_mongodbflex_instance_create.md)	 - Create a MongoDB Flex instance
-* [stackit mongodbflex instance delete](./stackit_mongodbflex_instance_delete.md)	 - Delete a MongoDB Flex instance
-* [stackit mongodbflex instance describe](./stackit_mongodbflex_instance_describe.md)	 - Get details of a MongoDB Flex instance
-* [stackit mongodbflex instance list](./stackit_mongodbflex_instance_list.md)	 - List all MongoDB Flex instances
-* [stackit mongodbflex instance update](./stackit_mongodbflex_instance_update.md)	 - Update a MongoDB Flex instance
+* [stackit mongodbflex instance create](./stackit_mongodbflex_instance_create.md)	 - Creates a MongoDB Flex instance
+* [stackit mongodbflex instance delete](./stackit_mongodbflex_instance_delete.md)	 - Deletes a MongoDB Flex instance
+* [stackit mongodbflex instance describe](./stackit_mongodbflex_instance_describe.md)	 - Shows details  of a MongoDB Flex instance
+* [stackit mongodbflex instance list](./stackit_mongodbflex_instance_list.md)	 - Lists all MongoDB Flex instances
+* [stackit mongodbflex instance update](./stackit_mongodbflex_instance_update.md)	 - Updates a MongoDB Flex instance
 

--- a/docs/stackit_mongodbflex_instance_create.md
+++ b/docs/stackit_mongodbflex_instance_create.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex instance create
 
-Create a MongoDB Flex instance
+Creates a MongoDB Flex instance
 
 ### Synopsis
 
-Create a MongoDB Flex instance.
+Creates a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance create [flags]

--- a/docs/stackit_mongodbflex_instance_delete.md
+++ b/docs/stackit_mongodbflex_instance_delete.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex instance delete
 
-Delete a MongoDB Flex instance
+Deletes a MongoDB Flex instance
 
 ### Synopsis
 
-Delete a MongoDB Flex instance.
+Deletes a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance delete INSTANCE_ID [flags]

--- a/docs/stackit_mongodbflex_instance_delete.md
+++ b/docs/stackit_mongodbflex_instance_delete.md
@@ -4,7 +4,7 @@ Delete a MongoDB Flex instance
 
 ### Synopsis
 
-Delete a MongoDB Flex instance
+Delete a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance delete INSTANCE_ID [flags]

--- a/docs/stackit_mongodbflex_instance_describe.md
+++ b/docs/stackit_mongodbflex_instance_describe.md
@@ -4,7 +4,7 @@ Get details of a MongoDB Flex instance
 
 ### Synopsis
 
-Get details of a MongoDB Flex instance
+Get details of a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance describe INSTANCE_ID [flags]

--- a/docs/stackit_mongodbflex_instance_describe.md
+++ b/docs/stackit_mongodbflex_instance_describe.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex instance describe
 
-Get details of a MongoDB Flex instance
+Shows details  of a MongoDB Flex instance
 
 ### Synopsis
 
-Get details of a MongoDB Flex instance.
+Shows details  of a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance describe INSTANCE_ID [flags]

--- a/docs/stackit_mongodbflex_instance_list.md
+++ b/docs/stackit_mongodbflex_instance_list.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex instance list
 
-List all MongoDB Flex instances
+Lists all MongoDB Flex instances
 
 ### Synopsis
 
-List all MongoDB Flex instances.
+Lists all MongoDB Flex instances.
 
 ```
 stackit mongodbflex instance list [flags]

--- a/docs/stackit_mongodbflex_instance_list.md
+++ b/docs/stackit_mongodbflex_instance_list.md
@@ -4,7 +4,7 @@ List all MongoDB Flex instances
 
 ### Synopsis
 
-List all MongoDB Flex instances
+List all MongoDB Flex instances.
 
 ```
 stackit mongodbflex instance list [flags]

--- a/docs/stackit_mongodbflex_instance_update.md
+++ b/docs/stackit_mongodbflex_instance_update.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex instance update
 
-Update a MongoDB Flex instance
+Updates a MongoDB Flex instance
 
 ### Synopsis
 
-Update a MongoDB Flex instance.
+Updates a MongoDB Flex instance.
 
 ```
 stackit mongodbflex instance update INSTANCE_ID [flags]
@@ -23,7 +23,7 @@ stackit mongodbflex instance update INSTANCE_ID [flags]
 ### Options
 
 ```
-      --acl strings              List of IP networks in CIDR notation which are allowed to access this instance (default [])
+      --acl strings              Lists of IP networks in CIDR notation which are allowed to access this instance (default [])
       --backup-schedule string   Backup schedule
       --cpu int                  Number of CPUs
       --flavor-id string         ID of the flavor

--- a/docs/stackit_mongodbflex_options.md
+++ b/docs/stackit_mongodbflex_options.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex options
 
-List MongoDB Flex options
+Lists MongoDB Flex options
 
 ### Synopsis
 
-List MongoDB Flex options (flavors, versions and storages for a given flavor)
+Lists MongoDB Flex options (flavors, versions and storages for a given flavor)
 Pass one or more flags to filter what categories are shown.
 
 ```

--- a/docs/stackit_mongodbflex_user.md
+++ b/docs/stackit_mongodbflex_user.md
@@ -4,7 +4,7 @@ Provides functionality for MongoDB Flex users
 
 ### Synopsis
 
-Provides functionality for MongoDB Flex users
+Provides functionality for MongoDB Flex users.
 
 ```
 stackit mongodbflex user [flags]

--- a/docs/stackit_mongodbflex_user.md
+++ b/docs/stackit_mongodbflex_user.md
@@ -28,10 +28,10 @@ stackit mongodbflex user [flags]
 ### SEE ALSO
 
 * [stackit mongodbflex](./stackit_mongodbflex.md)	 - Provides functionality for MongoDB Flex
-* [stackit mongodbflex user create](./stackit_mongodbflex_user_create.md)	 - Create a MongoDB Flex user
-* [stackit mongodbflex user delete](./stackit_mongodbflex_user_delete.md)	 - Delete a MongoDB Flex user
-* [stackit mongodbflex user describe](./stackit_mongodbflex_user_describe.md)	 - Get details of a MongoDB Flex user
-* [stackit mongodbflex user list](./stackit_mongodbflex_user_list.md)	 - List all MongoDB Flex users of an instance
-* [stackit mongodbflex user reset-password](./stackit_mongodbflex_user_reset-password.md)	 - Reset the password of a MongoDB Flex user
-* [stackit mongodbflex user update](./stackit_mongodbflex_user_update.md)	 - Update a MongoDB Flex user
+* [stackit mongodbflex user create](./stackit_mongodbflex_user_create.md)	 - Creates a MongoDB Flex user
+* [stackit mongodbflex user delete](./stackit_mongodbflex_user_delete.md)	 - Deletes a MongoDB Flex user
+* [stackit mongodbflex user describe](./stackit_mongodbflex_user_describe.md)	 - Shows details of a MongoDB Flex user
+* [stackit mongodbflex user list](./stackit_mongodbflex_user_list.md)	 - Lists all MongoDB Flex users of an instance
+* [stackit mongodbflex user reset-password](./stackit_mongodbflex_user_reset-password.md)	 - Resets the password of a MongoDB Flex user
+* [stackit mongodbflex user update](./stackit_mongodbflex_user_update.md)	 - Updates a MongoDB Flex user
 

--- a/docs/stackit_mongodbflex_user_create.md
+++ b/docs/stackit_mongodbflex_user_create.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user create
 
-Create a MongoDB Flex user
+Creates a MongoDB Flex user
 
 ### Synopsis
 
-Create a MongoDB Flex user.
+Creates a MongoDB Flex user.
 The password is only visible upon creation and cannot be retrieved later.
 Alternatively, you can reset the password and access the new one by running:
   $ stackit mongodbflex user reset-password --instance-id <INSTANCE_ID> --user-id <USER_ID>

--- a/docs/stackit_mongodbflex_user_delete.md
+++ b/docs/stackit_mongodbflex_user_delete.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user delete
 
-Delete a MongoDB Flex user
+Deletes a MongoDB Flex user
 
 ### Synopsis
 
-Delete a MongoDB Flex user by ID. You can get the IDs of users for an instance by running:
+Deletes a MongoDB Flex user by ID. You can get the IDs of users for an instance by running:
   $ stackit mongodbflex user list --instance-id <INSTANCE_ID>
 
 ```

--- a/docs/stackit_mongodbflex_user_describe.md
+++ b/docs/stackit_mongodbflex_user_describe.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user describe
 
-Get details of a MongoDB Flex user
+Shows details of a MongoDB Flex user
 
 ### Synopsis
 
-Get details of a MongoDB Flex user.
+Shows details of a MongoDB Flex user.
 The user password is hidden inside the "host" field and replaced with asterisks, as it is only visible upon creation. You can reset it by running:
   $ stackit mongodbflex user reset-password <USER_ID> --instance-id <INSTANCE_ID>
 

--- a/docs/stackit_mongodbflex_user_list.md
+++ b/docs/stackit_mongodbflex_user_list.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user list
 
-List all MongoDB Flex users of an instance
+Lists all MongoDB Flex users of an instance
 
 ### Synopsis
 
-List all MongoDB Flex users of an instance.
+Lists all MongoDB Flex users of an instance.
 
 ```
 stackit mongodbflex user list [flags]

--- a/docs/stackit_mongodbflex_user_reset-password.md
+++ b/docs/stackit_mongodbflex_user_reset-password.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user reset-password
 
-Reset the password of a MongoDB Flex user
+Resets the password of a MongoDB Flex user
 
 ### Synopsis
 
-Reset the password of a MongoDB Flex user. The new password is returned in the response.
+Resets the password of a MongoDB Flex user. The new password is returned in the response.
 
 ```
 stackit mongodbflex user reset-password USER_ID [flags]

--- a/docs/stackit_mongodbflex_user_reset-password.md
+++ b/docs/stackit_mongodbflex_user_reset-password.md
@@ -4,7 +4,7 @@ Resets the password of a MongoDB Flex user
 
 ### Synopsis
 
-Resets the password of a MongoDB Flex user. The new password is returned in the response.
+Resets the password of a MongoDB Flex user. The new password is shown in the command's output.
 
 ```
 stackit mongodbflex user reset-password USER_ID [flags]

--- a/docs/stackit_mongodbflex_user_update.md
+++ b/docs/stackit_mongodbflex_user_update.md
@@ -1,10 +1,10 @@
 ## stackit mongodbflex user update
 
-Update a MongoDB Flex user
+Updates a MongoDB Flex user
 
 ### Synopsis
 
-Update a MongoDB Flex user.
+Updates a MongoDB Flex user.
 
 ```
 stackit mongodbflex user update USER_ID [flags]

--- a/docs/stackit_opensearch.md
+++ b/docs/stackit_opensearch.md
@@ -30,5 +30,5 @@ stackit opensearch [flags]
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
 * [stackit opensearch credentials](./stackit_opensearch_credentials.md)	 - Provides functionality for OpenSearch credentials
 * [stackit opensearch instance](./stackit_opensearch_instance.md)	 - Provides functionality for OpenSearch instances
-* [stackit opensearch plans](./stackit_opensearch_plans.md)	 - List all OpenSearch service plans
+* [stackit opensearch plans](./stackit_opensearch_plans.md)	 - Lists all OpenSearch service plans
 

--- a/docs/stackit_opensearch.md
+++ b/docs/stackit_opensearch.md
@@ -4,7 +4,7 @@ Provides functionality for OpenSearch
 
 ### Synopsis
 
-Provides functionality for OpenSearch
+Provides functionality for OpenSearch.
 
 ```
 stackit opensearch [flags]

--- a/docs/stackit_opensearch_credentials.md
+++ b/docs/stackit_opensearch_credentials.md
@@ -4,7 +4,7 @@ Provides functionality for OpenSearch credentials
 
 ### Synopsis
 
-Provides functionality for OpenSearch credentials
+Provides functionality for OpenSearch credentials.
 
 ```
 stackit opensearch credentials [flags]

--- a/docs/stackit_opensearch_credentials.md
+++ b/docs/stackit_opensearch_credentials.md
@@ -28,8 +28,8 @@ stackit opensearch credentials [flags]
 ### SEE ALSO
 
 * [stackit opensearch](./stackit_opensearch.md)	 - Provides functionality for OpenSearch
-* [stackit opensearch credentials create](./stackit_opensearch_credentials_create.md)	 - Create credentials for an OpenSearch instance
-* [stackit opensearch credentials delete](./stackit_opensearch_credentials_delete.md)	 - Delete credentials of an OpenSearch instance
-* [stackit opensearch credentials describe](./stackit_opensearch_credentials_describe.md)	 - Get details of credentials of an OpenSearch instance
-* [stackit opensearch credentials list](./stackit_opensearch_credentials_list.md)	 - List all credentials' IDs for an OpenSearch instance
+* [stackit opensearch credentials create](./stackit_opensearch_credentials_create.md)	 - Creates credentials for an OpenSearch instance
+* [stackit opensearch credentials delete](./stackit_opensearch_credentials_delete.md)	 - Deletes credentials of an OpenSearch instance
+* [stackit opensearch credentials describe](./stackit_opensearch_credentials_describe.md)	 - Shows details of credentials of an OpenSearch instance
+* [stackit opensearch credentials list](./stackit_opensearch_credentials_list.md)	 - Lists all credentials' IDs for an OpenSearch instance
 

--- a/docs/stackit_opensearch_credentials_create.md
+++ b/docs/stackit_opensearch_credentials_create.md
@@ -4,7 +4,7 @@ Create credentials for an OpenSearch instance
 
 ### Synopsis
 
-Create credentials (username and password) for an OpenSearch instance
+Create credentials (username and password) for an OpenSearch instance.
 
 ```
 stackit opensearch credentials create [flags]

--- a/docs/stackit_opensearch_credentials_create.md
+++ b/docs/stackit_opensearch_credentials_create.md
@@ -1,10 +1,10 @@
 ## stackit opensearch credentials create
 
-Create credentials for an OpenSearch instance
+Creates credentials for an OpenSearch instance
 
 ### Synopsis
 
-Create credentials (username and password) for an OpenSearch instance.
+Creates credentials (username and password) for an OpenSearch instance.
 
 ```
 stackit opensearch credentials create [flags]

--- a/docs/stackit_opensearch_credentials_delete.md
+++ b/docs/stackit_opensearch_credentials_delete.md
@@ -4,7 +4,7 @@ Delete credentials of an OpenSearch instance
 
 ### Synopsis
 
-Delete credentials of an OpenSearch instance
+Delete credentials of an OpenSearch instance.
 
 ```
 stackit opensearch credentials delete CREDENTIALS_ID [flags]

--- a/docs/stackit_opensearch_credentials_delete.md
+++ b/docs/stackit_opensearch_credentials_delete.md
@@ -1,10 +1,10 @@
 ## stackit opensearch credentials delete
 
-Delete credentials of an OpenSearch instance
+Deletes credentials of an OpenSearch instance
 
 ### Synopsis
 
-Delete credentials of an OpenSearch instance.
+Deletes credentials of an OpenSearch instance.
 
 ```
 stackit opensearch credentials delete CREDENTIALS_ID [flags]

--- a/docs/stackit_opensearch_credentials_describe.md
+++ b/docs/stackit_opensearch_credentials_describe.md
@@ -1,10 +1,10 @@
 ## stackit opensearch credentials describe
 
-Get details of credentials of an OpenSearch instance
+Shows details of credentials of an OpenSearch instance
 
 ### Synopsis
 
-Get details of credentials of an OpenSearch instance. The password will be shown in plain text in the output.
+Shows details of credentials of an OpenSearch instance. The password will be shown in plain text in the output.
 
 ```
 stackit opensearch credentials describe CREDENTIALS_ID [flags]

--- a/docs/stackit_opensearch_credentials_list.md
+++ b/docs/stackit_opensearch_credentials_list.md
@@ -1,10 +1,10 @@
 ## stackit opensearch credentials list
 
-List all credentials' IDs for an OpenSearch instance
+Lists all credentials' IDs for an OpenSearch instance
 
 ### Synopsis
 
-List all credentials' IDs for an OpenSearch instance.
+Lists all credentials' IDs for an OpenSearch instance.
 
 ```
 stackit opensearch credentials list [flags]

--- a/docs/stackit_opensearch_credentials_list.md
+++ b/docs/stackit_opensearch_credentials_list.md
@@ -4,7 +4,7 @@ List all credentials' IDs for an OpenSearch instance
 
 ### Synopsis
 
-List all credentials' IDs for an OpenSearch instance
+List all credentials' IDs for an OpenSearch instance.
 
 ```
 stackit opensearch credentials list [flags]

--- a/docs/stackit_opensearch_instance.md
+++ b/docs/stackit_opensearch_instance.md
@@ -4,7 +4,7 @@ Provides functionality for OpenSearch instances
 
 ### Synopsis
 
-Provides functionality for OpenSearch instances
+Provides functionality for OpenSearch instances.
 
 ```
 stackit opensearch instance [flags]
@@ -32,5 +32,5 @@ stackit opensearch instance [flags]
 * [stackit opensearch instance delete](./stackit_opensearch_instance_delete.md)	 - Delete an OpenSearch instance
 * [stackit opensearch instance describe](./stackit_opensearch_instance_describe.md)	 - Get details of an OpenSearch instance
 * [stackit opensearch instance list](./stackit_opensearch_instance_list.md)	 - List all OpenSearch instances
-* [stackit opensearch instance update](./stackit_opensearch_instance_update.md)	 - Updates an OpenSearch instance
+* [stackit opensearch instance update](./stackit_opensearch_instance_update.md)	 - Update an OpenSearch instance
 

--- a/docs/stackit_opensearch_instance.md
+++ b/docs/stackit_opensearch_instance.md
@@ -28,9 +28,9 @@ stackit opensearch instance [flags]
 ### SEE ALSO
 
 * [stackit opensearch](./stackit_opensearch.md)	 - Provides functionality for OpenSearch
-* [stackit opensearch instance create](./stackit_opensearch_instance_create.md)	 - Create an OpenSearch instance
-* [stackit opensearch instance delete](./stackit_opensearch_instance_delete.md)	 - Delete an OpenSearch instance
-* [stackit opensearch instance describe](./stackit_opensearch_instance_describe.md)	 - Get details of an OpenSearch instance
-* [stackit opensearch instance list](./stackit_opensearch_instance_list.md)	 - List all OpenSearch instances
-* [stackit opensearch instance update](./stackit_opensearch_instance_update.md)	 - Update an OpenSearch instance
+* [stackit opensearch instance create](./stackit_opensearch_instance_create.md)	 - Creates an OpenSearch instance
+* [stackit opensearch instance delete](./stackit_opensearch_instance_delete.md)	 - Deletes an OpenSearch instance
+* [stackit opensearch instance describe](./stackit_opensearch_instance_describe.md)	 - Shows details  of an OpenSearch instance
+* [stackit opensearch instance list](./stackit_opensearch_instance_list.md)	 - Lists all OpenSearch instances
+* [stackit opensearch instance update](./stackit_opensearch_instance_update.md)	 - Updates an OpenSearch instance
 

--- a/docs/stackit_opensearch_instance_create.md
+++ b/docs/stackit_opensearch_instance_create.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance create
 
-Create an OpenSearch instance
+Creates an OpenSearch instance
 
 ### Synopsis
 
-Create an OpenSearch instance.
+Creates an OpenSearch instance.
 
 ```
 stackit opensearch instance create [flags]

--- a/docs/stackit_opensearch_instance_delete.md
+++ b/docs/stackit_opensearch_instance_delete.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance delete
 
-Delete an OpenSearch instance
+Deletes an OpenSearch instance
 
 ### Synopsis
 
-Delete an OpenSearch instance.
+Deletes an OpenSearch instance.
 
 ```
 stackit opensearch instance delete INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_instance_delete.md
+++ b/docs/stackit_opensearch_instance_delete.md
@@ -4,7 +4,7 @@ Delete an OpenSearch instance
 
 ### Synopsis
 
-Delete an OpenSearch instance
+Delete an OpenSearch instance.
 
 ```
 stackit opensearch instance delete INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_instance_describe.md
+++ b/docs/stackit_opensearch_instance_describe.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance describe
 
-Get details of an OpenSearch instance
+Shows details  of an OpenSearch instance
 
 ### Synopsis
 
-Get details of an OpenSearch instance.
+Shows details  of an OpenSearch instance.
 
 ```
 stackit opensearch instance describe INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_instance_describe.md
+++ b/docs/stackit_opensearch_instance_describe.md
@@ -4,7 +4,7 @@ Get details of an OpenSearch instance
 
 ### Synopsis
 
-Get details of an OpenSearch instance
+Get details of an OpenSearch instance.
 
 ```
 stackit opensearch instance describe INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_instance_list.md
+++ b/docs/stackit_opensearch_instance_list.md
@@ -4,7 +4,7 @@ List all OpenSearch instances
 
 ### Synopsis
 
-List all OpenSearch instances
+List all OpenSearch instances.
 
 ```
 stackit opensearch instance list [flags]

--- a/docs/stackit_opensearch_instance_list.md
+++ b/docs/stackit_opensearch_instance_list.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance list
 
-List all OpenSearch instances
+Lists all OpenSearch instances
 
 ### Synopsis
 
-List all OpenSearch instances.
+Lists all OpenSearch instances.
 
 ```
 stackit opensearch instance list [flags]

--- a/docs/stackit_opensearch_instance_update.md
+++ b/docs/stackit_opensearch_instance_update.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance update
 
-Updates an OpenSearch instance
+Update an OpenSearch instance
 
 ### Synopsis
 
-Updates an OpenSearch instance
+Update an OpenSearch instance.
 
 ```
 stackit opensearch instance update INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_instance_update.md
+++ b/docs/stackit_opensearch_instance_update.md
@@ -1,10 +1,10 @@
 ## stackit opensearch instance update
 
-Update an OpenSearch instance
+Updates an OpenSearch instance
 
 ### Synopsis
 
-Update an OpenSearch instance.
+Updates an OpenSearch instance.
 
 ```
 stackit opensearch instance update INSTANCE_ID [flags]

--- a/docs/stackit_opensearch_plans.md
+++ b/docs/stackit_opensearch_plans.md
@@ -4,7 +4,7 @@ List all OpenSearch service plans
 
 ### Synopsis
 
-List all OpenSearch service plans
+List all OpenSearch service plans.
 
 ```
 stackit opensearch plans [flags]

--- a/docs/stackit_opensearch_plans.md
+++ b/docs/stackit_opensearch_plans.md
@@ -1,10 +1,10 @@
 ## stackit opensearch plans
 
-List all OpenSearch service plans
+Lists all OpenSearch service plans
 
 ### Synopsis
 
-List all OpenSearch service plans.
+Lists all OpenSearch service plans.
 
 ```
 stackit opensearch plans [flags]

--- a/docs/stackit_organization.md
+++ b/docs/stackit_organization.md
@@ -5,7 +5,7 @@ Provides functionality regarding organizations
 ### Synopsis
 
 Provides functionality regarding organizations.
-An active STACKIT organization is the root element of the resource hierarchy and a prerequisite to use any STACKIT Cloud Resource / Service
+An active STACKIT organization is the root element of the resource hierarchy and a prerequisite to use any STACKIT Cloud Resource / Service.
 
 ```
 stackit organization [flags]

--- a/docs/stackit_organization_member.md
+++ b/docs/stackit_organization_member.md
@@ -4,7 +4,7 @@ Provides functionality regarding organization members
 
 ### Synopsis
 
-Provides functionality regarding organization members
+Provides functionality regarding organization members.
 
 ```
 stackit organization member [flags]

--- a/docs/stackit_organization_member.md
+++ b/docs/stackit_organization_member.md
@@ -28,7 +28,7 @@ stackit organization member [flags]
 ### SEE ALSO
 
 * [stackit organization](./stackit_organization.md)	 - Provides functionality regarding organizations
-* [stackit organization member add](./stackit_organization_member_add.md)	 - Add a member to an organization
-* [stackit organization member list](./stackit_organization_member_list.md)	 - List members of an organization
-* [stackit organization member remove](./stackit_organization_member_remove.md)	 - Remove a member from an organization.
+* [stackit organization member add](./stackit_organization_member_add.md)	 - Adds a member to an organization
+* [stackit organization member list](./stackit_organization_member_list.md)	 - Lists members of an organization
+* [stackit organization member remove](./stackit_organization_member_remove.md)	 - Removes a member from an organization.
 

--- a/docs/stackit_organization_member.md
+++ b/docs/stackit_organization_member.md
@@ -30,5 +30,5 @@ stackit organization member [flags]
 * [stackit organization](./stackit_organization.md)	 - Provides functionality regarding organizations
 * [stackit organization member add](./stackit_organization_member_add.md)	 - Adds a member to an organization
 * [stackit organization member list](./stackit_organization_member_list.md)	 - Lists members of an organization
-* [stackit organization member remove](./stackit_organization_member_remove.md)	 - Removes a member from an organization.
+* [stackit organization member remove](./stackit_organization_member_remove.md)	 - Removes a member from an organization
 

--- a/docs/stackit_organization_member_add.md
+++ b/docs/stackit_organization_member_add.md
@@ -1,10 +1,10 @@
 ## stackit organization member add
 
-Add a member to an organization
+Adds a member to an organization
 
 ### Synopsis
 
-Add a member to an organization.
+Adds a member to an organization.
 A member is a combination of a subject (user, service account or client) and a role.
 The subject is usually email address for users or name in case of clients
 For more details on the available roles, run:

--- a/docs/stackit_organization_member_list.md
+++ b/docs/stackit_organization_member_list.md
@@ -1,10 +1,10 @@
 ## stackit organization member list
 
-List members of an organization
+Lists members of an organization
 
 ### Synopsis
 
-List members of an organization
+Lists members of an organization
 
 ```
 stackit organization member list [flags]

--- a/docs/stackit_organization_member_remove.md
+++ b/docs/stackit_organization_member_remove.md
@@ -6,7 +6,7 @@ Remove a member from an organization.
 
 Remove a member from an organization.
 A member is a combination of a subject (user, service account or client) and a role.
-The subject is usually email address for users or name in case of clients
+The subject is usually email address for users or name in case of clients.
 
 ```
 stackit organization member remove SUBJECT [flags]

--- a/docs/stackit_organization_member_remove.md
+++ b/docs/stackit_organization_member_remove.md
@@ -1,6 +1,6 @@
 ## stackit organization member remove
 
-Removes a member from an organization.
+Removes a member from an organization
 
 ### Synopsis
 

--- a/docs/stackit_organization_member_remove.md
+++ b/docs/stackit_organization_member_remove.md
@@ -6,7 +6,7 @@ Remove a member from an organization.
 
 Remove a member from an organization.
 A member is a combination of a subject (user, service account or client) and a role.
-The subject is usually email address for users or name in case of clients.
+The subject is usually email address (for users) or name (for clients).
 
 ```
 stackit organization member remove SUBJECT [flags]

--- a/docs/stackit_organization_member_remove.md
+++ b/docs/stackit_organization_member_remove.md
@@ -1,10 +1,10 @@
 ## stackit organization member remove
 
-Remove a member from an organization.
+Removes a member from an organization.
 
 ### Synopsis
 
-Remove a member from an organization.
+Removes a member from an organization.
 A member is a combination of a subject (user, service account or client) and a role.
 The subject is usually email address (for users) or name (for clients).
 

--- a/docs/stackit_organization_role.md
+++ b/docs/stackit_organization_role.md
@@ -4,7 +4,7 @@ Provides functionality regarding organization roles
 
 ### Synopsis
 
-Provides functionality regarding organization roles
+Provides functionality regarding organization roles.
 
 ```
 stackit organization role [flags]

--- a/docs/stackit_organization_role.md
+++ b/docs/stackit_organization_role.md
@@ -28,5 +28,5 @@ stackit organization role [flags]
 ### SEE ALSO
 
 * [stackit organization](./stackit_organization.md)	 - Provides functionality regarding organizations
-* [stackit organization role list](./stackit_organization_role_list.md)	 - List roles and permissions of an organization
+* [stackit organization role list](./stackit_organization_role_list.md)	 - Lists roles and permissions of an organization
 

--- a/docs/stackit_organization_role_list.md
+++ b/docs/stackit_organization_role_list.md
@@ -4,7 +4,7 @@ List roles and permissions of an organization
 
 ### Synopsis
 
-List roles and permissions of an organization
+List roles and permissions of an organization.
 
 ```
 stackit organization role list [flags]

--- a/docs/stackit_organization_role_list.md
+++ b/docs/stackit_organization_role_list.md
@@ -1,10 +1,10 @@
 ## stackit organization role list
 
-List roles and permissions of an organization
+Lists roles and permissions of an organization
 
 ### Synopsis
 
-List roles and permissions of an organization.
+Lists roles and permissions of an organization.
 
 ```
 stackit organization role list [flags]

--- a/docs/stackit_project.md
+++ b/docs/stackit_project.md
@@ -31,7 +31,7 @@ stackit project [flags]
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
 * [stackit project create](./stackit_project_create.md)	 - Creates a STACKIT project
 * [stackit project delete](./stackit_project_delete.md)	 - Deletes a STACKIT project
-* [stackit project describe](./stackit_project_describe.md)	 - Show details of a STACKIT project
+* [stackit project describe](./stackit_project_describe.md)	 - Shows details of a STACKIT project
 * [stackit project list](./stackit_project_list.md)	 - Lists STACKIT projects
 * [stackit project member](./stackit_project_member.md)	 - Provides functionality regarding project members
 * [stackit project role](./stackit_project_role.md)	 - Provides functionality regarding project roles

--- a/docs/stackit_project.md
+++ b/docs/stackit_project.md
@@ -29,11 +29,11 @@ stackit project [flags]
 ### SEE ALSO
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
-* [stackit project create](./stackit_project_create.md)	 - Create a STACKIT project
-* [stackit project delete](./stackit_project_delete.md)	 - Delete a STACKIT project
-* [stackit project describe](./stackit_project_describe.md)	 - Get the details of a STACKIT project
-* [stackit project list](./stackit_project_list.md)	 - List STACKIT projects
+* [stackit project create](./stackit_project_create.md)	 - Creates a STACKIT project
+* [stackit project delete](./stackit_project_delete.md)	 - Deletes a STACKIT project
+* [stackit project describe](./stackit_project_describe.md)	 - Show details of a STACKIT project
+* [stackit project list](./stackit_project_list.md)	 - Lists STACKIT projects
 * [stackit project member](./stackit_project_member.md)	 - Provides functionality regarding project members
 * [stackit project role](./stackit_project_role.md)	 - Provides functionality regarding project roles
-* [stackit project update](./stackit_project_update.md)	 - Update a STACKIT project
+* [stackit project update](./stackit_project_update.md)	 - Updates a STACKIT project
 

--- a/docs/stackit_project.md
+++ b/docs/stackit_project.md
@@ -29,7 +29,7 @@ stackit project [flags]
 ### SEE ALSO
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
-* [stackit project create](./stackit_project_create.md)	 - Create STACKIT projects
+* [stackit project create](./stackit_project_create.md)	 - Create a STACKIT project
 * [stackit project delete](./stackit_project_delete.md)	 - Delete a STACKIT project
 * [stackit project describe](./stackit_project_describe.md)	 - Get the details of a STACKIT project
 * [stackit project list](./stackit_project_list.md)	 - List STACKIT projects

--- a/docs/stackit_project_create.md
+++ b/docs/stackit_project_create.md
@@ -1,10 +1,10 @@
 ## stackit project create
 
-Create STACKIT projects
+Create a STACKIT project
 
 ### Synopsis
 
-Create STACKIT projects
+Create a STACKIT project.
 
 ```
 stackit project create [flags]

--- a/docs/stackit_project_create.md
+++ b/docs/stackit_project_create.md
@@ -1,10 +1,10 @@
 ## stackit project create
 
-Create a STACKIT project
+Creates a STACKIT project
 
 ### Synopsis
 
-Create a STACKIT project.
+Creates a STACKIT project.
 
 ```
 stackit project create [flags]

--- a/docs/stackit_project_delete.md
+++ b/docs/stackit_project_delete.md
@@ -1,10 +1,10 @@
 ## stackit project delete
 
-Delete a STACKIT project
+Deletes a STACKIT project
 
 ### Synopsis
 
-Delete a STACKIT project.
+Deletes a STACKIT project.
 
 ```
 stackit project delete [flags]

--- a/docs/stackit_project_delete.md
+++ b/docs/stackit_project_delete.md
@@ -4,7 +4,7 @@ Delete a STACKIT project
 
 ### Synopsis
 
-Delete a STACKIT project
+Delete a STACKIT project.
 
 ```
 stackit project delete [flags]

--- a/docs/stackit_project_describe.md
+++ b/docs/stackit_project_describe.md
@@ -4,7 +4,7 @@ Get the details of a STACKIT project
 
 ### Synopsis
 
-Get the details of a STACKIT project
+Get the details of a STACKIT project.
 
 ```
 stackit project describe [flags]

--- a/docs/stackit_project_describe.md
+++ b/docs/stackit_project_describe.md
@@ -1,10 +1,10 @@
 ## stackit project describe
 
-Show details of a STACKIT project
+Shows details of a STACKIT project
 
 ### Synopsis
 
-Show details of a STACKIT project.
+Shows details of a STACKIT project.
 
 ```
 stackit project describe [flags]

--- a/docs/stackit_project_describe.md
+++ b/docs/stackit_project_describe.md
@@ -1,10 +1,10 @@
 ## stackit project describe
 
-Get the details of a STACKIT project
+Show details of a STACKIT project
 
 ### Synopsis
 
-Get the details of a STACKIT project.
+Show details of a STACKIT project.
 
 ```
 stackit project describe [flags]

--- a/docs/stackit_project_list.md
+++ b/docs/stackit_project_list.md
@@ -1,10 +1,10 @@
 ## stackit project list
 
-List STACKIT projects
+Lists STACKIT projects
 
 ### Synopsis
 
-List all STACKIT projects that match certain criteria.
+Lists all STACKIT projects that match certain criteria.
 
 ```
 stackit project list [flags]

--- a/docs/stackit_project_list.md
+++ b/docs/stackit_project_list.md
@@ -4,7 +4,7 @@ List STACKIT projects
 
 ### Synopsis
 
-List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided.
+List all STACKIT projects that match certain criteria.
 
 ```
 stackit project list [flags]

--- a/docs/stackit_project_list.md
+++ b/docs/stackit_project_list.md
@@ -4,7 +4,7 @@ List STACKIT projects
 
 ### Synopsis
 
-List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided
+List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided.
 
 ```
 stackit project list [flags]

--- a/docs/stackit_project_member.md
+++ b/docs/stackit_project_member.md
@@ -4,7 +4,7 @@ Provides functionality regarding project members
 
 ### Synopsis
 
-Provides functionality regarding project members
+Provides functionality regarding project members.
 
 ```
 stackit project member [flags]

--- a/docs/stackit_project_member.md
+++ b/docs/stackit_project_member.md
@@ -28,7 +28,7 @@ stackit project member [flags]
 ### SEE ALSO
 
 * [stackit project](./stackit_project.md)	 - Provides functionality regarding projects
-* [stackit project member add](./stackit_project_member_add.md)	 - Add a member to a project
-* [stackit project member list](./stackit_project_member_list.md)	 - List members of a project
-* [stackit project member remove](./stackit_project_member_remove.md)	 - Remove a member from a project.
+* [stackit project member add](./stackit_project_member_add.md)	 - Adds a member to a project
+* [stackit project member list](./stackit_project_member_list.md)	 - Lists members of a project
+* [stackit project member remove](./stackit_project_member_remove.md)	 - Removes a member from a project.
 

--- a/docs/stackit_project_member.md
+++ b/docs/stackit_project_member.md
@@ -30,5 +30,5 @@ stackit project member [flags]
 * [stackit project](./stackit_project.md)	 - Provides functionality regarding projects
 * [stackit project member add](./stackit_project_member_add.md)	 - Adds a member to a project
 * [stackit project member list](./stackit_project_member_list.md)	 - Lists members of a project
-* [stackit project member remove](./stackit_project_member_remove.md)	 - Removes a member from a project.
+* [stackit project member remove](./stackit_project_member_remove.md)	 - Removes a member from a project
 

--- a/docs/stackit_project_member_add.md
+++ b/docs/stackit_project_member_add.md
@@ -1,10 +1,10 @@
 ## stackit project member add
 
-Add a member to a project
+Adds a member to a project
 
 ### Synopsis
 
-Add a member to a project.
+Adds a member to a project.
 A member is a combination of a subject (user, service account or client) and a role.
 The subject is usually email address for users or name in case of clients
 For more details on the available roles, run:

--- a/docs/stackit_project_member_list.md
+++ b/docs/stackit_project_member_list.md
@@ -4,7 +4,7 @@ List members of a project
 
 ### Synopsis
 
-List members of a project
+List members of a project.
 
 ```
 stackit project member list [flags]

--- a/docs/stackit_project_member_list.md
+++ b/docs/stackit_project_member_list.md
@@ -1,10 +1,10 @@
 ## stackit project member list
 
-List members of a project
+Lists members of a project
 
 ### Synopsis
 
-List members of a project.
+Lists members of a project.
 
 ```
 stackit project member list [flags]

--- a/docs/stackit_project_member_list.md
+++ b/docs/stackit_project_member_list.md
@@ -29,7 +29,7 @@ stackit project member list [flags]
   -h, --help             Help for "stackit project member list"
       --limit int        Maximum number of entries to list
       --sort-by string   Sort entries by a specific field, one of ["subject" "role"] (default "subject")
-      --subject string   Filter by subject (Identifier of user, service account or client. Usually email address in case of users or name in case of clients)
+      --subject string   Filter by subject (the identifier of a user, service account or client). This is usually the email address (for users) or name (for clients)
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_project_member_remove.md
+++ b/docs/stackit_project_member_remove.md
@@ -1,6 +1,6 @@
 ## stackit project member remove
 
-Removes a member from a project.
+Removes a member from a project
 
 ### Synopsis
 

--- a/docs/stackit_project_member_remove.md
+++ b/docs/stackit_project_member_remove.md
@@ -1,10 +1,10 @@
 ## stackit project member remove
 
-Remove a member from a project.
+Removes a member from a project.
 
 ### Synopsis
 
-Remove a member from a project.
+Removes a member from a project.
 A member is a combination of a subject (user, service account or client) and a role.
 The subject is usually email address for users or name in case of clients
 

--- a/docs/stackit_project_role.md
+++ b/docs/stackit_project_role.md
@@ -4,7 +4,7 @@ Provides functionality regarding project roles
 
 ### Synopsis
 
-Provides functionality regarding project roles
+Provides functionality regarding project roles.
 
 ```
 stackit project role [flags]

--- a/docs/stackit_project_role.md
+++ b/docs/stackit_project_role.md
@@ -28,5 +28,5 @@ stackit project role [flags]
 ### SEE ALSO
 
 * [stackit project](./stackit_project.md)	 - Provides functionality regarding projects
-* [stackit project role list](./stackit_project_role_list.md)	 - List roles and permissions of a project
+* [stackit project role list](./stackit_project_role_list.md)	 - Lists roles and permissions of a project
 

--- a/docs/stackit_project_role_list.md
+++ b/docs/stackit_project_role_list.md
@@ -1,10 +1,10 @@
 ## stackit project role list
 
-List roles and permissions of a project
+Lists roles and permissions of a project
 
 ### Synopsis
 
-List roles and permissions of a project.
+Lists roles and permissions of a project.
 
 ```
 stackit project role list [flags]

--- a/docs/stackit_project_role_list.md
+++ b/docs/stackit_project_role_list.md
@@ -4,7 +4,7 @@ List roles and permissions of a project
 
 ### Synopsis
 
-List roles and permissions of a project
+List roles and permissions of a project.
 
 ```
 stackit project role list [flags]

--- a/docs/stackit_project_update.md
+++ b/docs/stackit_project_update.md
@@ -1,10 +1,10 @@
 ## stackit project update
 
-Update a STACKIT project
+Updates a STACKIT project
 
 ### Synopsis
 
-Update a STACKIT project.
+Updates a STACKIT project.
 
 ```
 stackit project update [flags]

--- a/docs/stackit_project_update.md
+++ b/docs/stackit_project_update.md
@@ -4,7 +4,7 @@ Update a STACKIT project
 
 ### Synopsis
 
-Update a STACKIT project
+Update a STACKIT project.
 
 ```
 stackit project update [flags]

--- a/docs/stackit_service-account.md
+++ b/docs/stackit_service-account.md
@@ -30,7 +30,7 @@ stackit service-account [flags]
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
 * [stackit service-account create](./stackit_service-account_create.md)	 - Creates a service account
 * [stackit service-account delete](./stackit_service-account_delete.md)	 - Deletes a service account
-* [stackit service-account get-jwks](./stackit_service-account_get-jwks.md)	 - Gets the JWKS for a service account
+* [stackit service-account get-jwks](./stackit_service-account_get-jwks.md)	 - Shows the JWKS for a service account
 * [stackit service-account key](./stackit_service-account_key.md)	 - Provides functionality regarding service account keys
 * [stackit service-account list](./stackit_service-account_list.md)	 - Lists all service accounts
 * [stackit service-account token](./stackit_service-account_token.md)	 - Provides functionality regarding service account tokens

--- a/docs/stackit_service-account.md
+++ b/docs/stackit_service-account.md
@@ -4,7 +4,7 @@ Provides functionality for service accounts
 
 ### Synopsis
 
-Provides functionality for service accounts
+Provides functionality for service accounts.
 
 ```
 stackit service-account [flags]

--- a/docs/stackit_service-account.md
+++ b/docs/stackit_service-account.md
@@ -28,10 +28,10 @@ stackit service-account [flags]
 ### SEE ALSO
 
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
-* [stackit service-account create](./stackit_service-account_create.md)	 - Create a service account
-* [stackit service-account delete](./stackit_service-account_delete.md)	 - Delete a service account
-* [stackit service-account get-jwks](./stackit_service-account_get-jwks.md)	 - Get JWKS for a service account
+* [stackit service-account create](./stackit_service-account_create.md)	 - Creates a service account
+* [stackit service-account delete](./stackit_service-account_delete.md)	 - Deletes a service account
+* [stackit service-account get-jwks](./stackit_service-account_get-jwks.md)	 - Gets the JWKS for a service account
 * [stackit service-account key](./stackit_service-account_key.md)	 - Provides functionality regarding service account keys
-* [stackit service-account list](./stackit_service-account_list.md)	 - List all service accounts
+* [stackit service-account list](./stackit_service-account_list.md)	 - Lists all service accounts
 * [stackit service-account token](./stackit_service-account_token.md)	 - Provides functionality regarding service account tokens
 

--- a/docs/stackit_service-account_create.md
+++ b/docs/stackit_service-account_create.md
@@ -1,10 +1,10 @@
 ## stackit service-account create
 
-Create a service account
+Creates a service account
 
 ### Synopsis
 
-Create a service account.
+Creates a service account.
 
 ```
 stackit service-account create [flags]

--- a/docs/stackit_service-account_create.md
+++ b/docs/stackit_service-account_create.md
@@ -4,7 +4,7 @@ Create a service account
 
 ### Synopsis
 
-Create a service account
+Create a service account.
 
 ```
 stackit service-account create [flags]

--- a/docs/stackit_service-account_delete.md
+++ b/docs/stackit_service-account_delete.md
@@ -4,7 +4,7 @@ Delete a service account
 
 ### Synopsis
 
-Delete a service account
+Delete a service account.
 
 ```
 stackit service-account delete EMAIL [flags]

--- a/docs/stackit_service-account_delete.md
+++ b/docs/stackit_service-account_delete.md
@@ -1,10 +1,10 @@
 ## stackit service-account delete
 
-Delete a service account
+Deletes a service account
 
 ### Synopsis
 
-Delete a service account.
+Deletes a service account.
 
 ```
 stackit service-account delete EMAIL [flags]

--- a/docs/stackit_service-account_get-jwks.md
+++ b/docs/stackit_service-account_get-jwks.md
@@ -1,10 +1,10 @@
 ## stackit service-account get-jwks
 
-Gets the JWKS for a service account
+Shows the JWKS for a service account
 
 ### Synopsis
 
-Gets the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.
+Shows the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.
 
 ```
 stackit service-account get-jwks EMAIL [flags]

--- a/docs/stackit_service-account_get-jwks.md
+++ b/docs/stackit_service-account_get-jwks.md
@@ -1,10 +1,10 @@
 ## stackit service-account get-jwks
 
-Get JWKS for a service account
+Gets the JWKS for a service account
 
 ### Synopsis
 
-Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported.
+Gets the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.
 
 ```
 stackit service-account get-jwks EMAIL [flags]

--- a/docs/stackit_service-account_get-jwks.md
+++ b/docs/stackit_service-account_get-jwks.md
@@ -4,7 +4,7 @@ Get JWKS for a service account
 
 ### Synopsis
 
-Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported
+Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported.
 
 ```
 stackit service-account get-jwks EMAIL [flags]

--- a/docs/stackit_service-account_key.md
+++ b/docs/stackit_service-account_key.md
@@ -4,7 +4,7 @@ Provides functionality regarding service account keys
 
 ### Synopsis
 
-Provides functionality regarding service account keys
+Provides functionality regarding service account keys.
 
 ```
 stackit service-account key [flags]

--- a/docs/stackit_service-account_key.md
+++ b/docs/stackit_service-account_key.md
@@ -28,9 +28,9 @@ stackit service-account key [flags]
 ### SEE ALSO
 
 * [stackit service-account](./stackit_service-account.md)	 - Provides functionality for service accounts
-* [stackit service-account key create](./stackit_service-account_key_create.md)	 - Create a service account key
-* [stackit service-account key delete](./stackit_service-account_key_delete.md)	 - Delete a service account key
-* [stackit service-account key describe](./stackit_service-account_key_describe.md)	 - Get details of a service account key
-* [stackit service-account key list](./stackit_service-account_key_list.md)	 - List all service account keys
-* [stackit service-account key update](./stackit_service-account_key_update.md)	 - Update a service account key
+* [stackit service-account key create](./stackit_service-account_key_create.md)	 - Creates a service account key
+* [stackit service-account key delete](./stackit_service-account_key_delete.md)	 - Deletes a service account key
+* [stackit service-account key describe](./stackit_service-account_key_describe.md)	 - Shows details of a service account key
+* [stackit service-account key list](./stackit_service-account_key_list.md)	 - Lists all service account keys
+* [stackit service-account key update](./stackit_service-account_key_update.md)	 - Updates a service account key
 

--- a/docs/stackit_service-account_key_create.md
+++ b/docs/stackit_service-account_key_create.md
@@ -1,10 +1,10 @@
 ## stackit service-account key create
 
-Create a service account key
+Creates a service account key
 
 ### Synopsis
 
-Create a service account key.
+Creates a service account key.
 You can generate an RSA keypair and provide the public key.
 If you do not provide a public key, the service will generate a new key-pair and the private key is included in the response. You won't be able to retrieve it later.
 

--- a/docs/stackit_service-account_key_delete.md
+++ b/docs/stackit_service-account_key_delete.md
@@ -1,10 +1,10 @@
 ## stackit service-account key delete
 
-Delete a service account key
+Deletes a service account key
 
 ### Synopsis
 
-Delete a service account key.
+Deletes a service account key.
 
 ```
 stackit service-account key delete KEY_ID [flags]

--- a/docs/stackit_service-account_key_describe.md
+++ b/docs/stackit_service-account_key_describe.md
@@ -1,10 +1,10 @@
 ## stackit service-account key describe
 
-Get details of a service account key
+Shows details of a service account key
 
 ### Synopsis
 
-Get details of a service account key. Only JSON output is supported.
+Shows details of a service account key. Only JSON output is supported.
 
 ```
 stackit service-account key describe KEY_ID [flags]

--- a/docs/stackit_service-account_key_list.md
+++ b/docs/stackit_service-account_key_list.md
@@ -1,10 +1,10 @@
 ## stackit service-account key list
 
-List all service account keys
+Lists all service account keys
 
 ### Synopsis
 
-List all service account keys.
+Lists all service account keys.
 
 ```
 stackit service-account key list [flags]

--- a/docs/stackit_service-account_key_update.md
+++ b/docs/stackit_service-account_key_update.md
@@ -1,10 +1,10 @@
 ## stackit service-account key update
 
-Update a service account key
+Updates a service account key
 
 ### Synopsis
 
-Update a service account key.
+Updates a service account key.
 You can temporarily activate or deactivate the key and/or update its date of expiration.
 
 ```

--- a/docs/stackit_service-account_list.md
+++ b/docs/stackit_service-account_list.md
@@ -1,10 +1,10 @@
 ## stackit service-account list
 
-List all service accounts
+Lists all service accounts
 
 ### Synopsis
 
-List all service accounts.
+Lists all service accounts.
 
 ```
 stackit service-account list [flags]

--- a/docs/stackit_service-account_list.md
+++ b/docs/stackit_service-account_list.md
@@ -4,7 +4,7 @@ List all service accounts
 
 ### Synopsis
 
-List all service accounts
+List all service accounts.
 
 ```
 stackit service-account list [flags]

--- a/docs/stackit_service-account_token.md
+++ b/docs/stackit_service-account_token.md
@@ -28,7 +28,7 @@ stackit service-account token [flags]
 ### SEE ALSO
 
 * [stackit service-account](./stackit_service-account.md)	 - Provides functionality for service accounts
-* [stackit service-account token create](./stackit_service-account_token_create.md)	 - Create an access token for a service account
-* [stackit service-account token list](./stackit_service-account_token_list.md)	 - List access tokens of a service account
-* [stackit service-account token revoke](./stackit_service-account_token_revoke.md)	 - Revoke an access token of a service account
+* [stackit service-account token create](./stackit_service-account_token_create.md)	 - Creates an access token for a service account
+* [stackit service-account token list](./stackit_service-account_token_list.md)	 - Lists access tokens of a service account
+* [stackit service-account token revoke](./stackit_service-account_token_revoke.md)	 - Revokes an access token of a service account
 

--- a/docs/stackit_service-account_token.md
+++ b/docs/stackit_service-account_token.md
@@ -4,7 +4,7 @@ Provides functionality regarding service account tokens
 
 ### Synopsis
 
-Provides functionality regarding service account tokens
+Provides functionality regarding service account tokens.
 
 ```
 stackit service-account token [flags]

--- a/docs/stackit_service-account_token_create.md
+++ b/docs/stackit_service-account_token_create.md
@@ -1,10 +1,10 @@
 ## stackit service-account token create
 
-Create an access token for a service account
+Creates an access token for a service account
 
 ### Synopsis
 
-Create an access token for a service account.
+Creates an access token for a service account.
 The access token can be then used for API calls (where enabled).
 The token is only displayed upon creation, and it will not be recoverable later.
 

--- a/docs/stackit_service-account_token_list.md
+++ b/docs/stackit_service-account_token_list.md
@@ -1,10 +1,10 @@
 ## stackit service-account token list
 
-List access tokens of a service account
+Lists access tokens of a service account
 
 ### Synopsis
 
-List access tokens of a service account.
+Lists access tokens of a service account.
 Only the metadata about the access tokens is shown, and not the tokens themselves.
 Access tokens (including revoked tokens) are returned until they are expired.
 

--- a/docs/stackit_service-account_token_revoke.md
+++ b/docs/stackit_service-account_token_revoke.md
@@ -1,10 +1,10 @@
 ## stackit service-account token revoke
 
-Revoke an access token of a service account
+Revokes an access token of a service account
 
 ### Synopsis
 
-Revoke an access token of a service account.
+Revokes an access token of a service account.
 The access token is instantly revoked, any following calls with the token will be unauthorized.
 The token metadata is still stored until the expiration time.
 

--- a/docs/stackit_ske.md
+++ b/docs/stackit_ske.md
@@ -30,8 +30,8 @@ stackit ske [flags]
 * [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
 * [stackit ske cluster](./stackit_ske_cluster.md)	 - Provides functionality for SKE cluster
 * [stackit ske credentials](./stackit_ske_credentials.md)	 - Provides functionality for SKE credentials
-* [stackit ske describe](./stackit_ske_describe.md)	 - Get overall details regarding SKE
-* [stackit ske disable](./stackit_ske_disable.md)	 - Disable SKE for a project
-* [stackit ske enable](./stackit_ske_enable.md)	 - Enable SKE for a project
-* [stackit ske options](./stackit_ske_options.md)	 - List SKE provider options
+* [stackit ske describe](./stackit_ske_describe.md)	 - Shows overall details regarding SKE
+* [stackit ske disable](./stackit_ske_disable.md)	 - Disables SKE for a project
+* [stackit ske enable](./stackit_ske_enable.md)	 - Enables SKE for a project
+* [stackit ske options](./stackit_ske_options.md)	 - Lists SKE provider options
 

--- a/docs/stackit_ske.md
+++ b/docs/stackit_ske.md
@@ -4,7 +4,7 @@ Provides functionality for SKE
 
 ### Synopsis
 
-Provides functionality for STACKIT Kubernetes Engine (SKE)
+Provides functionality for STACKIT Kubernetes Engine (SKE).
 
 ```
 stackit ske [flags]
@@ -31,7 +31,7 @@ stackit ske [flags]
 * [stackit ske cluster](./stackit_ske_cluster.md)	 - Provides functionality for SKE cluster
 * [stackit ske credentials](./stackit_ske_credentials.md)	 - Provides functionality for SKE credentials
 * [stackit ske describe](./stackit_ske_describe.md)	 - Get overall details regarding SKE
-* [stackit ske disable](./stackit_ske_disable.md)	 - Disables SKE for a project
-* [stackit ske enable](./stackit_ske_enable.md)	 - Enables SKE for a project
+* [stackit ske disable](./stackit_ske_disable.md)	 - Disable SKE for a project
+* [stackit ske enable](./stackit_ske_enable.md)	 - Enable SKE for a project
 * [stackit ske options](./stackit_ske_options.md)	 - List SKE provider options
 

--- a/docs/stackit_ske_cluster.md
+++ b/docs/stackit_ske_cluster.md
@@ -4,7 +4,7 @@ Provides functionality for SKE cluster
 
 ### Synopsis
 
-Provides functionality for STACKIT Kubernetes Engine (SKE) cluster
+Provides functionality for STACKIT Kubernetes Engine (SKE) cluster.
 
 ```
 stackit ske cluster [flags]

--- a/docs/stackit_ske_cluster.md
+++ b/docs/stackit_ske_cluster.md
@@ -29,9 +29,9 @@ stackit ske cluster [flags]
 
 * [stackit ske](./stackit_ske.md)	 - Provides functionality for SKE
 * [stackit ske cluster create](./stackit_ske_cluster_create.md)	 - Creates an SKE cluster
-* [stackit ske cluster delete](./stackit_ske_cluster_delete.md)	 - Delete a SKE cluster
-* [stackit ske cluster describe](./stackit_ske_cluster_describe.md)	 - Get details of a SKE cluster
+* [stackit ske cluster delete](./stackit_ske_cluster_delete.md)	 - Deletes a SKE cluster
+* [stackit ske cluster describe](./stackit_ske_cluster_describe.md)	 - Shows details  of a SKE cluster
 * [stackit ske cluster generate-payload](./stackit_ske_cluster_generate-payload.md)	 - Generates a payload to create/update SKE clusters
-* [stackit ske cluster list](./stackit_ske_cluster_list.md)	 - List all SKE clusters
+* [stackit ske cluster list](./stackit_ske_cluster_list.md)	 - Lists all SKE clusters
 * [stackit ske cluster update](./stackit_ske_cluster_update.md)	 - Updates an SKE cluster
 

--- a/docs/stackit_ske_cluster_delete.md
+++ b/docs/stackit_ske_cluster_delete.md
@@ -4,7 +4,7 @@ Delete a SKE cluster
 
 ### Synopsis
 
-Delete a STACKIT Kubernetes Engine (SKE) cluster
+Delete a STACKIT Kubernetes Engine (SKE) cluster.
 
 ```
 stackit ske cluster delete CLUSTER_NAME [flags]

--- a/docs/stackit_ske_cluster_delete.md
+++ b/docs/stackit_ske_cluster_delete.md
@@ -1,10 +1,10 @@
 ## stackit ske cluster delete
 
-Delete a SKE cluster
+Deletes a SKE cluster
 
 ### Synopsis
 
-Delete a STACKIT Kubernetes Engine (SKE) cluster.
+Deletes a STACKIT Kubernetes Engine (SKE) cluster.
 
 ```
 stackit ske cluster delete CLUSTER_NAME [flags]

--- a/docs/stackit_ske_cluster_describe.md
+++ b/docs/stackit_ske_cluster_describe.md
@@ -4,7 +4,7 @@ Get details of a SKE cluster
 
 ### Synopsis
 
-Get details of a STACKIT Kubernetes Engine (SKE) cluster
+Get details of a STACKIT Kubernetes Engine (SKE) cluster.
 
 ```
 stackit ske cluster describe CLUSTER_NAME [flags]

--- a/docs/stackit_ske_cluster_describe.md
+++ b/docs/stackit_ske_cluster_describe.md
@@ -1,10 +1,10 @@
 ## stackit ske cluster describe
 
-Get details of a SKE cluster
+Shows details  of a SKE cluster
 
 ### Synopsis
 
-Get details of a STACKIT Kubernetes Engine (SKE) cluster.
+Shows details  of a STACKIT Kubernetes Engine (SKE) cluster.
 
 ```
 stackit ske cluster describe CLUSTER_NAME [flags]

--- a/docs/stackit_ske_cluster_list.md
+++ b/docs/stackit_ske_cluster_list.md
@@ -1,10 +1,10 @@
 ## stackit ske cluster list
 
-List all SKE clusters
+Lists all SKE clusters
 
 ### Synopsis
 
-List all STACKIT Kubernetes Engine (SKE) clusters.
+Lists all STACKIT Kubernetes Engine (SKE) clusters.
 
 ```
 stackit ske cluster list [flags]

--- a/docs/stackit_ske_cluster_list.md
+++ b/docs/stackit_ske_cluster_list.md
@@ -4,7 +4,7 @@ List all SKE clusters
 
 ### Synopsis
 
-List all STACKIT Kubernetes Engine (SKE) clusters
+List all STACKIT Kubernetes Engine (SKE) clusters.
 
 ```
 stackit ske cluster list [flags]

--- a/docs/stackit_ske_credentials.md
+++ b/docs/stackit_ske_credentials.md
@@ -4,7 +4,7 @@ Provides functionality for SKE credentials
 
 ### Synopsis
 
-Provides functionality for STACKIT Kubernetes Engine (SKE) credentials
+Provides functionality for STACKIT Kubernetes Engine (SKE) credentials.
 
 ```
 stackit ske credentials [flags]

--- a/docs/stackit_ske_credentials.md
+++ b/docs/stackit_ske_credentials.md
@@ -28,6 +28,6 @@ stackit ske credentials [flags]
 ### SEE ALSO
 
 * [stackit ske](./stackit_ske.md)	 - Provides functionality for SKE
-* [stackit ske credentials describe](./stackit_ske_credentials_describe.md)	 - Get details of the credentials associated to a SKE cluster
-* [stackit ske credentials rotate](./stackit_ske_credentials_rotate.md)	 - Rotate credentials associated to a SKE cluster
+* [stackit ske credentials describe](./stackit_ske_credentials_describe.md)	 - Shows details of the credentials associated to a SKE cluster
+* [stackit ske credentials rotate](./stackit_ske_credentials_rotate.md)	 - Rotates credentials associated to a SKE cluster
 

--- a/docs/stackit_ske_credentials_describe.md
+++ b/docs/stackit_ske_credentials_describe.md
@@ -1,10 +1,10 @@
 ## stackit ske credentials describe
 
-Get details of the credentials associated to a SKE cluster
+Shows details of the credentials associated to a SKE cluster
 
 ### Synopsis
 
-Get details of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster
+Shows details of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster
 
 ```
 stackit ske credentials describe CLUSTER_NAME [flags]

--- a/docs/stackit_ske_credentials_rotate.md
+++ b/docs/stackit_ske_credentials_rotate.md
@@ -1,10 +1,10 @@
 ## stackit ske credentials rotate
 
-Rotate credentials associated to a SKE cluster
+Rotates credentials associated to a SKE cluster
 
 ### Synopsis
 
-Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.
+Rotates credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.
 
 ```
 stackit ske credentials rotate CLUSTER_NAME [flags]

--- a/docs/stackit_ske_credentials_rotate.md
+++ b/docs/stackit_ske_credentials_rotate.md
@@ -4,7 +4,7 @@ Rotate credentials associated to a SKE cluster
 
 ### Synopsis
 
-Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation
+Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.
 
 ```
 stackit ske credentials rotate CLUSTER_NAME [flags]

--- a/docs/stackit_ske_describe.md
+++ b/docs/stackit_ske_describe.md
@@ -4,7 +4,7 @@ Get overall details regarding SKE
 
 ### Synopsis
 
-Get overall details regarding STACKIT Kubernetes Engine (SKE)
+Get overall details regarding STACKIT Kubernetes Engine (SKE).
 
 ```
 stackit ske describe [flags]

--- a/docs/stackit_ske_describe.md
+++ b/docs/stackit_ske_describe.md
@@ -1,10 +1,10 @@
 ## stackit ske describe
 
-Get overall details regarding SKE
+Shows overall details regarding SKE
 
 ### Synopsis
 
-Get overall details regarding STACKIT Kubernetes Engine (SKE).
+Shows overall details regarding STACKIT Kubernetes Engine (SKE).
 
 ```
 stackit ske describe [flags]

--- a/docs/stackit_ske_disable.md
+++ b/docs/stackit_ske_disable.md
@@ -1,10 +1,10 @@
 ## stackit ske disable
 
-Disables SKE for a project
+Disable SKE for a project
 
 ### Synopsis
 
-Disables STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters
+Disable STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.
 
 ```
 stackit ske disable [flags]

--- a/docs/stackit_ske_disable.md
+++ b/docs/stackit_ske_disable.md
@@ -1,10 +1,10 @@
 ## stackit ske disable
 
-Disable SKE for a project
+Disables SKE for a project
 
 ### Synopsis
 
-Disable STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.
+Disables STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.
 
 ```
 stackit ske disable [flags]

--- a/docs/stackit_ske_enable.md
+++ b/docs/stackit_ske_enable.md
@@ -1,10 +1,10 @@
 ## stackit ske enable
 
-Enables SKE for a project
+Enable SKE for a project
 
 ### Synopsis
 
-Enables STACKIT Kubernetes Engine (SKE) for a project
+Enable STACKIT Kubernetes Engine (SKE) for a project.
 
 ```
 stackit ske enable [flags]

--- a/docs/stackit_ske_enable.md
+++ b/docs/stackit_ske_enable.md
@@ -1,10 +1,10 @@
 ## stackit ske enable
 
-Enable SKE for a project
+Enables SKE for a project
 
 ### Synopsis
 
-Enable STACKIT Kubernetes Engine (SKE) for a project.
+Enables STACKIT Kubernetes Engine (SKE) for a project.
 
 ```
 stackit ske enable [flags]

--- a/docs/stackit_ske_options.md
+++ b/docs/stackit_ske_options.md
@@ -1,10 +1,10 @@
 ## stackit ske options
 
-List SKE provider options
+Lists SKE provider options
 
 ### Synopsis
 
-List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).
+Lists STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).
 Pass one or more flags to filter what categories are shown.
 
 ```

--- a/docs/stackit_ske_options.md
+++ b/docs/stackit_ske_options.md
@@ -5,7 +5,7 @@ List SKE provider options
 ### Synopsis
 
 List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types)
-Pass one or more flags to filter what categories are shown
+Pass one or more flags to filter what categories are shown.
 
 ```
 stackit ske options [flags]

--- a/docs/stackit_ske_options.md
+++ b/docs/stackit_ske_options.md
@@ -4,7 +4,7 @@ List SKE provider options
 
 ### Synopsis
 
-List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types)
+List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).
 Pass one or more flags to filter what categories are shown.
 
 ```

--- a/internal/cmd/auth/activate-service-account/activate_service_account.go
+++ b/internal/cmd/auth/activate-service-account/activate_service_account.go
@@ -34,9 +34,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "activate-service-account",
-		Short: "Activate service account authentication",
+		Short: "Authenticates using a service account",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Activate authentication using service account credentials.",
+			"Authenticates to the CLI using service account credentials.",
 			"Subsequent commands will be authenticated using the service account credentials provided.",
 			"For more details on how to configure your service account, check our Authentication guide at https://github.com/stackitcloud/stackit-cli/blob/main/AUTHENTICATION.md.",
 		),

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -13,7 +13,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Provides authentication functionality",
-		Long:  "Provides authentication functionality",
+		Long:  "Provides authentication functionality.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/auth/login/login.go
+++ b/internal/cmd/auth/login/login.go
@@ -13,8 +13,8 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to the STACKIT CLI",
-		Long:  "Login to the STACKIT CLI.",
+		Short: "Logs in to the STACKIT CLI",
+		Long:  "Logs in to the STACKIT CLI using a user account.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/auth/login/login.go
+++ b/internal/cmd/auth/login/login.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Login to the STACKIT CLI",
-		Long:  "Login to the STACKIT CLI",
+		Long:  "Login to the STACKIT CLI.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "CLI configuration options",
-		Long:  "CLI configuration options",
+		Long:  "CLI configuration options.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -19,7 +19,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the current CLI configuration values",
-		Long:  "List the current CLI configuration values",
+		Long:  "List the current CLI configuration values.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -18,8 +18,8 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List the current CLI configuration values",
-		Long:  "List the current CLI configuration values.",
+		Short: "Lists the current CLI configuration values",
+		Long:  "Lists the current CLI configuration values.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -35,11 +35,13 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
-		Short: "Set CLI configuration options",
-		Long: `Set CLI configuration options. 
-All of the configuration options can be set using an environment variable, which takes precedence over what is configured. 
-The environment variable is the name of the flag, with underscores ("_") instead of dashes ("-") and the "STACKIT" prefix.
-Example: to set the project ID you can set the environment variable STACKIT_PROJECT_ID`,
+		Short: "Sets CLI configuration options",
+		Long: fmt.Sprintf("%s\n%s\n%s\n%s",
+			"Sets CLI configuration options.",
+			"All of the configuration options can be set using an environment variable, which takes precedence over what is configured.",
+			`The environment variable is the name of the flag, with underscores ("_") instead of dashes ("-") and the "STACKIT" prefix.`,
+			"Example: to set the project ID you can set the environment variable STACKIT_PROJECT_ID.",
+		),
 		Args: args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -45,7 +45,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
 		Short: "Unset CLI configuration options",
-		Long:  "Unset CLI configuration options",
+		Long:  "Unset CLI configuration options.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -44,8 +44,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
-		Short: "Unset CLI configuration options",
-		Long:  "Unset CLI configuration options.",
+		Short: "Unsets CLI configuration options",
+		Long:  "Unsets CLI configuration options.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -46,8 +46,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("curl %s", urlArg),
-		Short: "Execute an authenticated HTTP request to an endpoint",
-		Long:  "Execute an HTTP request to an endpoint, using the authentication provided by the CLI.",
+		Short: "Executes an authenticated HTTP request to an endpoint",
+		Long:  "Executes an HTTP request to an endpoint, using the authentication provided by the CLI.",
 		Example: examples.Build(
 			examples.NewExample(
 				"Make a GET request to http://locahost:8000",

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("curl %s", urlArg),
 		Short: "Execute an authenticated HTTP request to an endpoint",
-		Long:  "Execute an HTTP request to an endpoint, using the authentication provided by the CLI",
+		Long:  "Execute an HTTP request to an endpoint, using the authentication provided by the CLI.",
 		Example: examples.Build(
 			examples.NewExample(
 				"Make a GET request to http://locahost:8000",

--- a/internal/cmd/dns/dns.go
+++ b/internal/cmd/dns/dns.go
@@ -13,7 +13,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dns",
 		Short: "Provides functionality for DNS",
-		Long:  "Provides functionality for DNS",
+		Long:  "Provides functionality for DNS.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -44,8 +44,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Creates a DNS record set",
-		Long:  "Creates a DNS record set",
+		Short: "Create a DNS record set",
+		Long:  "Create a DNS record set.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -44,8 +44,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a DNS record set",
-		Long:  "Create a DNS record set.",
+		Short: "Creates a DNS record set",
+		Long:  "Creates a DNS record set.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/delete/delete.go
+++ b/internal/cmd/dns/record-set/delete/delete.go
@@ -35,8 +35,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", recordSetIdArg),
-		Short: "Delete a DNS record set",
-		Long:  "Delete a DNS record set.",
+		Short: "Deletes a DNS record set",
+		Long:  "Deletes a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/delete/delete.go
+++ b/internal/cmd/dns/record-set/delete/delete.go
@@ -36,7 +36,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", recordSetIdArg),
 		Short: "Delete a DNS record set",
-		Long:  "Delete a DNS record set",
+		Long:  "Delete a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -34,8 +34,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", recordSetIdArg),
-		Short: "Get details of a DNS record set",
-		Long:  "Get details of a DNS record set.",
+		Short: "Shows details  of a DNS record set",
+		Long:  "Shows details  of a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", recordSetIdArg),
 		Short: "Get details of a DNS record set",
-		Long:  "Get details of a DNS record set",
+		Long:  "Get details of a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/record_set.go
+++ b/internal/cmd/dns/record-set/record_set.go
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "record-set",
 		Short: "Provides functionality for DNS record set",
-		Long:  "Provides functionality for DNS record set",
+		Long:  "Provides functionality for DNS record set.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/dns/record-set/update/update.go
+++ b/internal/cmd/dns/record-set/update/update.go
@@ -43,8 +43,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", recordSetIdArg),
-		Short: "Update a DNS record set",
-		Long:  "Update a DNS record set.",
+		Short: "Updates a DNS record set",
+		Long:  "Updates a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/update/update.go
+++ b/internal/cmd/dns/record-set/update/update.go
@@ -43,8 +43,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", recordSetIdArg),
-		Short: "Updates a DNS record set",
-		Long:  "Updates a DNS record set. Performs a partial update; fields not provided are kept unchanged",
+		Short: "Update a DNS record set",
+		Long:  "Update a DNS record set. Performs a partial update, i.e., fields not provided are kept unchanged.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/record-set/update/update.go
+++ b/internal/cmd/dns/record-set/update/update.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", recordSetIdArg),
 		Short: "Update a DNS record set",
-		Long:  "Update a DNS record set. Performs a partial update, i.e., fields not provided are kept unchanged.",
+		Long:  "Update a DNS record set.",
 		Args:  args.SingleArg(recordSetIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -55,8 +55,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a DNS zone",
-		Long:  "Create a DNS zone.",
+		Short: "Creates a DNS zone",
+		Long:  "Creates a DNS zone.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -55,8 +55,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Creates a DNS zone",
-		Long:  "Creates a DNS zone",
+		Short: "Create a DNS zone",
+		Long:  "Create a DNS zone.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/delete/delete.go
+++ b/internal/cmd/dns/zone/delete/delete.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", zoneIdArg),
 		Short: "Delete a DNS zone",
-		Long:  "Delete a DNS zone",
+		Long:  "Delete a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/delete/delete.go
+++ b/internal/cmd/dns/zone/delete/delete.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", zoneIdArg),
-		Short: "Delete a DNS zone",
-		Long:  "Delete a DNS zone.",
+		Short: "Deletes a DNS zone",
+		Long:  "Deletes a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", zoneIdArg),
-		Short: "Get details of a DNS zone",
-		Long:  "Get details of a DNS zone.",
+		Short: "Shows details  of a DNS zone",
+		Long:  "Shows details  of a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", zoneIdArg),
 		Short: "Get details of a DNS zone",
-		Long:  "Get details of a DNS zone",
+		Long:  "Get details of a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/update/update.go
+++ b/internal/cmd/dns/zone/update/update.go
@@ -53,8 +53,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", zoneIdArg),
-		Short: "Update a DNS zone",
-		Long:  "Update a DNS zone.",
+		Short: "Updates a DNS zone",
+		Long:  "Updates a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/update/update.go
+++ b/internal/cmd/dns/zone/update/update.go
@@ -53,8 +53,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", zoneIdArg),
-		Short: "Updates a DNS zone",
-		Long:  "Updates a DNS zone. Performs a partial update; fields not provided are kept unchanged",
+		Short: "Update a DNS zone",
+		Long:  "Update a DNS zone. Performs a partial update, i.e., fields not provided are kept unchanged.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/update/update.go
+++ b/internal/cmd/dns/zone/update/update.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", zoneIdArg),
 		Short: "Update a DNS zone",
-		Long:  "Update a DNS zone. Performs a partial update, i.e., fields not provided are kept unchanged.",
+		Long:  "Update a DNS zone.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/dns/zone/zone.go
+++ b/internal/cmd/dns/zone/zone.go
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zone",
 		Short: "Provides functionality for DNS zones",
-		Long:  "Provides functionality for DNS zones",
+		Long:  "Provides functionality for DNS zones.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -59,8 +59,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a MongoDB Flex instance",
-		Long:  "Create a MongoDB Flex instance.",
+		Short: "Creates a MongoDB Flex instance",
+		Long:  "Creates a MongoDB Flex instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/delete/delete.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", instanceIdArg),
 		Short: "Delete a MongoDB Flex instance",
-		Long:  "Delete a MongoDB Flex instance",
+		Long:  "Delete a MongoDB Flex instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/delete/delete.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", instanceIdArg),
-		Short: "Delete a MongoDB Flex instance",
-		Long:  "Delete a MongoDB Flex instance.",
+		Short: "Deletes a MongoDB Flex instance",
+		Long:  "Deletes a MongoDB Flex instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", instanceIdArg),
 		Short: "Get details of a MongoDB Flex instance",
-		Long:  "Get details of a MongoDB Flex instance",
+		Long:  "Get details of a MongoDB Flex instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", instanceIdArg),
-		Short: "Get details of a MongoDB Flex instance",
-		Long:  "Get details of a MongoDB Flex instance.",
+		Short: "Shows details  of a MongoDB Flex instance",
+		Long:  "Shows details  of a MongoDB Flex instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/instance.go
+++ b/internal/cmd/mongodbflex/instance/instance.go
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Provides functionality for MongoDB Flex instances",
-		Long:  "Provides functionality for MongoDB Flex instances",
+		Long:  "Provides functionality for MongoDB Flex instances.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -30,8 +30,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all MongoDB Flex instances",
-		Long:  "List all MongoDB Flex instances.",
+		Short: "Lists all MongoDB Flex instances",
+		Long:  "Lists all MongoDB Flex instances.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all MongoDB Flex instances",
-		Long:  "List all MongoDB Flex instances",
+		Long:  "List all MongoDB Flex instances.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -57,8 +57,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", instanceIdArg),
-		Short: "Update a MongoDB Flex instance",
-		Long:  "Update a MongoDB Flex instance.",
+		Short: "Updates a MongoDB Flex instance",
+		Long:  "Updates a MongoDB Flex instance.",
 		Example: examples.Build(
 			examples.NewExample(
 				`Update the name of a MongoDB Flex instance`,
@@ -135,7 +135,7 @@ func configureFlags(cmd *cobra.Command) {
 	typeFlagOptions := []string{"Single", "Replica", "Sharded"}
 
 	cmd.Flags().StringP(instanceNameFlag, "n", "", "Instance name")
-	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "List of IP networks in CIDR notation which are allowed to access this instance")
+	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "Lists of IP networks in CIDR notation which are allowed to access this instance")
 	cmd.Flags().String(backupScheduleFlag, "", "Backup schedule")
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
 	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")

--- a/internal/cmd/mongodbflex/mongodbflex.go
+++ b/internal/cmd/mongodbflex/mongodbflex.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mongodbflex",
 		Short: "Provides functionality for MongoDB Flex",
-		Long:  "Provides functionality for MongoDB Flex",
+		Long:  "Provides functionality for MongoDB Flex.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -47,8 +47,8 @@ type flavorStorages struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "options",
-		Short: "List MongoDB Flex options",
-		Long:  "List MongoDB Flex options (flavors, versions and storages for a given flavor)\nPass one or more flags to filter what categories are shown.",
+		Short: "Lists MongoDB Flex options",
+		Long:  "Lists MongoDB Flex options (flavors, versions and storages for a given flavor)\nPass one or more flags to filter what categories are shown.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -40,9 +40,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a MongoDB Flex user",
+		Short: "Creates a MongoDB Flex user",
 		Long: fmt.Sprintf("%s\n%s\n%s\n%s",
-			"Create a MongoDB Flex user.",
+			"Creates a MongoDB Flex user.",
 			"The password is only visible upon creation and cannot be retrieved later.",
 			"Alternatively, you can reset the password and access the new one by running:",
 			"  $ stackit mongodbflex user reset-password --instance-id <INSTANCE_ID> --user-id <USER_ID>",

--- a/internal/cmd/mongodbflex/user/delete/delete.go
+++ b/internal/cmd/mongodbflex/user/delete/delete.go
@@ -34,9 +34,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", userIdArg),
-		Short: "Delete a MongoDB Flex user",
+		Short: "Deletes a MongoDB Flex user",
 		Long: fmt.Sprintf("%s\n%s",
-			"Delete a MongoDB Flex user by ID. You can get the IDs of users for an instance by running:",
+			"Deletes a MongoDB Flex user by ID. You can get the IDs of users for an instance by running:",
 			"  $ stackit mongodbflex user list --instance-id <INSTANCE_ID>",
 		),
 		Example: examples.Build(

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -34,9 +34,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", userIdArg),
-		Short: "Get details of a MongoDB Flex user",
+		Short: "Shows details of a MongoDB Flex user",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Get details of a MongoDB Flex user.",
+			"Shows details of a MongoDB Flex user.",
 			`The user password is hidden inside the "host" field and replaced with asterisks, as it is only visible upon creation. You can reset it by running:`,
 			"  $ stackit mongodbflex user reset-password <USER_ID> --instance-id <INSTANCE_ID>",
 		),

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all MongoDB Flex users of an instance",
-		Long:  "List all MongoDB Flex users of an instance.",
+		Short: "Lists all MongoDB Flex users of an instance",
+		Long:  "Lists all MongoDB Flex users of an instance.",
 		Example: examples.Build(
 			examples.NewExample(
 				`List all MongoDB Flex users of instance with ID "xxx"`,

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -34,8 +34,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("reset-password %s", userIdArg),
-		Short: "Reset the password of a MongoDB Flex user",
-		Long:  "Reset the password of a MongoDB Flex user. The new password is returned in the response.",
+		Short: "Resets the password of a MongoDB Flex user",
+		Long:  "Resets the password of a MongoDB Flex user. The new password is returned in the response.",
 		Example: examples.Build(
 			examples.NewExample(
 				`Reset the password of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"`,

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("reset-password %s", userIdArg),
 		Short: "Resets the password of a MongoDB Flex user",
-		Long:  "Resets the password of a MongoDB Flex user. The new password is returned in the response.",
+		Long:  "Resets the password of a MongoDB Flex user. The new password is shown in the command's output.",
 		Example: examples.Build(
 			examples.NewExample(
 				`Reset the password of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"`,

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -38,8 +38,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", userIdArg),
-		Short: "Update a MongoDB Flex user",
-		Long:  "Update a MongoDB Flex user.",
+		Short: "Updates a MongoDB Flex user",
+		Long:  "Updates a MongoDB Flex user.",
 		Example: examples.Build(
 			examples.NewExample(
 				`Update the roles of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"`,

--- a/internal/cmd/mongodbflex/user/user.go
+++ b/internal/cmd/mongodbflex/user/user.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "user",
 		Short: "Provides functionality for MongoDB Flex users",
-		Long:  "Provides functionality for MongoDB Flex users",
+		Long:  "Provides functionality for MongoDB Flex users.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create credentials for an OpenSearch instance",
-		Long:  "Create credentials (username and password) for an OpenSearch instance",
+		Long:  "Create credentials (username and password) for an OpenSearch instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create credentials for an OpenSearch instance",
-		Long:  "Create credentials (username and password) for an OpenSearch instance.",
+		Short: "Creates credentials for an OpenSearch instance",
+		Long:  "Creates credentials (username and password) for an OpenSearch instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/credentials.go
+++ b/internal/cmd/opensearch/credentials/credentials.go
@@ -15,7 +15,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "credentials",
 		Short: "Provides functionality for OpenSearch credentials",
-		Long:  "Provides functionality for OpenSearch credentials",
+		Long:  "Provides functionality for OpenSearch credentials.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/opensearch/credentials/delete/delete.go
+++ b/internal/cmd/opensearch/credentials/delete/delete.go
@@ -34,7 +34,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", credentialsIdArg),
 		Short: "Delete credentials of an OpenSearch instance",
-		Long:  "Delete credentials of an OpenSearch instance",
+		Long:  "Delete credentials of an OpenSearch instance.",
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/delete/delete.go
+++ b/internal/cmd/opensearch/credentials/delete/delete.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", credentialsIdArg),
-		Short: "Delete credentials of an OpenSearch instance",
-		Long:  "Delete credentials of an OpenSearch instance.",
+		Short: "Deletes credentials of an OpenSearch instance",
+		Long:  "Deletes credentials of an OpenSearch instance.",
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", credentialsIdArg),
-		Short: "Get details of credentials of an OpenSearch instance",
-		Long:  "Get details of credentials of an OpenSearch instance. The password will be shown in plain text in the output.",
+		Short: "Shows details of credentials of an OpenSearch instance",
+		Long:  "Shows details of credentials of an OpenSearch instance. The password will be shown in plain text in the output.",
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -32,8 +32,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all credentials' IDs for an OpenSearch instance",
-		Long:  "List all credentials' IDs for an OpenSearch instance.",
+		Short: "Lists all credentials' IDs for an OpenSearch instance",
+		Long:  "Lists all credentials' IDs for an OpenSearch instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -33,7 +33,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all credentials' IDs for an OpenSearch instance",
-		Long:  "List all credentials' IDs for an OpenSearch instance",
+		Long:  "List all credentials' IDs for an OpenSearch instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/create/create.go
+++ b/internal/cmd/opensearch/instance/create/create.go
@@ -58,8 +58,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an OpenSearch instance",
-		Long:  "Create an OpenSearch instance.",
+		Short: "Creates an OpenSearch instance",
+		Long:  "Creates an OpenSearch instance.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/delete/delete.go
+++ b/internal/cmd/opensearch/instance/delete/delete.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", instanceIdArg),
 		Short: "Delete an OpenSearch instance",
-		Long:  "Delete an OpenSearch instance",
+		Long:  "Delete an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/delete/delete.go
+++ b/internal/cmd/opensearch/instance/delete/delete.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", instanceIdArg),
-		Short: "Delete an OpenSearch instance",
-		Long:  "Delete an OpenSearch instance.",
+		Short: "Deletes an OpenSearch instance",
+		Long:  "Deletes an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", instanceIdArg),
-		Short: "Get details of an OpenSearch instance",
-		Long:  "Get details of an OpenSearch instance.",
+		Short: "Shows details  of an OpenSearch instance",
+		Long:  "Shows details  of an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", instanceIdArg),
 		Short: "Get details of an OpenSearch instance",
-		Long:  "Get details of an OpenSearch instance",
+		Long:  "Get details of an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/instance.go
+++ b/internal/cmd/opensearch/instance/instance.go
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instance",
 		Short: "Provides functionality for OpenSearch instances",
-		Long:  "Provides functionality for OpenSearch instances",
+		Long:  "Provides functionality for OpenSearch instances.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -30,8 +30,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all OpenSearch instances",
-		Long:  "List all OpenSearch instances.",
+		Short: "Lists all OpenSearch instances",
+		Long:  "Lists all OpenSearch instances.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all OpenSearch instances",
-		Long:  "List all OpenSearch instances",
+		Long:  "List all OpenSearch instances.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/update/update.go
+++ b/internal/cmd/opensearch/instance/update/update.go
@@ -59,8 +59,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", instanceIdArg),
-		Short: "Updates an OpenSearch instance",
-		Long:  "Updates an OpenSearch instance",
+		Short: "Update an OpenSearch instance",
+		Long:  "Update an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/instance/update/update.go
+++ b/internal/cmd/opensearch/instance/update/update.go
@@ -59,8 +59,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", instanceIdArg),
-		Short: "Update an OpenSearch instance",
-		Long:  "Update an OpenSearch instance.",
+		Short: "Updates an OpenSearch instance",
+		Long:  "Updates an OpenSearch instance.",
 		Args:  args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/opensearch.go
+++ b/internal/cmd/opensearch/opensearch.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "opensearch",
 		Short: "Provides functionality for OpenSearch",
-		Long:  "Provides functionality for OpenSearch",
+		Long:  "Provides functionality for OpenSearch.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -30,8 +30,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plans",
-		Short: "List all OpenSearch service plans",
-		Long:  "List all OpenSearch service plans.",
+		Short: "Lists all OpenSearch service plans",
+		Long:  "Lists all OpenSearch service plans.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plans",
 		Short: "List all OpenSearch service plans",
-		Long:  "List all OpenSearch service plans",
+		Long:  "List all OpenSearch service plans.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/organization/member/add/add.go
+++ b/internal/cmd/organization/member/add/add.go
@@ -36,9 +36,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("add %s", subjectArg),
-		Short: "Add a member to an organization",
+		Short: "Adds a member to an organization",
 		Long: fmt.Sprintf("%s\n%s\n%s\n%s\n%s",
-			"Add a member to an organization.",
+			"Adds a member to an organization.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
 			"The subject is usually email address for users or name in case of clients",
 			"For more details on the available roles, run:",

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -39,8 +39,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List members of an organization",
-		Long:  "List members of an organization",
+		Short: "Lists members of an organization",
+		Long:  "Lists members of an organization",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/organization/member/member.go
+++ b/internal/cmd/organization/member/member.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "member",
 		Short: "Provides functionality regarding organization members",
-		Long:  "Provides functionality regarding organization members",
+		Long:  "Provides functionality regarding organization members.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -38,9 +38,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("remove %s", subjectArg),
-		Short: "Remove a member from an organization.",
+		Short: "Removes a member from an organization.",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Remove a member from an organization.",
+			"Removes a member from an organization.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
 			"The subject is usually email address (for users) or name (for clients).",
 		),

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -38,7 +38,7 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("remove %s", subjectArg),
-		Short: "Removes a member from an organization.",
+		Short: "Removes a member from an organization",
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			"Removes a member from an organization.",
 			"A member is a combination of a subject (user, service account or client) and a role.",

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -42,7 +42,7 @@ func NewCmd() *cobra.Command {
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			"Remove a member from an organization.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
-			"The subject is usually email address for users or name in case of clients.",
+			"The subject is usually email address (for users) or name (for clients).",
 		),
 		Args: args.SingleArg(subjectArg, nil),
 		Example: examples.Build(

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -42,7 +42,7 @@ func NewCmd() *cobra.Command {
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			"Remove a member from an organization.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
-			"The subject is usually email address for users or name in case of clients",
+			"The subject is usually email address for users or name in case of clients.",
 		),
 		Args: args.SingleArg(subjectArg, nil),
 		Example: examples.Build(

--- a/internal/cmd/organization/organization.go
+++ b/internal/cmd/organization/organization.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 		Short: "Provides functionality regarding organizations",
 		Long: fmt.Sprintf("%s\n%s",
 			"Provides functionality regarding organizations.",
-			"An active STACKIT organization is the root element of the resource hierarchy and a prerequisite to use any STACKIT Cloud Resource / Service",
+			"An active STACKIT organization is the root element of the resource hierarchy and a prerequisite to use any STACKIT Cloud Resource / Service.",
 		),
 		Args: args.NoArgs,
 		Run:  utils.CmdHelp,

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List roles and permissions of an organization",
-		Long:  "List roles and permissions of an organization",
+		Long:  "List roles and permissions of an organization.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -34,8 +34,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List roles and permissions of an organization",
-		Long:  "List roles and permissions of an organization.",
+		Short: "Lists roles and permissions of an organization",
+		Long:  "Lists roles and permissions of an organization.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/organization/role/role.go
+++ b/internal/cmd/organization/role/role.go
@@ -12,7 +12,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "role",
 		Short: "Provides functionality regarding organization roles",
-		Long:  "Provides functionality regarding organization roles",
+		Long:  "Provides functionality regarding organization roles.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -39,8 +39,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create STACKIT projects",
-		Long:  "Create STACKIT projects",
+		Short: "Create a STACKIT project",
+		Long:  "Create a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -39,8 +39,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a STACKIT project",
-		Long:  "Create a STACKIT project.",
+		Short: "Creates a STACKIT project",
+		Long:  "Creates a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/delete/delete.go
+++ b/internal/cmd/project/delete/delete.go
@@ -24,7 +24,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a STACKIT project",
-		Long:  "Delete a STACKIT project",
+		Long:  "Delete a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/delete/delete.go
+++ b/internal/cmd/project/delete/delete.go
@@ -23,8 +23,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a STACKIT project",
-		Long:  "Delete a STACKIT project.",
+		Short: "Deletes a STACKIT project",
+		Long:  "Deletes a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Get the details of a STACKIT project",
-		Long:  "Get the details of a STACKIT project.",
+		Short: "Show details of a STACKIT project",
+		Long:  "Show details of a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Show details of a STACKIT project",
-		Long:  "Show details of a STACKIT project.",
+		Short: "Shows details of a STACKIT project",
+		Long:  "Shows details of a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Get the details of a STACKIT project",
-		Long:  "Get the details of a STACKIT project",
+		Long:  "Get the details of a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List STACKIT projects",
-		Long:  "List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided",
+		Long:  "List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -43,8 +43,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List STACKIT projects",
-		Long:  "List all STACKIT projects that match certain criteria.",
+		Short: "Lists STACKIT projects",
+		Long:  "Lists all STACKIT projects that match certain criteria.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List STACKIT projects",
-		Long:  "List all STACKIT projects that match certain criteria. At least one of parent-id, project-id-like or member flag must be provided.",
+		Long:  "List all STACKIT projects that match certain criteria.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/member/add/add.go
+++ b/internal/cmd/project/member/add/add.go
@@ -36,9 +36,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("add %s", subjectArg),
-		Short: "Add a member to a project",
+		Short: "Adds a member to a project",
 		Long: fmt.Sprintf("%s\n%s\n%s\n%s\n%s",
-			"Add a member to a project.",
+			"Adds a member to a project.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
 			"The subject is usually email address for users or name in case of clients",
 			"For more details on the available roles, run:",

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -38,8 +38,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List members of a project",
-		Long:  "List members of a project.",
+		Short: "Lists members of a project",
+		Long:  "Lists members of a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -96,7 +96,7 @@ func NewCmd() *cobra.Command {
 func configureFlags(cmd *cobra.Command) {
 	sortByFlagOptions := []string{"subject", "role"}
 
-	cmd.Flags().String(subjectFlag, "", "Filter by subject (Identifier of user, service account or client. Usually email address in case of users or name in case of clients)")
+	cmd.Flags().String(subjectFlag, "", "Filter by subject (the identifier of a user, service account or client). This is usually the email address (for users) or name (for clients)")
 	cmd.Flags().Int64(limitFlag, 0, "Maximum number of entries to list")
 	cmd.Flags().Var(flags.EnumFlag(false, "subject", sortByFlagOptions...), sortByFlag, fmt.Sprintf("Sort entries by a specific field, one of %q", sortByFlagOptions))
 }

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -39,7 +39,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List members of a project",
-		Long:  "List members of a project",
+		Long:  "List members of a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/member/member.go
+++ b/internal/cmd/project/member/member.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "member",
 		Short: "Provides functionality regarding project members",
-		Long:  "Provides functionality regarding project members",
+		Long:  "Provides functionality regarding project members.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/project/member/remove/remove.go
+++ b/internal/cmd/project/member/remove/remove.go
@@ -38,7 +38,7 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("remove %s", subjectArg),
-		Short: "Removes a member from a project.",
+		Short: "Removes a member from a project",
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			"Removes a member from a project.",
 			"A member is a combination of a subject (user, service account or client) and a role.",

--- a/internal/cmd/project/member/remove/remove.go
+++ b/internal/cmd/project/member/remove/remove.go
@@ -38,9 +38,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("remove %s", subjectArg),
-		Short: "Remove a member from a project.",
+		Short: "Removes a member from a project.",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Remove a member from a project.",
+			"Removes a member from a project.",
 			"A member is a combination of a subject (user, service account or client) and a role.",
 			"The subject is usually email address for users or name in case of clients",
 		),

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List roles and permissions of a project",
-		Long:  "List roles and permissions of a project.",
+		Short: "Lists roles and permissions of a project",
+		Long:  "Lists roles and permissions of a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -34,7 +34,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List roles and permissions of a project",
-		Long:  "List roles and permissions of a project",
+		Long:  "List roles and permissions of a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/project/role/role.go
+++ b/internal/cmd/project/role/role.go
@@ -12,7 +12,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "role",
 		Short: "Provides functionality regarding project roles",
-		Long:  "Provides functionality regarding project roles",
+		Long:  "Provides functionality regarding project roles.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/project/update/update.go
+++ b/internal/cmd/project/update/update.go
@@ -38,8 +38,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update a STACKIT project",
-		Long:  "Update a STACKIT project.",
+		Short: "Updates a STACKIT project",
+		Long:  "Updates a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 

--- a/internal/cmd/project/update/update.go
+++ b/internal/cmd/project/update/update.go
@@ -39,7 +39,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a STACKIT project",
-		Long:  "Update a STACKIT project",
+		Long:  "Update a STACKIT project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a service account",
-		Long:  "Create a service account.",
+		Short: "Creates a service account",
+		Long:  "Creates a service account.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a service account",
-		Long:  "Create a service account",
+		Long:  "Create a service account.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -28,7 +28,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", emailArg),
 		Short: "Delete a service account",
-		Long:  "Delete a service account",
+		Long:  "Delete a service account.",
 		Args:  args.SingleArg(emailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -27,8 +27,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", emailArg),
-		Short: "Delete a service account",
-		Long:  "Delete a service account.",
+		Short: "Deletes a service account",
+		Long:  "Deletes a service account.",
 		Args:  args.SingleArg(emailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -24,8 +24,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("get-jwks %s", emailArg),
-		Short: "Gets the JWKS for a service account",
-		Long:  "Gets the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.",
+		Short: "Shows the JWKS for a service account",
+		Long:  "Shows the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.",
 		Args:  args.SingleArg(emailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -25,7 +25,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("get-jwks %s", emailArg),
 		Short: "Get JWKS for a service account",
-		Long:  "Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported",
+		Long:  "Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported.",
 		Args:  args.SingleArg(emailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -24,8 +24,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("get-jwks %s", emailArg),
-		Short: "Get JWKS for a service account",
-		Long:  "Get JSON Web Key set (JWKS) for a service account. Only JSON output is supported.",
+		Short: "Gets the JWKS for a service account",
+		Long:  "Gets the JSON Web Key set (JWKS) for a service account. Only JSON output is supported.",
 		Args:  args.SingleArg(emailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -36,9 +36,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a service account key",
+		Short: "Creates a service account key",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Create a service account key.",
+			"Creates a service account key.",
 			"You can generate an RSA keypair and provide the public key.",
 			"If you do not provide a public key, the service will generate a new key-pair and the private key is included in the response. You won't be able to retrieve it later.",
 		),

--- a/internal/cmd/service-account/key/delete/delete.go
+++ b/internal/cmd/service-account/key/delete/delete.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", keyIdArg),
-		Short: "Delete a service account key",
-		Long:  "Delete a service account key.",
+		Short: "Deletes a service account key",
+		Long:  "Deletes a service account key.",
 		Args:  args.SingleArg(keyIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/key/describe/describe.go
+++ b/internal/cmd/service-account/key/describe/describe.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", keyIdArg),
-		Short: "Get details of a service account key",
-		Long:  "Get details of a service account key. Only JSON output is supported.",
+		Short: "Shows details of a service account key",
+		Long:  "Shows details of a service account key. Only JSON output is supported.",
 		Args:  args.SingleArg(keyIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/key/key.go
+++ b/internal/cmd/service-account/key/key.go
@@ -16,7 +16,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "key",
 		Short: "Provides functionality regarding service account keys",
-		Long:  "Provides functionality regarding service account keys",
+		Long:  "Provides functionality regarding service account keys.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -32,8 +32,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all service account keys",
-		Long:  "List all service account keys.",
+		Short: "Lists all service account keys",
+		Long:  "Lists all service account keys.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/key/update/update.go
+++ b/internal/cmd/service-account/key/update/update.go
@@ -41,9 +41,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("update %s", keyIdArg),
-		Short: "Update a service account key",
+		Short: "Updates a service account key",
 		Long: fmt.Sprintf("%s\n%s",
-			"Update a service account key.",
+			"Updates a service account key.",
 			"You can temporarily activate or deactivate the key and/or update its date of expiration.",
 		),
 		Args: args.SingleArg(keyIdArg, utils.ValidateUUID),

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -31,7 +31,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all service accounts",
-		Long:  "List all service accounts",
+		Long:  "List all service accounts.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -30,8 +30,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all service accounts",
-		Long:  "List all service accounts.",
+		Short: "Lists all service accounts",
+		Long:  "Lists all service accounts.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/service-account/service_account.go
+++ b/internal/cmd/service-account/service_account.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "service-account",
 		Short: "Provides functionality for service accounts",
-		Long:  "Provides functionality for service accounts",
+		Long:  "Provides functionality for service accounts.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -33,9 +33,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an access token for a service account",
+		Short: "Creates an access token for a service account",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Create an access token for a service account.",
+			"Creates an access token for a service account.",
 			"The access token can be then used for API calls (where enabled).",
 			"The token is only displayed upon creation, and it will not be recoverable later.",
 		),

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -32,9 +32,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List access tokens of a service account",
+		Short: "Lists access tokens of a service account",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"List access tokens of a service account.",
+			"Lists access tokens of a service account.",
 			"Only the metadata about the access tokens is shown, and not the tokens themselves.",
 			"Access tokens (including revoked tokens) are returned until they are expired.",
 		),

--- a/internal/cmd/service-account/token/revoke/revoke.go
+++ b/internal/cmd/service-account/token/revoke/revoke.go
@@ -32,9 +32,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("revoke %s", tokenIdArg),
-		Short: "Revoke an access token of a service account",
+		Short: "Revokes an access token of a service account",
 		Long: fmt.Sprintf("%s\n%s\n%s",
-			"Revoke an access token of a service account.",
+			"Revokes an access token of a service account.",
 			"The access token is instantly revoked, any following calls with the token will be unauthorized.",
 			"The token metadata is still stored until the expiration time.",
 		),

--- a/internal/cmd/service-account/token/token.go
+++ b/internal/cmd/service-account/token/token.go
@@ -14,7 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "token",
 		Short: "Provides functionality regarding service account tokens",
-		Long:  "Provides functionality regarding service account tokens",
+		Long:  "Provides functionality regarding service account tokens.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/ske/cluster/cluster.go
+++ b/internal/cmd/ske/cluster/cluster.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Provides functionality for SKE cluster",
-		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE) cluster",
+		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE) cluster.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", clusterNameArg),
-		Short: "Delete a SKE cluster",
-		Long:  "Delete a STACKIT Kubernetes Engine (SKE) cluster.",
+		Short: "Deletes a SKE cluster",
+		Long:  "Deletes a STACKIT Kubernetes Engine (SKE) cluster.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("delete %s", clusterNameArg),
 		Short: "Delete a SKE cluster",
-		Long:  "Delete a STACKIT Kubernetes Engine (SKE) cluster",
+		Long:  "Delete a STACKIT Kubernetes Engine (SKE) cluster.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -29,7 +29,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", clusterNameArg),
 		Short: "Get details of a SKE cluster",
-		Long:  "Get details of a STACKIT Kubernetes Engine (SKE) cluster",
+		Long:  "Get details of a STACKIT Kubernetes Engine (SKE) cluster.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -28,8 +28,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", clusterNameArg),
-		Short: "Get details of a SKE cluster",
-		Long:  "Get details of a STACKIT Kubernetes Engine (SKE) cluster.",
+		Short: "Shows details  of a SKE cluster",
+		Long:  "Shows details  of a STACKIT Kubernetes Engine (SKE) cluster.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -31,8 +31,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all SKE clusters",
-		Long:  "List all STACKIT Kubernetes Engine (SKE) clusters.",
+		Short: "Lists all SKE clusters",
+		Long:  "Lists all STACKIT Kubernetes Engine (SKE) clusters.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all SKE clusters",
-		Long:  "List all STACKIT Kubernetes Engine (SKE) clusters",
+		Long:  "List all STACKIT Kubernetes Engine (SKE) clusters.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/credentials/credentials.go
+++ b/internal/cmd/ske/credentials/credentials.go
@@ -13,7 +13,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "credentials",
 		Short: "Provides functionality for SKE credentials",
-		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE) credentials",
+		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE) credentials.",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/ske/credentials/describe/describe.go
+++ b/internal/cmd/ske/credentials/describe/describe.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", clusterNameArg),
-		Short: "Get details of the credentials associated to a SKE cluster",
-		Long:  "Get details of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster",
+		Short: "Shows details of the credentials associated to a SKE cluster",
+		Long:  "Shows details of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/credentials/rotate/rotate.go
+++ b/internal/cmd/ske/credentials/rotate/rotate.go
@@ -30,7 +30,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("rotate %s", clusterNameArg),
 		Short: "Rotate credentials associated to a SKE cluster",
-		Long:  "Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation",
+		Long:  "Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/credentials/rotate/rotate.go
+++ b/internal/cmd/ske/credentials/rotate/rotate.go
@@ -29,8 +29,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("rotate %s", clusterNameArg),
-		Short: "Rotate credentials associated to a SKE cluster",
-		Long:  "Rotate credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.",
+		Short: "Rotates credentials associated to a SKE cluster",
+		Long:  "Rotates credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. The old credentials will be invalid after the operation.",
 		Args:  args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -23,8 +23,8 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
-		Short: "Get overall details regarding SKE",
-		Long:  "Get overall details regarding STACKIT Kubernetes Engine (SKE).",
+		Short: "Shows overall details regarding SKE",
+		Long:  "Shows overall details regarding STACKIT Kubernetes Engine (SKE).",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -24,7 +24,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Get overall details regarding SKE",
-		Long:  "Get overall details regarding STACKIT Kubernetes Engine (SKE)",
+		Long:  "Get overall details regarding STACKIT Kubernetes Engine (SKE).",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -25,8 +25,8 @@ type InputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
-		Short: "Disables SKE for a project",
-		Long:  "Disables STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters",
+		Short: "Disable SKE for a project",
+		Long:  "Disable STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -25,8 +25,8 @@ type InputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
-		Short: "Disable SKE for a project",
-		Long:  "Disable STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.",
+		Short: "Disables SKE for a project",
+		Long:  "Disables STACKIT Kubernetes Engine (SKE) for a project. It will delete all associated clusters.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -25,8 +25,8 @@ type InputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
-		Short: "Enable SKE for a project",
-		Long:  "Enable STACKIT Kubernetes Engine (SKE) for a project.",
+		Short: "Enables SKE for a project",
+		Long:  "Enables STACKIT Kubernetes Engine (SKE) for a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -25,8 +25,8 @@ type InputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
-		Short: "Enables SKE for a project",
-		Long:  "Enables STACKIT Kubernetes Engine (SKE) for a project",
+		Short: "Enable SKE for a project",
+		Long:  "Enable STACKIT Kubernetes Engine (SKE) for a project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -38,9 +38,9 @@ type inputModel struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "options",
-		Short: "List SKE provider options",
+		Short: "Lists SKE provider options",
 		Long: fmt.Sprintf("%s\n%s",
-			"List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).",
+			"Lists STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).",
 			"Pass one or more flags to filter what categories are shown.",
 		),
 		Args: args.NoArgs,

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -39,8 +39,11 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "options",
 		Short: "List SKE provider options",
-		Long:  "List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types)\nPass one or more flags to filter what categories are shown.",
-		Args:  args.NoArgs,
+		Long: fmt.Sprintf("%s\n%s",
+			"List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types).",
+			"Pass one or more flags to filter what categories are shown.",
+		),
+		Args: args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(
 				`List SKE options for all categories`,

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -39,7 +39,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "options",
 		Short: "List SKE provider options",
-		Long:  "List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types)\nPass one or more flags to filter what categories are shown",
+		Long:  "List STACKIT Kubernetes Engine (SKE) provider options (availability zones, Kubernetes versions, machine images and types, volume types)\nPass one or more flags to filter what categories are shown.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/ske/ske.go
+++ b/internal/cmd/ske/ske.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ske",
 		Short: "Provides functionality for SKE",
-		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE)",
+		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE).",
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}


### PR DESCRIPTION
Rationale followed:
- `Long` descriptions always end in a full stop (`.`, `!`, ...)
- Command descriptions use a declarative form (e.g. `Provides functionality for ...`, `Creates a ...`, `Deletes a ...`)