### PR TITLE
Auth, organization and service account fixes

### DIFF
--- a/docs/stackit_organization_member_list.md
+++ b/docs/stackit_organization_member_list.md
@@ -14,13 +14,13 @@ stackit organization member list [flags]
 
 ```
   List all members of an organization
-  $ stackit organization role list --organization-id xxx
+  $ stackit organization member list --organization-id xxx
 
   List all members of an organization in JSON format
-  $ stackit organization role list --organization-id xxx --output-format json
+  $ stackit organization member list --organization-id xxx --output-format json
 
   List up to 10 members of an organization
-  $ stackit organization role list --organization-id xxx --limit 10
+  $ stackit organization member list --organization-id xxx --limit 10
 ```
 
 ### Options

--- a/docs/stackit_service-account_token_create.md
+++ b/docs/stackit_service-account_token_create.md
@@ -16,7 +16,7 @@ stackit service-account token create [flags]
 
 ```
   Create an access token for the service account with email "my-service-account-1234567@sa.stackit.cloud" with a default time to live
-  $ stackit service-account token create --sa-email my-service-account-1234567@sa.stackit.cloud
+  $ stackit service-account token create --email my-service-account-1234567@sa.stackit.cloud
 
   Create an access token for the service account with email "my-service-account-1234567@sa.stackit.cloud" with a time to live of 10 days
   $ stackit service-account token create --email my-service-account-1234567@sa.stackit.cloud --ttl-days 10

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -45,13 +45,13 @@ func NewCmd() *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`List all members of an organization`,
-				"$ stackit organization role list --organization-id xxx"),
+				"$ stackit organization member list --organization-id xxx"),
 			examples.NewExample(
 				`List all members of an organization in JSON format`,
-				"$ stackit organization role list --organization-id xxx --output-format json"),
+				"$ stackit organization member list --organization-id xxx --output-format json"),
 			examples.NewExample(
 				`List up to 10 members of an organization`,
-				"$ stackit organization role list --organization-id xxx --limit 10"),
+				"$ stackit organization member list --organization-id xxx --limit 10"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -66,7 +66,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("delete service account: %w", err)
 			}
 
-			cmd.Printf("Service account %s deleted", model.Email)
+			cmd.Printf("Service account %s deleted\n", model.Email)
 			return nil
 		},
 	}

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -86,7 +86,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			cmd.PrintErrf("Created key for service account %s\n", model.ServiceAccountEmail)
+			cmd.PrintErrf("Created key for service account %s with id %s\n", model.ServiceAccountEmail, *resp.Id)
 
 			key, err := json.MarshalIndent(resp, "", "  ")
 			if err != nil {

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -43,7 +43,7 @@ func NewCmd() *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`Create an access token for the service account with email "my-service-account-1234567@sa.stackit.cloud" with a default time to live`,
-				"$ stackit service-account token create --sa-email my-service-account-1234567@sa.stackit.cloud"),
+				"$ stackit service-account token create --email my-service-account-1234567@sa.stackit.cloud"),
 			examples.NewExample(
 				`Create an access token for the service account with email "my-service-account-1234567@sa.stackit.cloud" with a time to live of 10 days`,
 				"$ stackit service-account token create --email my-service-account-1234567@sa.stackit.cloud --ttl-days 10"),


### PR DESCRIPTION
`auth`
- add user-friendly message to failed because of invalid storage key

`organization`
- fix examples

`service-account`
- fix example
- fix messages