### PR TITLE
Allow specifying empty list for CIDRSliceFlag

### DIFF
--- a/internal/pkg/flags/cidrslice.go
+++ b/internal/pkg/flags/cidrslice.go
@@ -24,7 +24,11 @@ func (f *cidrSliceFlag) String() string {
 
 func (f *cidrSliceFlag) Set(value string) error {
 	if value == "" {
-		f.value = []string{}
+		// If it's the first value to be set to the flag, we set it to an empty list
+		// Otherwise, we just ignore an empty value
+		if len(f.value) == 0 {
+			f.value = []string{}
+		}
 		return nil
 	}
 

--- a/internal/pkg/flags/cidrslice.go
+++ b/internal/pkg/flags/cidrslice.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -25,7 +24,8 @@ func (f *cidrSliceFlag) String() string {
 
 func (f *cidrSliceFlag) Set(value string) error {
 	if value == "" {
-		return fmt.Errorf("value cannot be empty")
+		f.value = []string{}
+		return nil
 	}
 
 	cidrs := strings.Split(value, ",")

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -586,7 +586,7 @@ func TestCIDRSliceFlag(t *testing.T) {
 			isValid:     false,
 		},
 		{
-			description:   "invalid empty value",
+			description:   "empty value to specify empty list",
 			value1:        utils.Ptr(""),
 			isValid:       true,
 			expectedValue: []string{},

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -592,6 +592,13 @@ func TestCIDRSliceFlag(t *testing.T) {
 			expectedValue: []string{},
 		},
 		{
+			description:   "valid value and empty value",
+			value1:        utils.Ptr("198.51.100.14/24"),
+			value2:        utils.Ptr(""),
+			isValid:       true,
+			expectedValue: []string{"198.51.100.14/24"},
+		},
+		{
 			description: "invalid empty value in list",
 			value1:      utils.Ptr("198.51.100.14/24,198.51.100.14/32,"),
 			isValid:     false,

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -586,9 +586,10 @@ func TestCIDRSliceFlag(t *testing.T) {
 			isValid:     false,
 		},
 		{
-			description: "invalid empty value",
-			value1:      utils.Ptr(""),
-			isValid:     false,
+			description:   "invalid empty value",
+			value1:        utils.Ptr(""),
+			isValid:       true,
+			expectedValue: []string{},
 		},
 		{
 			description: "invalid empty value in list",


### PR DESCRIPTION
Allow users to specify an empty CIDR slice by setting the flag to `""`.
E.g. `stackit <service> instance update <instance ID> --acl ""` sets the ACLs of the instance to the empty list.

This makes the custom flag `CIDRSliceFlag` have the same behaviour for empty values as the more generic and default `StringSlice` flag type