### PR TITLE
Skip pre release uploads to homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,8 +87,7 @@ brews:
     license: "Apache-2.0"
     # If set to auto, the release will not be uploaded to the homebrew tap repo
     # if the tag has a prerelease indicator (e.g. v0.0.1-alpha1)
-    # Not setting it for now so we can publish prerelease tags
-    # skip_upload: auto
+    skip_upload: auto
 
 snapcrafts:
   # IDs of the builds for which to create packages for


### PR DESCRIPTION
Go releaser has been updated to prevent the pre release uploads to Homebrew. 