### PR TITLE
Postgresflex user fixes

### DIFF
--- a/docs/stackit_mongodbflex_instance_create.md
+++ b/docs/stackit_mongodbflex_instance_create.md
@@ -35,7 +35,7 @@ stackit mongodbflex instance create [flags]
       --ram int                  Amount of RAM (in GB)
       --storage-class string     Storage class (default "premium-perf2-mongodb")
       --storage-size int         Storage size (in GB) (default 10)
-      --type string              Instance type, one of ["Single" "Replica" "Sharded"] (default "Replica")
+      --type string              Instance type, one of ["Sharded" "Single" "Replica"] (default "Replica")
       --version string           MongoDB version. Defaults to the latest version available
 ```
 

--- a/docs/stackit_mongodbflex_instance_create.md
+++ b/docs/stackit_mongodbflex_instance_create.md
@@ -35,7 +35,7 @@ stackit mongodbflex instance create [flags]
       --ram int                  Amount of RAM (in GB)
       --storage-class string     Storage class (default "premium-perf2-mongodb")
       --storage-size int         Storage size (in GB) (default 10)
-      --type string              Instance type, one of ["Sharded" "Single" "Replica"] (default "Replica")
+      --type string              Instance type, one of ["Single" "Replica" "Sharded"] (default "Replica")
       --version string           MongoDB version. Defaults to the latest version available
 ```
 

--- a/docs/stackit_mongodbflex_instance_update.md
+++ b/docs/stackit_mongodbflex_instance_update.md
@@ -32,7 +32,7 @@ stackit mongodbflex instance update INSTANCE_ID [flags]
       --ram int                  Amount of RAM (in GB)
       --storage-class string     Storage class
       --storage-size int         Storage size (in GB)
-      --type string              Instance type, one of ["Single" "Replica" "Sharded"]
+      --type string              Instance type, one of ["Sharded" "Single" "Replica"]
       --version string           Version
 ```
 

--- a/docs/stackit_mongodbflex_user_create.md
+++ b/docs/stackit_mongodbflex_user_create.md
@@ -17,10 +17,10 @@ stackit mongodbflex user create [flags]
 
 ```
   Create a MongoDB Flex user for instance with ID "xxx" and specify the username
-  $ stackit mongodbflex user create --instance-id xxx --username johndoe --roles read --database default
+  $ stackit mongodbflex user create --instance-id xxx --username johndoe --role read --database default
 
   Create a MongoDB Flex user for instance with ID "xxx" with an automatically generated username
-  $ stackit mongodbflex user create --instance-id xxx --roles read --database default
+  $ stackit mongodbflex user create --instance-id xxx --role read --database default
 ```
 
 ### Options
@@ -29,7 +29,7 @@ stackit mongodbflex user create [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user create"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["read" "readWrite"] (default [read])
+      --role strings         Roles of the user, can be specified multiple times. Possible values are ["read" "readWrite"] (default [])
       --username string      Username of the user. If not specified, a random username will be assigned
 ```
 

--- a/docs/stackit_mongodbflex_user_create.md
+++ b/docs/stackit_mongodbflex_user_create.md
@@ -29,7 +29,7 @@ stackit mongodbflex user create [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user create"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, can be specified multiple times. Possible values are ["read" "readWrite"] (default [])
+      --role strings         Roles of the user, possible values are ["read" "readWrite"] (default [read])
       --username string      Username of the user. If not specified, a random username will be assigned
 ```
 

--- a/docs/stackit_mongodbflex_user_update.md
+++ b/docs/stackit_mongodbflex_user_update.md
@@ -23,7 +23,7 @@ stackit mongodbflex user update USER_ID [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user update"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, can be specified multiple times. Possible values are ["read" "readWrite"] (default [])
+      --role strings         Roles of the user, possible values are ["read" "readWrite"] (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_mongodbflex_user_update.md
+++ b/docs/stackit_mongodbflex_user_update.md
@@ -14,7 +14,7 @@ stackit mongodbflex user update USER_ID [flags]
 
 ```
   Update the roles of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"
-  $ stackit mongodbflex user update xxx --instance-id yyy --roles read
+  $ stackit mongodbflex user update xxx --instance-id yyy --role read
 ```
 
 ### Options
@@ -23,7 +23,7 @@ stackit mongodbflex user update USER_ID [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user update"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["read" "readWrite"] (default [])
+      --role strings         Roles of the user, can be specified multiple times. Possible values are ["read" "readWrite"] (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_postgresflex_user_create.md
+++ b/docs/stackit_postgresflex_user_create.md
@@ -28,8 +28,8 @@ stackit postgresflex user create [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user create"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["read" "readWrite"] (default [read])
-      --username string      Username of the user. If not specified, a random username will be assigned
+      --roles strings        Roles of the user, possible values are ["login" "createdb"] (default [login])
+      --username string      Username of the user
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_postgresflex_user_create.md
+++ b/docs/stackit_postgresflex_user_create.md
@@ -16,11 +16,11 @@ stackit postgresflex user create [flags]
 ### Examples
 
 ```
-  Create a PostgreSQL Flex user for instance with ID "xxx" and specify the username
-  $ stackit postgresflex user create --instance-id xxx --username johndoe --roles read
+  Create a PostgreSQL Flex user for instance with ID "xxx"
+  $ stackit postgresflex user create --instance-id xxx --username johndoe
 
-  Create a PostgreSQL Flex user for instance with ID "xxx" with an automatically generated username
-  $ stackit postgresflex user create --instance-id xxx --roles read
+  Create a PostgreSQL Flex user for instance with ID "xxx" and permission "createdb"
+  $ stackit postgresflex user create --instance-id xxx --username johndoe --role createdb
 ```
 
 ### Options
@@ -28,7 +28,7 @@ stackit postgresflex user create [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user create"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["login" "createdb"] (default [login])
+      --role strings         Roles of the user, can be specified multiple times. Possible values are ["login" "createdb"] (default [])
       --username string      Username of the user
 ```
 

--- a/docs/stackit_postgresflex_user_create.md
+++ b/docs/stackit_postgresflex_user_create.md
@@ -28,7 +28,7 @@ stackit postgresflex user create [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user create"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, can be specified multiple times. Possible values are ["login" "createdb"] (default [])
+      --role strings         Roles of the user, possible values are ["login" "createdb"] (default [login])
       --username string      Username of the user
 ```
 

--- a/docs/stackit_postgresflex_user_update.md
+++ b/docs/stackit_postgresflex_user_update.md
@@ -14,7 +14,7 @@ stackit postgresflex user update USER_ID [flags]
 
 ```
   Update the roles of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy"
-  $ stackit postgresflex user update xxx --instance-id yyy --roles read
+  $ stackit postgresflex user update xxx --instance-id yyy --role login
 ```
 
 ### Options
@@ -22,7 +22,7 @@ stackit postgresflex user update USER_ID [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user update"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["login" "createdb"] (default [])
+      --role strings         Roles of the user, can be specified multiple times. Possible values are ["login" "createdb"] (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_postgresflex_user_update.md
+++ b/docs/stackit_postgresflex_user_update.md
@@ -22,7 +22,7 @@ stackit postgresflex user update USER_ID [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user update"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, can be specified multiple times. Possible values are ["login" "createdb"] (default [])
+      --role strings         Roles of the user, possible values are ["login" "createdb"] (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_postgresflex_user_update.md
+++ b/docs/stackit_postgresflex_user_update.md
@@ -22,7 +22,7 @@ stackit postgresflex user update USER_ID [flags]
 ```
   -h, --help                 Help for "stackit postgresflex user update"
       --instance-id string   ID of the instance
-      --roles strings        Roles of the user, possible values are ["read" "readWrite"] (default [])
+      --roles strings        Roles of the user, possible values are ["login" "createdb"] (default [])
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -113,7 +113,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, databaseFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -113,7 +113,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, databaseFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -21,7 +21,7 @@ const (
 	instanceIdFlag = "instance-id"
 	usernameFlag   = "username"
 	databaseFlag   = "database"
-	rolesFlag      = "roles"
+	roleFlag       = "role"
 )
 
 var (
@@ -50,10 +50,10 @@ func NewCmd() *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`Create a MongoDB Flex user for instance with ID "xxx" and specify the username`,
-				"$ stackit mongodbflex user create --instance-id xxx --username johndoe --roles read --database default"),
+				"$ stackit mongodbflex user create --instance-id xxx --username johndoe --role read --database default"),
 			examples.NewExample(
 				`Create a MongoDB Flex user for instance with ID "xxx" with an automatically generated username`,
-				"$ stackit mongodbflex user create --instance-id xxx --roles read --database default"),
+				"$ stackit mongodbflex user create --instance-id xxx --role read --database default"),
 		),
 		Args: args.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -108,12 +108,12 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"read", "readWrite"}
+	roleOptions := []string{"read", "readWrite"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, databaseFlag)
 	cobra.CheckErr(err)
@@ -130,7 +130,7 @@ func parseInput(cmd *cobra.Command) (*inputModel, error) {
 		InstanceId:      flags.FlagToStringValue(cmd, instanceIdFlag),
 		Username:        flags.FlagToStringPointer(cmd, usernameFlag),
 		Database:        flags.FlagToStringPointer(cmd, databaseFlag),
-		Roles:           flags.FlagWithDefaultToStringSlicePointer(cmd, rolesFlag),
+		Roles:           flags.FlagWithDefaultToStringSlicePointer(cmd, roleFlag),
 	}, nil
 }
 

--- a/internal/cmd/mongodbflex/user/create/create_test.go
+++ b/internal/cmd/mongodbflex/user/create/create_test.go
@@ -29,7 +29,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		instanceIdFlag: testInstanceId,
 		usernameFlag:   "johndoe",
 		databaseFlag:   "default",
-		rolesFlag:      "read",
+		roleFlag:       "read",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -141,7 +141,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "roles missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, rolesFlag)
+				delete(flagValues, roleFlag)
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
@@ -151,7 +151,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "invalid role",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[rolesFlag] = "invalid-role"
+				flagValues[roleFlag] = "invalid-role"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -98,7 +98,7 @@ func configureFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -23,7 +23,7 @@ const (
 
 	instanceIdFlag = "instance-id"
 	databaseFlag   = "database"
-	rolesFlag      = "roles"
+	roleFlag       = "role"
 )
 
 type inputModel struct {
@@ -43,7 +43,7 @@ func NewCmd() *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`Update the roles of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"`,
-				"$ stackit mongodbflex user update xxx --instance-id yyy --roles read"),
+				"$ stackit mongodbflex user update xxx --instance-id yyy --role read"),
 		),
 		Args: args.SingleArg(userIdArg, utils.ValidateUUID),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -94,11 +94,11 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"read", "readWrite"}
+	roleOptions := []string{"read", "readWrite"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)
@@ -113,7 +113,7 @@ func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
 	}
 
 	database := flags.FlagToStringPointer(cmd, databaseFlag)
-	roles := flags.FlagToStringSlicePointer(cmd, rolesFlag)
+	roles := flags.FlagToStringSlicePointer(cmd, roleFlag)
 
 	if database == nil && roles == nil {
 		return nil, &errors.EmptyUpdateError{}

--- a/internal/cmd/mongodbflex/user/update/update_test.go
+++ b/internal/cmd/mongodbflex/user/update/update_test.go
@@ -103,7 +103,7 @@ func TestParseInput(t *testing.T) {
 			description: "update roles",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[rolesFlag] = "read"
+				flagValues[roleFlag] = "read"
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
@@ -177,7 +177,7 @@ func TestParseInput(t *testing.T) {
 			description: "invalid role",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[rolesFlag] = "invalid-role"
+				flagValues[roleFlag] = "invalid-role"
 			}),
 			isValid: false,
 		},
@@ -186,7 +186,7 @@ func TestParseInput(t *testing.T) {
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, databaseFlag)
-				delete(flagValues, rolesFlag)
+				delete(flagValues, roleFlag)
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -109,7 +109,7 @@ func configureFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, usernameFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -109,7 +109,7 @@ func configureFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, usernameFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	rolesDefault = []string{"read"}
+	rolesDefault = []string{"login"}
 )
 
 type inputModel struct {
@@ -105,7 +105,7 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"read", "readWrite"}
+	rolesOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -20,7 +20,7 @@ import (
 const (
 	instanceIdFlag = "instance-id"
 	usernameFlag   = "username"
-	rolesFlag      = "roles"
+	roleFlag       = "role"
 )
 
 var (
@@ -47,11 +47,11 @@ func NewCmd() *cobra.Command {
 		),
 		Example: examples.Build(
 			examples.NewExample(
-				`Create a PostgreSQL Flex user for instance with ID "xxx" and specify the username`,
-				"$ stackit postgresflex user create --instance-id xxx --username johndoe --roles read"),
+				`Create a PostgreSQL Flex user for instance with ID "xxx"`,
+				"$ stackit postgresflex user create --instance-id xxx --username johndoe"),
 			examples.NewExample(
-				`Create a PostgreSQL Flex user for instance with ID "xxx" with an automatically generated username`,
-				"$ stackit postgresflex user create --instance-id xxx --roles read"),
+				`Create a PostgreSQL Flex user for instance with ID "xxx" and permission "createdb"`,
+				"$ stackit postgresflex user create --instance-id xxx --username johndoe --role createdb"),
 		),
 		Args: args.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -105,11 +105,11 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"login", "createdb"}
+	roleOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, usernameFlag)
 	cobra.CheckErr(err)
@@ -125,7 +125,7 @@ func parseInput(cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 		InstanceId:      flags.FlagToStringValue(cmd, instanceIdFlag),
 		Username:        flags.FlagToStringPointer(cmd, usernameFlag),
-		Roles:           flags.FlagWithDefaultToStringSlicePointer(cmd, rolesFlag),
+		Roles:           flags.FlagWithDefaultToStringSlicePointer(cmd, roleFlag),
 	}, nil
 }
 

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -108,10 +108,10 @@ func configureFlags(cmd *cobra.Command) {
 	rolesOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
-	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")
+	cmd.Flags().String(usernameFlag, "", "Username of the user")
 	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))
 
-	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
+	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, usernameFlag)
 	cobra.CheckErr(err)
 }
 

--- a/internal/cmd/postgresflex/user/create/create_test.go
+++ b/internal/cmd/postgresflex/user/create/create_test.go
@@ -79,16 +79,6 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "no username specified",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, usernameFlag)
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Username = nil
-			}),
-		},
-		{
 			description: "no values",
 			flagValues:  map[string]string{},
 			isValid:     false,
@@ -125,6 +115,13 @@ func TestParseInput(t *testing.T) {
 			description: "instance id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[instanceIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "username missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, usernameFlag)
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/postgresflex/user/create/create_test.go
+++ b/internal/cmd/postgresflex/user/create/create_test.go
@@ -28,7 +28,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		projectIdFlag:  testProjectId,
 		instanceIdFlag: testInstanceId,
 		usernameFlag:   "johndoe",
-		rolesFlag:      "login",
+		roleFlag:       "login",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -128,7 +128,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "roles missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, rolesFlag)
+				delete(flagValues, roleFlag)
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
@@ -138,7 +138,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "invalid role",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[rolesFlag] = "invalid-role"
+				flagValues[roleFlag] = "invalid-role"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/postgresflex/user/create/create_test.go
+++ b/internal/cmd/postgresflex/user/create/create_test.go
@@ -28,7 +28,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		projectIdFlag:  testProjectId,
 		instanceIdFlag: testInstanceId,
 		usernameFlag:   "johndoe",
-		rolesFlag:      "read",
+		rolesFlag:      "login",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -43,7 +43,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		InstanceId: testInstanceId,
 		Username:   utils.Ptr("johndoe"),
-		Roles:      utils.Ptr([]string{"read"}),
+		Roles:      utils.Ptr([]string{"login"}),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -55,7 +55,7 @@ func fixtureRequest(mods ...func(request *postgresflex.ApiCreateUserRequest)) po
 	request := testClient.CreateUser(testCtx, testProjectId, testInstanceId)
 	request = request.CreateUserPayload(postgresflex.CreateUserPayload{
 		Username: utils.Ptr("johndoe"),
-		Roles:    utils.Ptr([]string{"read"}),
+		Roles:    utils.Ptr([]string{"login"}),
 	})
 
 	for _, mod := range mods {
@@ -211,7 +211,7 @@ func TestBuildRequest(t *testing.T) {
 				model.Username = nil
 			}),
 			expectedRequest: fixtureRequest().CreateUserPayload(postgresflex.CreateUserPayload{
-				Roles: utils.Ptr([]string{"read"}),
+				Roles: utils.Ptr([]string{"login"}),
 			}),
 		},
 	}

--- a/internal/cmd/postgresflex/user/delete/delete.go
+++ b/internal/cmd/postgresflex/user/delete/delete.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/client"
 	postgresflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
@@ -45,7 +44,7 @@ func NewCmd() *cobra.Command {
 				`Delete a PostgreSQL Flex user with ID "xxx" for instance with ID "yyy"`,
 				"$ stackit postgresflex user delete xxx --instance-id yyy"),
 		),
-		Args: args.SingleArg(userIdArg, utils.ValidateUUID),
+		Args: args.SingleArg(userIdArg, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			model, err := parseInput(cmd, args)

--- a/internal/cmd/postgresflex/user/delete/delete_test.go
+++ b/internal/cmd/postgresflex/user/delete/delete_test.go
@@ -20,7 +20,7 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &postgresflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testUserId = uuid.NewString()
+var testUserId = "12345"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -147,14 +147,8 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
-			description: "user id invalid 1",
+			description: "user id invalid",
 			argValues:   []string{""},
-			flagValues:  fixtureFlagValues(),
-			isValid:     false,
-		},
-		{
-			description: "user id invalid 2",
-			argValues:   []string{"invalid-uuid"},
 			flagValues:  fixtureFlagValues(),
 			isValid:     false,
 		},

--- a/internal/cmd/postgresflex/user/describe/describe.go
+++ b/internal/cmd/postgresflex/user/describe/describe.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
@@ -48,7 +47,7 @@ func NewCmd() *cobra.Command {
 				`Get details of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy" in table format`,
 				"$ stackit postgresflex user list xxx --instance-id yyy --output-format pretty"),
 		),
-		Args: args.SingleArg(userIdArg, utils.ValidateUUID),
+		Args: args.SingleArg(userIdArg, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			model, err := parseInput(cmd, args)

--- a/internal/cmd/postgresflex/user/describe/describe_test.go
+++ b/internal/cmd/postgresflex/user/describe/describe_test.go
@@ -20,7 +20,7 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &postgresflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testUserId = uuid.NewString()
+var testUserId = "12345"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -147,14 +147,8 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
-			description: "user id invalid 1",
+			description: "user id invalid",
 			argValues:   []string{""},
-			flagValues:  fixtureFlagValues(),
-			isValid:     false,
-		},
-		{
-			description: "user id invalid 2",
-			argValues:   []string{"invalid-uuid"},
 			flagValues:  fixtureFlagValues(),
 			isValid:     false,
 		},

--- a/internal/cmd/postgresflex/user/reset-password/reset_password.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/client"
 	postgresflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
@@ -41,7 +40,7 @@ func NewCmd() *cobra.Command {
 				`Reset the password of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy"`,
 				"$ stackit postgresflex user reset-password xxx --instance-id yyy"),
 		),
-		Args: args.SingleArg(userIdArg, utils.ValidateUUID),
+		Args: args.SingleArg(userIdArg, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			model, err := parseInput(cmd, args)

--- a/internal/cmd/postgresflex/user/reset-password/reset_password_test.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password_test.go
@@ -20,7 +20,7 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &postgresflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testUserId = uuid.NewString()
+var testUserId = "12345"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -147,14 +147,8 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
-			description: "user id invalid 1",
+			description: "user id invalid",
 			argValues:   []string{""},
-			flagValues:  fixtureFlagValues(),
-			isValid:     false,
-		},
-		{
-			description: "user id invalid 2",
-			argValues:   []string{"invalid-uuid"},
 			flagValues:  fixtureFlagValues(),
 			isValid:     false,
 		},

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -21,7 +21,7 @@ const (
 	userIdArg = "USER_ID"
 
 	instanceIdFlag = "instance-id"
-	rolesFlag      = "roles"
+	roleFlag       = "role"
 )
 
 type inputModel struct {
@@ -40,7 +40,7 @@ func NewCmd() *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`Update the roles of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy"`,
-				"$ stackit postgresflex user update xxx --instance-id yyy --roles read"),
+				"$ stackit postgresflex user update xxx --instance-id yyy --role login"),
 		),
 		Args: args.SingleArg(userIdArg, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -91,10 +91,10 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"login", "createdb"}
+	roleOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)
@@ -108,7 +108,7 @@ func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
 		return nil, &errors.ProjectIdError{}
 	}
 
-	roles := flags.FlagToStringSlicePointer(cmd, rolesFlag)
+	roles := flags.FlagToStringSlicePointer(cmd, roleFlag)
 	if roles == nil {
 		return nil, &errors.EmptyUpdateError{}
 	}

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/client"
 	postgresflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/postgresflex/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
@@ -43,7 +42,7 @@ func NewCmd() *cobra.Command {
 				`Update the roles of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy"`,
 				"$ stackit postgresflex user update xxx --instance-id yyy --roles read"),
 		),
-		Args: args.SingleArg(userIdArg, utils.ValidateUUID),
+		Args: args.SingleArg(userIdArg, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			model, err := parseInput(cmd, args)

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -94,7 +94,7 @@ func configureFlags(cmd *cobra.Command) {
 	roleOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, can be specified multiple times. Possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -92,7 +92,7 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	rolesOptions := []string{"read", "readWrite"}
+	rolesOptions := []string{"login", "createdb"}
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, rolesOptions...), rolesFlag, fmt.Sprintf("Roles of the user, possible values are %q", rolesOptions))

--- a/internal/cmd/postgresflex/user/update/update_test.go
+++ b/internal/cmd/postgresflex/user/update/update_test.go
@@ -37,7 +37,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 	flagValues := map[string]string{
 		projectIdFlag:  testProjectId,
 		instanceIdFlag: testInstanceId,
-		rolesFlag:      "login",
+		roleFlag:       "login",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -149,7 +149,7 @@ func TestParseInput(t *testing.T) {
 			description: "invalid role",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[rolesFlag] = "invalid-role"
+				flagValues[roleFlag] = "invalid-role"
 			}),
 			isValid: false,
 		},
@@ -157,7 +157,7 @@ func TestParseInput(t *testing.T) {
 			description: "empty update",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, rolesFlag)
+				delete(flagValues, roleFlag)
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/postgresflex/user/update/update_test.go
+++ b/internal/cmd/postgresflex/user/update/update_test.go
@@ -37,7 +37,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 	flagValues := map[string]string{
 		projectIdFlag:  testProjectId,
 		instanceIdFlag: testInstanceId,
-		rolesFlag:      "read",
+		rolesFlag:      "login",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -52,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		InstanceId: testInstanceId,
 		UserId:     testUserId,
-		Roles:      utils.Ptr([]string{"read"}),
+		Roles:      utils.Ptr([]string{"login"}),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -63,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 func fixtureRequest(mods ...func(request *postgresflex.ApiPartialUpdateUserRequest)) postgresflex.ApiPartialUpdateUserRequest {
 	request := testClient.PartialUpdateUser(testCtx, testProjectId, testInstanceId, testUserId)
 	request = request.PartialUpdateUserPayload(postgresflex.PartialUpdateUserPayload{
-		Roles: utils.Ptr([]string{"read"}),
+		Roles: utils.Ptr([]string{"login"}),
 	})
 	for _, mod := range mods {
 		mod(&request)

--- a/internal/cmd/postgresflex/user/update/update_test.go
+++ b/internal/cmd/postgresflex/user/update/update_test.go
@@ -21,7 +21,7 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &postgresflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testUserId = uuid.NewString()
+var testUserId = "12345"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -140,14 +140,8 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
-			description: "user id invalid 1",
+			description: "user id invalid",
 			argValues:   []string{""},
-			flagValues:  fixtureFlagValues(),
-			isValid:     false,
-		},
-		{
-			description: "user id invalid 2",
-			argValues:   []string{"invalid-uuid"},
 			flagValues:  fixtureFlagValues(),
 			isValid:     false,
 		},

--- a/internal/pkg/args/args.go
+++ b/internal/pkg/args/args.go
@@ -17,13 +17,20 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	}
 }
 
-// SingleArg checks if only one argument was provided and validates it
+// SingleArg checks if only one non-empty argument was provided and validates it
 // using the validate function. It returns an error if none or multiple arguments
 // are provided, or if the argument is invalid.
 // For no validation, you can pass a nil validate function
 func SingleArg(argName string, validate func(value string) error) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
+			return &errors.SingleArgExpectedError{
+				Cmd:      cmd,
+				Expected: argName,
+				Count:    len(args),
+			}
+		}
+		if args[0] == "" {
 			return &errors.SingleArgExpectedError{
 				Cmd:      cmd,
 				Expected: argName,

--- a/internal/pkg/args/args.go
+++ b/internal/pkg/args/args.go
@@ -23,14 +23,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 // For no validation, you can pass a nil validate function
 func SingleArg(argName string, validate func(value string) error) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return &errors.SingleArgExpectedError{
-				Cmd:      cmd,
-				Expected: argName,
-				Count:    len(args),
-			}
-		}
-		if args[0] == "" {
+		if len(args) != 1 || args[0] == "" {
 			return &errors.SingleArgExpectedError{
 				Cmd:      cmd,
 				Expected: argName,

--- a/internal/pkg/args/args_test.go
+++ b/internal/pkg/args/args_test.go
@@ -69,6 +69,11 @@ func TestSingleArg(t *testing.T) {
 			isValid:     false,
 		},
 		{
+			description: "empty_arg",
+			args:        []string{""},
+			isValid:     false,
+		},
+		{
 			description: "invalid_arg",
 			args:        []string{"arg"},
 			validateFunc: func(value string) error {


### PR DESCRIPTION
- Fix roles available
- Make `--username` flag required on creation
- Change `--roles` flag name to `--role`
- Remove incorrect UUID check of user ID
- Add check for args, check if args aren't empty