### PR TITLE
auth: login: use next free port

### DIFF
--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -41,7 +41,10 @@ func AuthorizeUser() error {
 	if err != nil {
 		return fmt.Errorf("bind port for login redirect: %w", err)
 	}
-	port := listener.Addr().(*net.TCPAddr).Port
+	port, ok := listener.Addr().(*net.TCPAddr).Port
+        if !ok {
+		return fmt.Errorf("assert listener address type to TCP address")
+	}
 	redirectURL := fmt.Sprintf("http://localhost:%d", port)
 
 	conf := &oauth2.Config{

--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -41,11 +41,11 @@ func AuthorizeUser() error {
 	if err != nil {
 		return fmt.Errorf("bind port for login redirect: %w", err)
 	}
-	port, ok := listener.Addr().(*net.TCPAddr).Port
-        if !ok {
+	address, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
 		return fmt.Errorf("assert listener address type to TCP address")
 	}
-	redirectURL := fmt.Sprintf("http://localhost:%d", port)
+	redirectURL := fmt.Sprintf("http://localhost:%d", address.Port)
 
 	conf := &oauth2.Config{
 		ClientID: clientId,


### PR DESCRIPTION
fixes #80.

This PR tries to address the issue of a fixed redirect port by choosing a random free one.

- [x] Use listener on next free port
- [x] While being complete codewise, the oauth config does not work: When using a different port than 8000, the login results in an error: `Invalid redirect http://localhost:40235 did not match one of the registered values`. This needs to be fixed by maintainers first.

Screenshot:

![image](https://github.com/stackitcloud/stackit-cli/assets/10872874/d72fdcb4-de32-4df7-93be-a18dd3486165)
