### PR TITLE
Extend unit tests of updates using CIDRSliceFlag

### DIFF
--- a/internal/cmd/mariadb/instance/update/update_test.go
+++ b/internal/cmd/mariadb/instance/update/update_test.go
@@ -227,6 +227,17 @@ func TestParseInput(t *testing.T) {
 			isValid:     false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, sgwAclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SgwAcl = nil
+			}),
+		},
+		{
 			description:  "repeated acl flags",
 			argValues:    fixtureArgValues(),
 			flagValues:   fixtureFlagValues(),

--- a/internal/cmd/mongodbflex/instance/update/update_test.go
+++ b/internal/cmd/mongodbflex/instance/update/update_test.go
@@ -252,6 +252,17 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureStandardFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, aclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureStandardInputModel(func(model *inputModel) {
+				model.ACL = nil
+			}),
+		},
+		{
 			description: "repeated acl flags",
 			argValues:   fixtureArgValues(),
 			flagValues:  fixtureRequiredFlagValues(),

--- a/internal/cmd/opensearch/instance/update/update_test.go
+++ b/internal/cmd/opensearch/instance/update/update_test.go
@@ -227,6 +227,17 @@ func TestParseInput(t *testing.T) {
 			isValid:     false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, sgwAclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SgwAcl = nil
+			}),
+		},
+		{
 			description:  "repeated acl flags",
 			argValues:    fixtureArgValues(),
 			flagValues:   fixtureFlagValues(),

--- a/internal/cmd/postgresflex/instance/update/update_test.go
+++ b/internal/cmd/postgresflex/instance/update/update_test.go
@@ -252,6 +252,17 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureStandardFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, aclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureStandardInputModel(func(model *inputModel) {
+				model.ACL = nil
+			}),
+		},
+		{
 			description: "repeated acl flags",
 			argValues:   fixtureArgValues(),
 			flagValues:  fixtureRequiredFlagValues(),

--- a/internal/cmd/rabbitmq/instance/update/update_test.go
+++ b/internal/cmd/rabbitmq/instance/update/update_test.go
@@ -227,6 +227,17 @@ func TestParseInput(t *testing.T) {
 			isValid:     false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, sgwAclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SgwAcl = nil
+			}),
+		},
+		{
 			description:  "repeated acl flags",
 			argValues:    fixtureArgValues(),
 			flagValues:   fixtureFlagValues(),

--- a/internal/cmd/redis/instance/update/update_test.go
+++ b/internal/cmd/redis/instance/update/update_test.go
@@ -227,6 +227,17 @@ func TestParseInput(t *testing.T) {
 			isValid:     false,
 		},
 		{
+			description: "no acl flag",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, sgwAclFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SgwAcl = nil
+			}),
+		},
+		{
 			description:  "repeated acl flags",
 			argValues:    fixtureArgValues(),
 			flagValues:   fixtureFlagValues(),


### PR DESCRIPTION
This tests that not specifying an `--acl` flag when updating instances is mapped to a `nil` ACL in the input model, so we don't set the instance ACL to an empty list (this would be achieved by setting `--acl ""`)