### PR TITLE
Fixes to publishing of DEB packages to APT repo

### DIFF
--- a/.aptly.conf
+++ b/.aptly.conf
@@ -1,5 +1,4 @@
 {
-  "rootDir": "./.aptly",
   "downloadConcurrency": 4,
   "downloadSpeedLimit": 0,
   "downloadRetries": 0,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI Workflow
+name: CI
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 # STACKIT CLI release workflow.
 name: Release
 
-# This GitHub action creates a release when a tag that matches the pattern
-# "v*" (e.g. v0.1.0) is created.
+# This GitHub action creates a release when a tag that matches one of the patterns below
+# E.g. v0.1.0, v0.1.0-something.1, etc 
 on:
   push:
     tags:
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   goreleaser:
+    name: Release
     runs-on: macOS-latest
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
@@ -71,5 +72,5 @@ jobs:
         if: contains(github.ref_name, '-') == false
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          GPG_PRIVATE_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
+          GPG_PRIVATE_KEY_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         run: ./scripts/publish-apt-packages.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,6 +60,7 @@ nfpms:
     # IDs of the builds for which to create packages for
     builds:
       - linux-builds
+    package_name: stackit
     vendor: STACKIT
     homepage: https://github.com/stackitcloud/stackit-cli
     maintainer: STACKIT <sit-stackit-developer-tools@mail.schwarz>

--- a/scripts/publish-apt-packages.sh
+++ b/scripts/publish-apt-packages.sh
@@ -10,19 +10,24 @@ OBJECT_STORAGE_ENDPOINT="https://object.storage.eu01.onstackit.cloud"
 APT_BUCKET_NAME="stackit-cli-apt"
 PUBLIC_KEY_BUCKET_NAME="stackit-public-key"
 PUBLIC_KEY_FILE="key.gpg"
-CUSTOM_KEYRING="custom-keyring"
+CUSTOM_KEYRING_FILE="aptly-keyring.gpg"
+DISTRIBUTION="stackit"
 APTLY_CONFIG_FILE_PATH="./.aptly.conf"
 GORELEASER_PACKAGES_FOLDER="dist/"
+
+# We need to disable the key database daemon (keyboxd)
+# This can be done by removing "use-keyboxd" from ~/.gnupg/common.conf (see https://github.com/gpg/gnupg/blob/master/README)
+echo -n >~/.gnupg/common.conf
 
 # Create a local mirror of the current state of the remote APT repository
 printf ">>> Creating mirror \n"
 curl ${OBJECT_STORAGE_ENDPOINT}/${PUBLIC_KEY_BUCKET_NAME}/${PUBLIC_KEY_FILE} >public.asc
-gpg --no-default-keyring --keyring ./${CUSTOM_KEYRING}.gpg --import public.asc
-aptly mirror create -keyring="${CUSTOM_KEYRING}.gpg" current "${OBJECT_STORAGE_ENDPOINT}/${APT_BUCKET_NAME}" stackit
+gpg --no-default-keyring --keyring=${CUSTOM_KEYRING_FILE} --import public.asc
+aptly mirror create -config "${APTLY_CONFIG_FILE_PATH}" -keyring="${CUSTOM_KEYRING_FILE}" current "${OBJECT_STORAGE_ENDPOINT}/${APT_BUCKET_NAME}" ${DISTRIBUTION}
 
 # Update the mirror to the latest state
 printf "\n>>> Updating mirror \n"
-aptly mirror update current
+aptly mirror update -keyring="${CUSTOM_KEYRING_FILE}" current
 
 # Create a snapshot of the mirror
 printf "\n>>> Creating snapshop from mirror \n"
@@ -30,7 +35,7 @@ aptly snapshot create current-snapshot from mirror current
 
 # Create a new fresh local APT repo
 printf "\n>>> Creating fresh local repo \n"
-aptly repo create -distribution="stackit-cli" new-repo
+aptly repo create -distribution="${DISTRIBUTION}" new-repo
 
 # Add new generated .deb packages to the new local repo
 printf "\n>>> Adding new packages to local repo \n"
@@ -42,8 +47,8 @@ aptly snapshot create new-snapshot from repo new-repo
 
 # Merge new-snapshot into current-snapshot creating a new snapshot updated-snapshot
 printf "\n>>> Merging snapshots \n"
-aptly snapshot pull -no-remove -architectures="amd64,i386,arm64" current-snapshot new-snapshot updated-snapshot stackit
+aptly snapshot pull -no-remove -architectures="amd64,i386,arm64" current-snapshot new-snapshot updated-snapshot ${DISTRIBUTION}
 
 # Publish the new snapshot to the remote repo
 printf "\n>>> Publishing updated snapshot \n"
-aptly publish switch -gpg-key="${GPG_PRIVATE_KEY_ID}" -passphrase "${GPG_PASSPHRASE}" -config "${APTLY_CONFIG_FILE_PATH}" stackit "s3:${APT_BUCKET_NAME}:" updated-snapshot
+aptly publish snapshot -keyring="${CUSTOM_KEYRING_FILE}" -gpg-key="${GPG_PRIVATE_KEY_FINGERPRINT}" -passphrase "${GPG_PASSPHRASE}" -config "${APTLY_CONFIG_FILE_PATH}" updated-snapshot "s3:${APT_BUCKET_NAME}:"


### PR DESCRIPTION
- Give GPG key fingerprint instead of key ID to Aptly for the signing of the release
  - Even though Aptly specifies in the [docs](https://www.aptly.info/doc/aptly/publish/snapshot/) that `gpg-key` expects a key ID, it actually expects a key fingerprint
- Disable the [key database daemon](https://github.com/gpg/gnupg/blob/master/README) (`keyboxd`):
  - Since version 2.3.0 of `gnupg` all imported keys are stored in a SQLite database instead of using the specified keyring, and we need to import the key to a custom keyring to use them with Aptly
- Rename Linux package name to `stackit`
- Make APT distribution name consistent across all steps of the script
- Removes `rootDir` from custom Aptly config file (as defaults to the default value)
- Improve comment and job name of workflow