### PR TITLE
Change flag behavior in "dns zone list"

### DIFF
--- a/docs/stackit_dns_zone_list.md
+++ b/docs/stackit_dns_zone_list.md
@@ -30,9 +30,9 @@ stackit dns zone list [flags]
 
 ```
       --active                 Filter for active zones
-      --deleted                Filter for deleted zones
   -h, --help                   Help for "stackit dns zone list"
-      --inactive               Filter for inactive zones. Deleted zones are always inactive and will be included when this flag is set
+      --inactive               Filter for inactive zones
+      --include-deleted        Includes successfully deleted zones (if unset, these are filtered out)
       --limit int              Maximum number of entries to list
       --name-like string       Filter by name
       --order-by-name string   Order by name, one of ["asc" "desc"]

--- a/docs/stackit_dns_zone_list.md
+++ b/docs/stackit_dns_zone_list.md
@@ -22,7 +22,7 @@ stackit dns zone list [flags]
   List up to 10 DNS zones
   $ stackit dns zone list --limit 10
 
-  List the deleted DNS zones
+  List DNS zones, including deleted
   $ stackit dns zone list --deleted
 ```
 

--- a/docs/stackit_dns_zone_list.md
+++ b/docs/stackit_dns_zone_list.md
@@ -23,7 +23,7 @@ stackit dns zone list [flags]
   $ stackit dns zone list --limit 10
 
   List DNS zones, including deleted
-  $ stackit dns zone list --deleted
+  $ stackit dns zone list --include-deleted
 ```
 
 ### Options

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -62,7 +62,7 @@ func NewCmd() *cobra.Command {
 				"$ stackit dns zone list --limit 10"),
 			examples.NewExample(
 				`List DNS zones, including deleted`,
-				"$ stackit dns zone list --deleted"),
+				"$ stackit dns zone list --include-deleted"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -61,7 +61,7 @@ func NewCmd() *cobra.Command {
 				`List up to 10 DNS zones`,
 				"$ stackit dns zone list --limit 10"),
 			examples.NewExample(
-				`List the deleted DNS zones`,
+				`List DNS zones, including deleted`,
 				"$ stackit dns zone list --deleted"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -20,13 +20,13 @@ import (
 )
 
 const (
-	activeFlag      = "active"
-	inactiveFlag    = "inactive"
-	deletedFlag     = "deleted"
-	nameLikeFlag    = "name-like"
-	orderByNameFlag = "order-by-name"
-	limitFlag       = "limit"
-	pageSizeFlag    = "page-size"
+	activeFlag         = "active"
+	inactiveFlag       = "inactive"
+	nameLikeFlag       = "name-like"
+	orderByNameFlag    = "order-by-name"
+	includeDeletedFlag = "include-deleted"
+	limitFlag          = "limit"
+	pageSizeFlag       = "page-size"
 
 	pageSizeDefault      = 100
 	deleteSucceededState = "DELETE_SUCCEEDED"
@@ -35,13 +35,13 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 
-	Active      bool
-	Inactive    bool
-	Deleted     bool
-	NameLike    *string
-	OrderByName *string
-	Limit       *int64
-	PageSize    int64
+	Active         bool
+	Inactive       bool
+	NameLike       *string
+	OrderByName    *string
+	IncludeDeleted bool
+	Limit          *int64
+	PageSize       int64
 }
 
 func NewCmd() *cobra.Command {
@@ -102,10 +102,10 @@ func configureFlags(cmd *cobra.Command) {
 	orderByNameFlagOptions := []string{"asc", "desc"}
 
 	cmd.Flags().Bool(activeFlag, false, "Filter for active zones")
-	cmd.Flags().Bool(inactiveFlag, false, "Filter for inactive zones. Deleted zones are always inactive and will be included when this flag is set")
-	cmd.Flags().Bool(deletedFlag, false, "Filter for deleted zones")
+	cmd.Flags().Bool(inactiveFlag, false, "Filter for inactive zones")
 	cmd.Flags().String(nameLikeFlag, "", "Filter by name")
 	cmd.Flags().Var(flags.EnumFlag(true, "", orderByNameFlagOptions...), orderByNameFlag, fmt.Sprintf("Order by name, one of %q", orderByNameFlagOptions))
+	cmd.Flags().Bool(includeDeletedFlag, false, "Includes successfully deleted zones (if unset, these are filtered out)")
 	cmd.Flags().Int64(limitFlag, 0, "Maximum number of entries to list")
 	cmd.Flags().Int64(pageSizeFlag, pageSizeDefault, "Number of items fetched in each API call. Does not affect the number of items in the command output")
 }
@@ -142,7 +142,7 @@ func parseInput(cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 		Active:          active,
 		Inactive:        inactive,
-		Deleted:         flags.FlagToBoolValue(cmd, deletedFlag),
+		IncludeDeleted:  flags.FlagToBoolValue(cmd, includeDeletedFlag),
 		NameLike:        flags.FlagToStringPointer(cmd, nameLikeFlag),
 		OrderByName:     flags.FlagToStringPointer(cmd, orderByNameFlag),
 		Limit:           limit,
@@ -158,16 +158,14 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient dnsClient, p
 	if model.Inactive {
 		req = req.ActiveEq(false)
 	}
-	if model.Deleted {
-		req = req.StateEq(deleteSucceededState)
-	} else if !model.Inactive {
-		req = req.StateNeq(deleteSucceededState)
-	}
 	if model.NameLike != nil {
 		req = req.NameLike(*model.NameLike)
 	}
 	if model.OrderByName != nil {
 		req = req.OrderByName(strings.ToUpper(*model.OrderByName))
+	}
+	if !model.IncludeDeleted {
+		req = req.StateNeq(deleteSucceededState)
 	}
 	req = req.PageSize(int32(model.PageSize))
 	req = req.Page(int32(page))

--- a/internal/cmd/dns/zone/list/list_test.go
+++ b/internal/cmd/dns/zone/list/list_test.go
@@ -78,13 +78,13 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "deleted zones",
+			description: "include deleted zones",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[deletedFlag] = "true"
+				flagValues[includeDeletedFlag] = "true"
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Deleted = true
+				model.IncludeDeleted = true
 			}),
 		},
 		{
@@ -269,12 +269,12 @@ func TestBuildRequest(t *testing.T) {
 			expectedRequest: fixtureRequest().StateNeq(deleteSucceededState).Page(10),
 		},
 		{
-			description: "deleted zones",
+			description: "include deleted zones",
 			model: fixtureInputModel(func(model *inputModel) {
-				model.Deleted = true
+				model.IncludeDeleted = true
 			}),
 			page:            1,
-			expectedRequest: fixtureRequest().StateEq(deleteSucceededState).Page(1),
+			expectedRequest: fixtureRequest().Page(1),
 		},
 		{
 			description: "active zones",
@@ -290,7 +290,7 @@ func TestBuildRequest(t *testing.T) {
 				model.Inactive = true
 			}),
 			page:            1,
-			expectedRequest: fixtureRequest().ActiveEq(false).Page(1),
+			expectedRequest: fixtureRequest().ActiveEq(false).StateNeq(deleteSucceededState).Page(1),
 		},
 		{
 			description: "required fields only",


### PR DESCRIPTION
- Flag `--deleted` (if set, would show deleted zones only; if unset, would show non-deleted zones only) replaced by `--include-deleted` (if set, shows all zones; if unset, shows non-deleted zones only)
- Remove flag `--inactive` showing deleted zones when `--deleted` isn't set