### PR TITLE
Misc fixes to database commands

### DIFF
--- a/docs/stackit_logme_credentials_describe.md
+++ b/docs/stackit_logme_credentials_describe.md
@@ -13,10 +13,10 @@ stackit logme credentials describe CREDENTIALS_ID [flags]
 ### Examples
 
 ```
-  Get details of credentials of a LogMe instance with ID "xxx" from instance with ID "yyy"
+  Get details of credentials with ID "xxx" from instance with ID "yyy"
   $ stackit logme credentials describe xxx --instance-id yyy
 
-  Get details of credentials of a LogMe instance with ID "xxx" from instance with ID "yyy" in a table format
+  Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format
   $ stackit logme credentials describe xxx --instance-id yyy --output-format pretty
 ```
 

--- a/docs/stackit_mariadb_credentials_describe.md
+++ b/docs/stackit_mariadb_credentials_describe.md
@@ -13,10 +13,10 @@ stackit mariadb credentials describe CREDENTIALS_ID [flags]
 ### Examples
 
 ```
-  Get details of credentials of a MariaDB instance with ID "xxx" from instance with ID "yyy"
+  Get details of credentials with ID "xxx" from instance with ID "yyy"
   $ stackit mariadb credentials describe xxx --instance-id yyy
 
-  Get details of credentials of a MariaDB instance with ID "xxx" from instance with ID "yyy" in a table format
+  Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format
   $ stackit mariadb credentials describe xxx --instance-id yyy --output-format pretty
 ```
 

--- a/docs/stackit_mongodbflex_user_reset-password.md
+++ b/docs/stackit_mongodbflex_user_reset-password.md
@@ -4,7 +4,8 @@ Resets the password of a MongoDB Flex user
 
 ### Synopsis
 
-Resets the password of a MongoDB Flex user. The new password is shown in the command's output.
+Resets the password of a MongoDB Flex user.
+sThe new password is visible after and cannot be retrieved later.
 
 ```
 stackit mongodbflex user reset-password USER_ID [flags]

--- a/docs/stackit_opensearch_credentials_describe.md
+++ b/docs/stackit_opensearch_credentials_describe.md
@@ -13,10 +13,10 @@ stackit opensearch credentials describe CREDENTIALS_ID [flags]
 ### Examples
 
 ```
-  Get details of credentials of an OpenSearch instance with ID "xxx" from instance with ID "yyy"
+  Get details of credentials with ID "xxx" from instance with ID "yyy"
   $ stackit opensearch credentials describe xxx --instance-id yyy
 
-  Get details of credentials of an OpenSearch instance with ID "xxx" from instance with ID "yyy" in a table format
+  Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format
   $ stackit opensearch credentials describe xxx --instance-id yyy --output-format pretty
 ```
 

--- a/docs/stackit_postgresflex_user_reset-password.md
+++ b/docs/stackit_postgresflex_user_reset-password.md
@@ -4,7 +4,8 @@ Resets the password of a PostgreSQL Flex user
 
 ### Synopsis
 
-Resets the password of a PostgreSQL Flex user. The new password is returned in the response.
+Resets the password of a PostgreSQL Flex user.
+sThe new password is visible after and cannot be retrieved later.
 
 ```
 stackit postgresflex user reset-password USER_ID [flags]

--- a/docs/stackit_rabbitmq_credentials_describe.md
+++ b/docs/stackit_rabbitmq_credentials_describe.md
@@ -13,10 +13,10 @@ stackit rabbitmq credentials describe CREDENTIALS_ID [flags]
 ### Examples
 
 ```
-  Get details of credentials of an RabbitMQ instance with ID "xxx" from instance with ID "yyy"
+  Get details of credentials with ID "xxx" from instance with ID "yyy"
   $ stackit rabbitmq credentials describe xxx --instance-id yyy
 
-  Get details of credentials of an RabbitMQ instance with ID "xxx" from instance with ID "yyy" in a table format
+  Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format
   $ stackit rabbitmq credentials describe xxx --instance-id yyy --output-format pretty
 ```
 

--- a/docs/stackit_redis_credentials_describe.md
+++ b/docs/stackit_redis_credentials_describe.md
@@ -13,10 +13,10 @@ stackit redis credentials describe CREDENTIALS_ID [flags]
 ### Examples
 
 ```
-  Get details of credentials of a Redis instance with ID "xxx" from instance with ID "yyy"
+  Get details of credentials with ID "xxx" from instance with ID "yyy"
   $ stackit redis credentials describe xxx --instance-id yyy
 
-  Get details of credentials of a Redis instance with ID "xxx" from instance with ID "yyy" in a table format
+  Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format
   $ stackit redis credentials describe xxx --instance-id yyy --output-format pretty
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/zalando/go-keyring v0.2.3
 	golang.org/x/mod v0.15.0
 	golang.org/x/oauth2 v0.17.0
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -56,7 +57,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/sys v0.16.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/internal/cmd/logme/credentials/describe/describe.go
+++ b/internal/cmd/logme/credentials/describe/describe.go
@@ -38,10 +38,10 @@ func NewCmd() *cobra.Command {
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
-				`Get details of credentials of a LogMe instance with ID "xxx" from instance with ID "yyy"`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy"`,
 				"$ stackit logme credentials describe xxx --instance-id yyy"),
 			examples.NewExample(
-				`Get details of credentials of a LogMe instance with ID "xxx" from instance with ID "yyy" in a table format`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format`,
 				"$ stackit logme credentials describe xxx --instance-id yyy --output-format pretty"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -38,10 +38,10 @@ func NewCmd() *cobra.Command {
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
-				`Get details of credentials of a MariaDB instance with ID "xxx" from instance with ID "yyy"`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy"`,
 				"$ stackit mariadb credentials describe xxx --instance-id yyy"),
 			examples.NewExample(
-				`Get details of credentials of a MariaDB instance with ID "xxx" from instance with ID "yyy" in a table format`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format`,
 				"$ stackit mariadb credentials describe xxx --instance-id yyy --output-format pretty"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -86,7 +86,7 @@ func NewCmd() *cobra.Command {
 			}
 
 			if !model.AssumeYes {
-				prompt := fmt.Sprintf("Are you sure you want to update instance %s?", instanceLabel)
+				prompt := fmt.Sprintf("Are you sure you want to update instance %s? (This may cause downtime)", instanceLabel)
 				err = confirm.PromptForConfirmation(cmd, prompt)
 				if err != nil {
 					return err

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -35,7 +35,10 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("reset-password %s", userIdArg),
 		Short: "Resets the password of a MongoDB Flex user",
-		Long:  "Resets the password of a MongoDB Flex user. The new password is shown in the command's output.",
+		Long: fmt.Sprintf("%s\ns%s",
+			"Resets the password of a MongoDB Flex user.",
+			"The new password is visible after and cannot be retrieved later.",
+		),
 		Example: examples.Build(
 			examples.NewExample(
 				`Reset the password of a MongoDB Flex user with ID "xxx" of instance with ID "yyy"`,

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -38,10 +38,10 @@ func NewCmd() *cobra.Command {
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
-				`Get details of credentials of an OpenSearch instance with ID "xxx" from instance with ID "yyy"`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy"`,
 				"$ stackit opensearch credentials describe xxx --instance-id yyy"),
 			examples.NewExample(
-				`Get details of credentials of an OpenSearch instance with ID "xxx" from instance with ID "yyy" in a table format`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format`,
 				"$ stackit opensearch credentials describe xxx --instance-id yyy --output-format pretty"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -126,11 +128,12 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []postgresf
 
 		return nil
 	default:
+		caser := cases.Title(language.English)
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS")
 		for i := range instances {
 			instance := instances[i]
-			table.AddRow(*instance.Id, *instance.Name, *instance.Status)
+			table.AddRow(*instance.Id, *instance.Name, caser.String(*instance.Status))
 		}
 		err := table.Display(cmd)
 		if err != nil {

--- a/internal/cmd/postgresflex/instance/update/update.go
+++ b/internal/cmd/postgresflex/instance/update/update.go
@@ -86,7 +86,7 @@ func NewCmd() *cobra.Command {
 			}
 
 			if !model.AssumeYes {
-				prompt := fmt.Sprintf("Are you sure you want to update instance %s?", instanceLabel)
+				prompt := fmt.Sprintf("Are you sure you want to update instance %s? (This may cause downtime)", instanceLabel)
 				err = confirm.PromptForConfirmation(cmd, prompt)
 				if err != nil {
 					return err

--- a/internal/cmd/postgresflex/user/reset-password/reset_password.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password.go
@@ -34,7 +34,10 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("reset-password %s", userIdArg),
 		Short: "Resets the password of a PostgreSQL Flex user",
-		Long:  "Resets the password of a PostgreSQL Flex user. The new password is returned in the response.",
+		Long: fmt.Sprintf("%s\ns%s",
+			"Resets the password of a PostgreSQL Flex user.",
+			"The new password is visible after and cannot be retrieved later.",
+		),
 		Example: examples.Build(
 			examples.NewExample(
 				`Reset the password of a PostgreSQL Flex user with ID "xxx" of instance with ID "yyy"`,

--- a/internal/cmd/rabbitmq/credentials/describe/describe.go
+++ b/internal/cmd/rabbitmq/credentials/describe/describe.go
@@ -38,10 +38,10 @@ func NewCmd() *cobra.Command {
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
-				`Get details of credentials of an RabbitMQ instance with ID "xxx" from instance with ID "yyy"`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy"`,
 				"$ stackit rabbitmq credentials describe xxx --instance-id yyy"),
 			examples.NewExample(
-				`Get details of credentials of an RabbitMQ instance with ID "xxx" from instance with ID "yyy" in a table format`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format`,
 				"$ stackit rabbitmq credentials describe xxx --instance-id yyy --output-format pretty"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/redis/credentials/describe/describe.go
+++ b/internal/cmd/redis/credentials/describe/describe.go
@@ -38,10 +38,10 @@ func NewCmd() *cobra.Command {
 		Args:  args.SingleArg(credentialsIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
-				`Get details of credentials of a Redis instance with ID "xxx" from instance with ID "yyy"`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy"`,
 				"$ stackit redis credentials describe xxx --instance-id yyy"),
 			examples.NewExample(
-				`Get details of credentials of a Redis instance with ID "xxx" from instance with ID "yyy" in a table format`,
+				`Get details of credentials with ID "xxx" from instance with ID "yyy" in a table format`,
 				"$ stackit redis credentials describe xxx --instance-id yyy --output-format pretty"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
- Add hint to `postgresflex/mongodbflex instance update` confirmation prompt that instance might be down
- Add note on usages of `postgresflex/mongodbflex user reset-password` saying password cannot be retrieved later
- Capitalize instance state on `postgresflex instance list` pretty output
- Fix examples descriptions for `logme/mariadb/opensearch/rabbitmq/redis credentials describe`