### PR TITLE
Send service account key creation to stderr

### DIFF
--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -86,7 +86,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			cmd.PrintErr(fmt.Sprintf("Created key for service account %s\n", model.ServiceAccountEmail))
+			cmd.PrintErrf("Created key for service account %s\n", model.ServiceAccountEmail)
 
 			key, err := json.MarshalIndent(resp, "", "  ")
 			if err != nil {

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -86,7 +86,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			cmd.Printf("Created key for service account %s\n", model.ServiceAccountEmail)
+			cmd.PrintErr(fmt.Sprintf("Created key for service account %s\n", model.ServiceAccountEmail))
 
 			key, err := json.MarshalIndent(resp, "", "  ")
 			if err != nil {


### PR DESCRIPTION
- To support use case of saving the result of service-account key creation directly in a file