### PR TITLE
Improvements to `curl` and `ske` commands

### DIFF
--- a/docs/stackit_curl.md
+++ b/docs/stackit_curl.md
@@ -13,17 +13,17 @@ stackit curl URL [flags]
 ### Examples
 
 ```
-  Make a GET request to http://locahost:8000
-  $ stackit curl http://locahost:8000
+  Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones
+  $ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones
 
-  Make a GET request to http://locahost:8000, write complete response (headers and body) to file "./output.txt"
-  $ stackit curl http://locahost:8000 -include --output ./output.txt
+  Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones, write complete response (headers and body) to file "./output.txt"
+  $ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -include --output ./output.txt
 
-  Make a POST request to http://locahost:8000 with payload from file "./payload.json"
-  $ stackit curl http://locahost:8000 -X POST --data @./payload.json
+  Create a new DNS zone for project with ID xxx via POST request to https://dns.api.stackit.cloud/v1/projects/xxx/zones with payload from file "./payload.json"
+  $ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -X POST --data @./payload.json
 
-  Make a POST request to http://locahost:8000 with header "Foo: Bar", fail if server returns error (such as 403 Forbidden)
-  $ stackit curl http://locahost:8000 -X POST -H "Foo: Bar" --fail
+  Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones, with header "Authorization: Bearer yyy", fail if server returns error (such as 403 Forbidden)
+  $ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -X POST -H "Authorization: Bearer yyy" --fail
 ```
 
 ### Options

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -122,7 +122,7 @@ func validateURL(value string) error {
 		return fmt.Errorf("bad url")
 	}
 	if !strings.HasSuffix(urlHost, "stackit.cloud") {
-		return fmt.Errorf("only urls belonging to STACKIT are permitted, e.g. https://dns.api.stackit.cloud/{path}")
+		return fmt.Errorf("only urls belonging to STACKIT are permitted, hostname must end in stackit.cloud")
 	}
 	return nil
 }

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -50,20 +50,20 @@ func NewCmd() *cobra.Command {
 		Long:  "Executes an HTTP request to an endpoint, using the authentication provided by the CLI.",
 		Example: examples.Build(
 			examples.NewExample(
-				"Make a GET request to http://locahost:8000",
-				"$ stackit curl http://locahost:8000",
+				"Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones",
+				"$ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones",
 			),
 			examples.NewExample(
-				`Make a GET request to http://locahost:8000, write complete response (headers and body) to file "./output.txt"`,
-				"$ stackit curl http://locahost:8000 -include --output ./output.txt",
+				`Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones, write complete response (headers and body) to file "./output.txt"`,
+				"$ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -include --output ./output.txt",
 			),
 			examples.NewExample(
-				`Make a POST request to http://locahost:8000 with payload from file "./payload.json"`,
-				`$ stackit curl http://locahost:8000 -X POST --data @./payload.json`,
+				`Create a new DNS zone for project with ID xxx via POST request to https://dns.api.stackit.cloud/v1/projects/xxx/zones with payload from file "./payload.json"`,
+				`$ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -X POST --data @./payload.json`,
 			),
 			examples.NewExample(
-				`Make a POST request to http://locahost:8000 with header "Foo: Bar", fail if server returns error (such as 403 Forbidden)`,
-				`$ stackit curl http://locahost:8000 -X POST -H "Foo: Bar" --fail`,
+				`Get all the DNS zones for project with ID xxx via GET request to https://dns.api.stackit.cloud/v1/projects/xxx/zones, with header "Authorization: Bearer yyy", fail if server returns error (such as 403 Forbidden)`,
+				`$ stackit curl https://dns.api.stackit.cloud/v1/projects/xxx/zones -X POST -H "Authorization: Bearer yyy" --fail`,
 			),
 		),
 		Args: args.SingleArg(urlArg, validateURL),
@@ -122,7 +122,7 @@ func validateURL(value string) error {
 		return fmt.Errorf("bad url")
 	}
 	if !strings.HasSuffix(urlHost, "stackit.cloud") {
-		return fmt.Errorf("only urls belonging to STACKIT are permitted")
+		return fmt.Errorf("only urls belonging to STACKIT are permitted, e.g. https://dns.api.stackit.cloud/{path}")
 	}
 	return nil
 }

--- a/internal/cmd/ske/cluster/update/update.go
+++ b/internal/cmd/ske/cluster/update/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/confirm"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
@@ -65,6 +66,14 @@ func NewCmd() *cobra.Command {
 			apiClient, err := client.ConfigureClient(cmd)
 			if err != nil {
 				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to update cluster %s?", model.ClusterName)
+				err = confirm.PromptForConfirmation(cmd, prompt)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Check if cluster exists


### PR DESCRIPTION
- Improve `curl` examples and error message
- Add prompt for confirmation before `ske cluster update`