### PR TITLE
SKE Credentials Rotation: kubeconfig create command

### DIFF
--- a/docs/stackit_ske.md
+++ b/docs/stackit_ske.md
@@ -33,5 +33,6 @@ stackit ske [flags]
 * [stackit ske describe](./stackit_ske_describe.md)	 - Shows overall details regarding SKE
 * [stackit ske disable](./stackit_ske_disable.md)	 - Disables SKE for a project
 * [stackit ske enable](./stackit_ske_enable.md)	 - Enables SKE for a project
+* [stackit ske kubeconfig](./stackit_ske_kubeconfig.md)	 - Provides functionality for SKE kubeconfig
 * [stackit ske options](./stackit_ske_options.md)	 - Lists SKE provider options
 

--- a/docs/stackit_ske_credentials.md
+++ b/docs/stackit_ske_credentials.md
@@ -28,6 +28,7 @@ stackit ske credentials [flags]
 ### SEE ALSO
 
 * [stackit ske](./stackit_ske.md)	 - Provides functionality for SKE
+* [stackit ske credentials complete-rotation](./stackit_ske_credentials_complete-rotation.md)	 - Completes the rotation of the credentials associated to a SKE cluster
 * [stackit ske credentials describe](./stackit_ske_credentials_describe.md)	 - Shows details of the credentials associated to a SKE cluster
 * [stackit ske credentials rotate](./stackit_ske_credentials_rotate.md)	 - Rotates credentials associated to a SKE cluster
 * [stackit ske credentials start-rotation](./stackit_ske_credentials_start-rotation.md)	 - Starts the rotation of the credentials associated to a SKE cluster

--- a/docs/stackit_ske_credentials_complete-rotation.md
+++ b/docs/stackit_ske_credentials_complete-rotation.md
@@ -1,0 +1,52 @@
+## stackit ske credentials complete-rotation
+
+Completes the rotation of the credentials associated to a SKE cluster
+
+### Synopsis
+
+Completes the rotation of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster.
+To ensure continued access to the Kubernetes cluster, please update your kubeconfig service account to the newly created account.
+This is step 2 of a 2-step process to rotate all SKE cluster credentials. Tasks accomplished in this phase include:
+  - The old certification authority will be dropped from the package.
+  - The old signing key for the service account will be dropped from the bundle.
+
+If you haven't, please start the process by running:
+  $ stackit ske credentials start-rotation my-cluster
+After completing the rotation of credentials, you can generate a new kubeconfig file by running:
+  $ stackit ske kubeconfig create my-cluster
+
+```
+stackit ske credentials complete-rotation CLUSTER_NAME [flags]
+```
+
+### Examples
+
+```
+  Complete the rotation of the credentials associated to the SKE cluster with name "my-cluster"
+  $ stackit ske credentials complete-rotation my-cluster
+
+  Flow of the 2-step process to rotate all SKE cluster credentials, including generating a new kubeconfig file
+  $ stackit ske credentials start-rotation my-cluster
+  $ stackit ske credentials complete-rotation my-cluster
+  $ stackit ske kubeconfig create my-cluster
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit ske credentials complete-rotation"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty"]
+  -p, --project-id string      Project ID
+```
+
+### SEE ALSO
+
+* [stackit ske credentials](./stackit_ske_credentials.md)	 - Provides functionality for SKE credentials
+

--- a/docs/stackit_ske_credentials_start-rotation.md
+++ b/docs/stackit_ske_credentials_start-rotation.md
@@ -4,8 +4,17 @@ Starts the rotation of the credentials associated to a SKE cluster
 
 ### Synopsis
 
-Starts the rotation of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster. This is step 1 of a two-step process. 
-Complete the rotation using the 'stackit ske credentials complete-rotation' command.
+Starts the rotation of the credentials associated to a STACKIT Kubernetes Engine (SKE) cluster.
+This is step 1 of a 2-step process to rotate all SKE cluster credentials. Tasks accomplished in this phase include:
+  - Rolling recreation of all worker nodes
+  - A new Certificate Authority (CA) will be established and incorporated into the existing CA bundle.
+  - A new etcd encryption key is generated and added to the Certificate Authority (CA) bundle.
+  - A new signing key will be generated for the service account and added to the Certificate Authority (CA) bundle.
+  - The kube-apiserver will rewrite all secrets in the cluster, encrypting them with the new encryption key.
+The old CA, encryption key and signing key will be retained until the rotation is completed.
+
+Complete the rotation by running:
+  $ stackit ske credentials complete-rotation my-cluster
 
 ```
 stackit ske credentials start-rotation CLUSTER_NAME [flags]
@@ -16,6 +25,11 @@ stackit ske credentials start-rotation CLUSTER_NAME [flags]
 ```
   Start the rotation of the credentials associated to the SKE cluster with name "my-cluster"
   $ stackit ske credentials start-rotation my-cluster
+
+  Flow of the 2-step process to rotate all SKE cluster credentials, including generating a new kubeconfig file
+  $ stackit ske credentials start-rotation my-cluster
+  $ stackit ske credentials complete-rotation my-cluster
+  $ stackit ske kubeconfig create my-cluster
 ```
 
 ### Options

--- a/docs/stackit_ske_kubeconfig.md
+++ b/docs/stackit_ske_kubeconfig.md
@@ -1,0 +1,32 @@
+## stackit ske kubeconfig
+
+Provides functionality for SKE kubeconfig
+
+### Synopsis
+
+Provides functionality for STACKIT Kubernetes Engine (SKE) kubeconfig.
+
+```
+stackit ske kubeconfig [flags]
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit ske kubeconfig"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty"]
+  -p, --project-id string      Project ID
+```
+
+### SEE ALSO
+
+* [stackit ske](./stackit_ske.md)	 - Provides functionality for SKE
+* [stackit ske kubeconfig create](./stackit_ske_kubeconfig_create.md)	 - Creates a kubeconfig for an SKE cluster
+

--- a/docs/stackit_ske_kubeconfig_create.md
+++ b/docs/stackit_ske_kubeconfig_create.md
@@ -1,0 +1,50 @@
+## stackit ske kubeconfig create
+
+Creates a kubeconfig for an SKE cluster
+
+### Synopsis
+
+Creates a kubeconfig for a STACKIT Kubernetes Engine (SKE) cluster.
+By default the kubeconfig is created in the .kube folder, in the user's home directory. The kubeconfig file will be overwritten if it already exists.
+
+```
+stackit ske kubeconfig create CLUSTER_NAME [flags]
+```
+
+### Examples
+
+```
+  Create a kubeconfig for the SKE cluster with name "my-cluster"
+  $ stackit ske kubeconfig create my-cluster
+
+  Create a kubeconfig for the SKE cluster with name "my-cluster" and set the expiration time to 30 days
+  $ stackit ske kubeconfig create my-cluster --expiration 30d
+
+  Create a kubeconfig for the SKE cluster with name "my-cluster" and set the expiration time to 2 months
+  $ stackit ske kubeconfig create my-cluster --expiration 2M
+
+  Create a kubeconfig for the SKE cluster with name "my-cluster" in a custom location
+  $ stackit ske kubeconfig create my-cluster --location /path/to/config
+```
+
+### Options
+
+```
+  -e, --expiration string   Expiration time for the kubeconfig in seconds(s), minutes(m), hours(h), days(d) or months(M). Example: 30d. By default, expiration time is 1h
+  -h, --help                Help for "stackit ske kubeconfig create"
+      --location string     Folder location to store the kubeconfig file. By default, the kubeconfig is created in the .kube folder, in the user's home directory.
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty"]
+  -p, --project-id string      Project ID
+```
+
+### SEE ALSO
+
+* [stackit ske kubeconfig](./stackit_ske_kubeconfig.md)	 - Provides functionality for SKE kubeconfig
+

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -92,14 +92,14 @@ func NewCmd() *cobra.Command {
 					return fmt.Errorf("could not get user home directory: %w", err)
 				}
 
-				err = os.MkdirAll(fmt.Sprintf("%s/.kube", userHome), 0700)
+				err = os.MkdirAll(fmt.Sprintf("%s/.kube", userHome), 0o700)
 				if err != nil {
 					return fmt.Errorf("could not create kube directory: %w", err)
 				}
 				configPath = utils.Ptr(fmt.Sprintf("%s/.kube", userHome))
 			}
 
-			err = os.WriteFile(fmt.Sprintf("%s/config", *configPath), []byte(*resp.Kubeconfig), 0600)
+			err = os.WriteFile(fmt.Sprintf("%s/config", *configPath), []byte(*resp.Kubeconfig), 0o600)
 			if err != nil {
 				return fmt.Errorf("could not write kubeconfig file: %w", err)
 			}

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -3,6 +3,8 @@ package create
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/confirm"
@@ -11,6 +13,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
@@ -20,11 +23,13 @@ const (
 	clusterNameArg = "CLUSTER_NAME"
 
 	expirationFlag = "expiration"
+	locationFlag   = "location"
 )
 
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	ClusterName    string
+	KubeconfigPath *string
 	ExpirationTime *string
 }
 
@@ -32,12 +37,23 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("create %s", clusterNameArg),
 		Short: "Creates a kubeconfig for an SKE cluster",
-		Long:  "Creates a kubeconfig for a STACKIT Kubernetes Engine (SKE) cluster.",
-		Args:  args.SingleArg(clusterNameArg, nil),
+		Long: fmt.Sprintf("%s\n%s",
+			"Creates a kubeconfig for a STACKIT Kubernetes Engine (SKE) cluster.",
+			"By default the kubeconfig is created in the .kube folder, in the user's home directory. The kubeconfig file will be overwritten if it already exists."),
+		Args: args.SingleArg(clusterNameArg, nil),
 		Example: examples.Build(
 			examples.NewExample(
 				`Create a kubeconfig for the SKE cluster with name "my-cluster"`,
 				"$ stackit ske kubeconfig create my-cluster"),
+			examples.NewExample(
+				`Create a kubeconfig for the SKE cluster with name "my-cluster" and set the expiration time to 30 days`,
+				"$ stackit ske kubeconfig create my-cluster --expiration 30d"),
+			examples.NewExample(
+				`Create a kubeconfig for the SKE cluster with name "my-cluster" and set the expiration time to 2 months`,
+				"$ stackit ske kubeconfig create my-cluster --expiration 2M"),
+			examples.NewExample(
+				`Create a kubeconfig for the SKE cluster with name "my-cluster" in a custom location`,
+				"$ stackit ske kubeconfig create my-cluster --location /path/to/config"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -53,7 +69,7 @@ func NewCmd() *cobra.Command {
 			}
 
 			if !model.AssumeYes {
-				prompt := fmt.Sprintf("Are you sure you want to start the rotation of the credentials for SKE cluster %q?", model.ClusterName)
+				prompt := fmt.Sprintf("Are you sure you want to create a kubeconfig for SKE cluster %q? This will OVERWRITE your current configuration, if it exists.", model.ClusterName)
 				err = confirm.PromptForConfirmation(cmd, prompt)
 				if err != nil {
 					return err
@@ -67,8 +83,28 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("create kubeconfig for SKE cluster: %w", err)
 			}
 
-			// Output kubeconfig to stdout
-			fmt.Println(*resp.Kubeconfig)
+			// Create a config file in $HOME/.kube/config
+			configPath := model.KubeconfigPath
+
+			if configPath == nil {
+				userHome, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("could not get user home directory: %w", err)
+				}
+
+				err = os.MkdirAll(fmt.Sprintf("%s/.kube", userHome), 0700)
+				if err != nil {
+					return fmt.Errorf("could not create kube directory: %w", err)
+				}
+				configPath = utils.Ptr(fmt.Sprintf("%s/.kube", userHome))
+			}
+
+			err = os.WriteFile(fmt.Sprintf("%s/config", *configPath), []byte(*resp.Kubeconfig), 0600)
+			if err != nil {
+				return fmt.Errorf("could not write kubeconfig file: %w", err)
+			}
+
+			fmt.Printf("Created kubeconfig file for cluster %s with expiration date %v.\n", model.ClusterName, *resp.ExpirationTimestamp)
 
 			return nil
 		},
@@ -78,7 +114,8 @@ func NewCmd() *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP(expirationFlag, "e", "", "Expiration time for the kubeconfig")
+	cmd.Flags().StringP(expirationFlag, "e", "", "Expiration time for the kubeconfig in seconds(s), minutes(m), hours(h), days(d) or months(M). Example: 30d. By default, expiration time is 1h")
+	cmd.Flags().String(locationFlag, "", "Folder location to store the kubeconfig file. By default, the kubeconfig is created in the .kube folder, in the user's home directory.")
 }
 
 func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
@@ -89,11 +126,63 @@ func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
 		return nil, &errors.ProjectIdError{}
 	}
 
+	expirationTimeInput := flags.FlagToStringPointer(cmd, expirationFlag)
+	var expirationTime *string
+	if expirationTimeInput != nil {
+		expirationTime = convertToSeconds(*expirationTimeInput)
+		if expirationTime == nil {
+			return nil, fmt.Errorf("invalid expiration time: %s", *expirationTimeInput)
+		}
+	}
+
 	return &inputModel{
 		GlobalFlagModel: globalFlags,
 		ClusterName:     clusterName,
-		ExpirationTime:  flags.FlagToStringPointer(cmd, expirationFlag),
+		KubeconfigPath:  flags.FlagToStringPointer(cmd, locationFlag),
+		ExpirationTime:  expirationTime,
 	}, nil
+}
+
+func convertToSeconds(timeStr string) *string {
+	if len(timeStr) < 2 {
+		return nil
+	}
+
+	unit := timeStr[len(timeStr)-1:]
+	if _, err := strconv.Atoi(unit); err == nil {
+		// If the last character is a digit, assume the whole string is a number of seconds
+		return utils.Ptr(timeStr)
+	}
+
+	valueStr := timeStr[:len(timeStr)-1]
+	value, err := strconv.ParseUint(valueStr, 10, 64)
+	if err != nil {
+		return nil
+	}
+
+	var multiplier uint64
+	switch unit {
+	// second
+	case "s":
+		multiplier = 1
+	// minute
+	case "m":
+		multiplier = 60
+	// hour
+	case "h":
+		multiplier = 60 * 60
+	// day
+	case "d":
+		multiplier = 60 * 60 * 24
+	// month, assume 30 days
+	case "M":
+		multiplier = 60 * 60 * 24 * 30
+	default:
+		return nil
+	}
+
+	result := uint64(value) * multiplier
+	return utils.Ptr(strconv.FormatUint(result, 10))
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClient) ske.ApiCreateKubeconfigRequest {

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -89,20 +89,22 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("no kubeconfig returned from the API")
 			}
 
+			var kubeconfigPath string
 			if model.Location == nil {
-				kubeconfigPath, err := skeUtils.GetDefaultKubeconfigLocation()
+				kubeconfigPath, err = skeUtils.GetDefaultKubeconfigLocation()
 				if err != nil {
 					return fmt.Errorf("get default kubeconfig location: %w", err)
 				}
-				model.Location = &kubeconfigPath
+			} else {
+				kubeconfigPath = *model.Location
 			}
 
-			err = skeUtils.WriteConfigFile(*model.Location, *resp.Kubeconfig)
+			err = skeUtils.WriteConfigFile(kubeconfigPath, *resp.Kubeconfig)
 			if err != nil {
 				return fmt.Errorf("write kubeconfig file: %w", err)
 			}
 
-			fmt.Printf("Created kubeconfig file for cluster %s in %q, with expiration date %v (UTC)\n", model.ClusterName, *model.Location, *resp.ExpirationTimestamp)
+			fmt.Printf("Created kubeconfig file for cluster %s in %q, with expiration date %v (UTC)\n", model.ClusterName, kubeconfigPath, *resp.ExpirationTimestamp)
 
 			return nil
 		},
@@ -140,7 +142,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	if model.ExpirationTime != nil {
 		expirationTime, err := skeUtils.ConvertToSeconds(*model.ExpirationTime)
 		if err != nil {
-			return req, fmt.Errorf("parsing expiration time: %w", err)
+			return req, fmt.Errorf("parse expiration time: %w", err)
 		}
 
 		payload.ExpirationSeconds = expirationTime

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -1,0 +1,109 @@
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/confirm"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/ske"
+)
+
+const (
+	clusterNameArg = "CLUSTER_NAME"
+
+	expirationFlag = "expiration"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	ClusterName    string
+	ExpirationTime *string
+}
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("create %s", clusterNameArg),
+		Short: "Creates a kubeconfig for an SKE cluster",
+		Long:  "Creates a kubeconfig for a STACKIT Kubernetes Engine (SKE) cluster.",
+		Args:  args.SingleArg(clusterNameArg, nil),
+		Example: examples.Build(
+			examples.NewExample(
+				`Create a kubeconfig for the SKE cluster with name "my-cluster"`,
+				"$ stackit ske kubeconfig create my-cluster"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to start the rotation of the credentials for SKE cluster %q?", model.ClusterName)
+				err = confirm.PromptForConfirmation(cmd, prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("create kubeconfig for SKE cluster: %w", err)
+			}
+
+			// Output kubeconfig to stdout
+			fmt.Println(*resp.Kubeconfig)
+
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP(expirationFlag, "e", "", "Expiration time for the kubeconfig")
+}
+
+func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	clusterName := inputArgs[0]
+
+	globalFlags := globalflags.Parse(cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	return &inputModel{
+		GlobalFlagModel: globalFlags,
+		ClusterName:     clusterName,
+		ExpirationTime:  flags.FlagToStringPointer(cmd, expirationFlag),
+	}, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClient) ske.ApiCreateKubeconfigRequest {
+	req := apiClient.CreateKubeconfig(ctx, model.ProjectId, model.ClusterName)
+
+	payload := ske.CreateKubeconfigPayload{}
+
+	if model.ExpirationTime != nil {
+		payload.ExpirationSeconds = model.ExpirationTime
+	}
+
+	return req.CreateKubeconfigPayload(payload)
+}

--- a/internal/cmd/ske/kubeconfig/create/create_test.go
+++ b/internal/cmd/ske/kubeconfig/create/create_test.go
@@ -1,0 +1,1 @@
+package create

--- a/internal/cmd/ske/kubeconfig/create/create_test.go
+++ b/internal/cmd/ske/kubeconfig/create/create_test.go
@@ -1,1 +1,298 @@
 package create
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-sdk-go/services/ske"
+)
+
+var projectIdFlag = globalflags.ProjectIdFlag
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &ske.APIClient{}
+var testProjectId = uuid.NewString()
+var testClusterName = "cluster"
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testClusterName,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		projectIdFlag: testProjectId,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+		},
+		ClusterName: testClusterName,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *ske.ApiCreateKubeconfigRequest)) ske.ApiCreateKubeconfigRequest {
+	request := testClient.CreateKubeconfig(testCtx, testProjectId, testClusterName)
+	request = request.CreateKubeconfigPayload(ske.CreateKubeconfigPayload{})
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			argValues:     fixtureArgValues(),
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "1000s expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "1000s"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("1000")
+			}),
+		},
+		{
+			description: "1000 expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "1000"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("1000")
+			}),
+		},
+		{
+			description: "60m expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "60m"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("3600")
+			}),
+		},
+		{
+			description: "4h expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "4h"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("14400")
+			}),
+		},
+		{
+			description: "2d expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "2d"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("172800")
+			}),
+		},
+		{
+			description: "2M expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "2M"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("5184000")
+			}),
+		},
+		{
+			description: "invalid expiration time",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["expiration"] = "2A"
+			}),
+			isValid: false,
+		},
+		{
+			description: "custom location",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues["location"] = "/path/to/config"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.KubeconfigPath = utils.Ptr("/path/to/config")
+			}),
+		},
+		{
+			description: "no values",
+			argValues:   []string{},
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "project id missing",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, projectIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[projectIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[projectIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cmd := NewCmd()
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(cmd, tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing flags: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest ske.ApiCreateKubeconfigRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+		{
+			description: "expiration time",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.ExpirationTime = utils.Ptr("30000")
+			}),
+			expectedRequest: fixtureRequest().CreateKubeconfigPayload(ske.CreateKubeconfigPayload{
+				ExpirationSeconds: utils.Ptr("30000")}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/cmd/ske/kubeconfig/create/create_test.go
+++ b/internal/cmd/ske/kubeconfig/create/create_test.go
@@ -80,79 +80,17 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "1000s expiration time",
+			description: "30d expiration time",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "1000s"
+				flagValues["expiration"] = "30d"
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("1000")
+				model.ExpirationTime = utils.Ptr("30d")
 			}),
 		},
-		{
-			description: "1000 expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "1000"
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("1000")
-			}),
-		},
-		{
-			description: "60m expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "60m"
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("3600")
-			}),
-		},
-		{
-			description: "4h expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "4h"
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("14400")
-			}),
-		},
-		{
-			description: "2d expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "2d"
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("172800")
-			}),
-		},
-		{
-			description: "2M expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "2M"
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("5184000")
-			}),
-		},
-		{
-			description: "invalid expiration time",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues["expiration"] = "2A"
-			}),
-			isValid: false,
-		},
+
 		{
 			description: "custom location",
 			argValues:   fixtureArgValues(),
@@ -161,7 +99,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.KubeconfigPath = utils.Ptr("/path/to/config")
+				model.Location = utils.Ptr("/path/to/config")
 			}),
 		},
 		{
@@ -275,16 +213,16 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "expiration time",
 			model: fixtureInputModel(func(model *inputModel) {
-				model.ExpirationTime = utils.Ptr("30000")
+				model.ExpirationTime = utils.Ptr("30d")
 			}),
 			expectedRequest: fixtureRequest().CreateKubeconfigPayload(ske.CreateKubeconfigPayload{
-				ExpirationSeconds: utils.Ptr("30000")}),
+				ExpirationSeconds: utils.Ptr("2592000")}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request := buildRequest(testCtx, tt.model, testClient)
+			request, _ := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/ske/kubeconfig/kubeconfig.go
+++ b/internal/cmd/ske/kubeconfig/kubeconfig.go
@@ -1,0 +1,25 @@
+package kubeconfig
+
+import (
+	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/kubeconfig/create"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubeconfig",
+		Short: "Provides functionality for SKE kubeconfig",
+		Long:  "Provides functionality for STACKIT Kubernetes Engine (SKE) kubeconfig.",
+		Args:  args.NoArgs,
+		Run:   utils.CmdHelp,
+	}
+	addSubcommands(cmd)
+	return cmd
+}
+
+func addSubcommands(cmd *cobra.Command) {
+	cmd.AddCommand(create.NewCmd())
+}

--- a/internal/cmd/ske/ske.go
+++ b/internal/cmd/ske/ske.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/describe"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/disable"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/enable"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/kubeconfig"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/ske/options"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -28,6 +29,7 @@ func NewCmd() *cobra.Command {
 func addSubcommands(cmd *cobra.Command) {
 	cmd.AddCommand(describe.NewCmd())
 	cmd.AddCommand(enable.NewCmd())
+	cmd.AddCommand(kubeconfig.NewCmd())
 	cmd.AddCommand(disable.NewCmd())
 	cmd.AddCommand(cluster.NewCmd())
 	cmd.AddCommand(credentials.NewCmd())

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -229,4 +231,32 @@ func ConvertToSeconds(timeStr string) (*string, error) {
 
 	result := uint64(value) * multiplier
 	return utils.Ptr(strconv.FormatUint(result, 10)), nil
+}
+
+func WriteConfigFile(configPath string, data string) error {
+	if data == "" {
+		return fmt.Errorf("no data to write")
+	}
+
+	dir := filepath.Dir(configPath)
+
+	err := os.MkdirAll(dir, 0o700)
+	if err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	err = os.WriteFile(configPath, []byte(data), 0o600)
+	if err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}
+
+func GetDefaultKubeconfigLocation() (string, error) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get user home directory: %w", err)
+	}
+
+	return filepath.Join(userHome, ".kube", "config"), nil
 }

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
@@ -190,4 +191,42 @@ func getDefaultPayloadNodepool(resp *ske.ProviderOptions) (*ske.Nodepool, error)
 	}
 
 	return output, nil
+}
+
+func ConvertToSeconds(timeStr string) (*string, error) {
+	if len(timeStr) < 2 {
+		return nil, fmt.Errorf("invalid time format: %s", timeStr)
+	}
+
+	unit := timeStr[len(timeStr)-1:]
+
+	valueStr := timeStr[:len(timeStr)-1]
+	value, err := strconv.ParseUint(valueStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse uint: %s", timeStr)
+	}
+
+	var multiplier uint64
+	switch unit {
+	// second
+	case "s":
+		multiplier = 1
+	// minute
+	case "m":
+		multiplier = 60
+	// hour
+	case "h":
+		multiplier = 60 * 60
+	// day
+	case "d":
+		multiplier = 60 * 60 * 24
+	// month, assume 30 days
+	case "M":
+		multiplier = 60 * 60 * 24 * 30
+	default:
+		return nil, fmt.Errorf("invalid time format: %s", timeStr)
+	}
+
+	result := uint64(value) * multiplier
+	return utils.Ptr(strconv.FormatUint(result, 10)), nil
 }

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -237,7 +237,7 @@ func ConvertToSeconds(timeStr string) (*string, error) {
 
 // WriteConfigFile writes the given data to the given path.
 // The directory is created if it does not exist.
-func WriteConfigFile(configPath string, data string) error {
+func WriteConfigFile(configPath, data string) error {
 	if data == "" {
 		return fmt.Errorf("no data to write")
 	}

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -195,6 +195,8 @@ func getDefaultPayloadNodepool(resp *ske.ProviderOptions) (*ske.Nodepool, error)
 	return output, nil
 }
 
+// ConvertToSeconds	converts a time string to seconds.
+// The time string must be in the format of <value><unit>, where unit is one of s, m, h, d, M.
 func ConvertToSeconds(timeStr string) (*string, error) {
 	if len(timeStr) < 2 {
 		return nil, fmt.Errorf("invalid time format: %s", timeStr)
@@ -233,6 +235,8 @@ func ConvertToSeconds(timeStr string) (*string, error) {
 	return utils.Ptr(strconv.FormatUint(result, 10)), nil
 }
 
+// WriteConfigFile writes the given data to the given path.
+// The directory is created if it does not exist.
 func WriteConfigFile(configPath string, data string) error {
 	if data == "" {
 		return fmt.Errorf("no data to write")
@@ -252,6 +256,7 @@ func WriteConfigFile(configPath string, data string) error {
 	return nil
 }
 
+// GetDefaultKubeconfigLocation returns the default location for the kubeconfig file.
 func GetDefaultKubeconfigLocation() (string, error) {
 	userHome, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -596,5 +596,8 @@ func TestWriteConfigFile(t *testing.T) {
 		})
 	}
 	// Cleanup
-	os.RemoveAll("test_data/")
+	err := os.RemoveAll("test_data/")
+	if err != nil {
+		t.Errorf("failed cleaning test data")
+	}
 }

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -543,7 +543,7 @@ func TestWriteConfigFile(t *testing.T) {
 	}{
 		{
 			description: "base",
-			location:    "test_data/base/config",
+			location:    "base/config",
 			kubeconfig:  "kubeconfig",
 			isValid:     true,
 		},
@@ -554,28 +554,28 @@ func TestWriteConfigFile(t *testing.T) {
 			isValid:     false,
 		},
 		{
-			description: "no permission location",
-			location:    "/root/config",
-			kubeconfig:  "kubeconfig",
-			isValid:     false,
-		},
-		{
 			description: "path is only dir",
-			location:    "test_data/only_dir/",
+			location:    "only_dir/",
 			kubeconfig:  "kubeconfig",
 			isValid:     false,
 		},
 		{
 			description: "empty kubeconfig",
-			location:    "test_data/empty/config",
+			location:    "empty/config",
 			kubeconfig:  "",
 			isValid:     false,
 		},
 	}
 
+	baseTestDir := "test_data/"
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			err := WriteConfigFile(tt.location, tt.kubeconfig)
+			testLocation := baseTestDir + tt.location
+			// make sure empty case still works
+			if tt.location == "" {
+				testLocation = ""
+			}
+			err := WriteConfigFile(testLocation, tt.kubeconfig)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -585,7 +585,7 @@ func TestWriteConfigFile(t *testing.T) {
 			}
 
 			if tt.isValid {
-				data, err := os.ReadFile(tt.location)
+				data, err := os.ReadFile(testLocation)
 				if err != nil {
 					t.Errorf("could not read file: %s", tt.location)
 				}
@@ -596,7 +596,7 @@ func TestWriteConfigFile(t *testing.T) {
 		})
 	}
 	// Cleanup
-	err := os.RemoveAll("test_data/")
+	err := os.RemoveAll(baseTestDir)
 	if err != nil {
 		t.Errorf("failed cleaning test data")
 	}

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -441,3 +441,93 @@ func TestGetDefaultPayload(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToSeconds(t *testing.T) {
+	tests := []struct {
+		description    string
+		expirationTime string
+		isValid        bool
+		expectedOutput string
+	}{
+		{
+			description:    "seconds",
+			expirationTime: "30s",
+			isValid:        true,
+			expectedOutput: "30",
+		},
+		{
+			description:    "minutes",
+			expirationTime: "30m",
+			isValid:        true,
+			expectedOutput: "1800",
+		},
+		{
+			description:    "hours",
+			expirationTime: "30h",
+			isValid:        true,
+			expectedOutput: "108000",
+		},
+		{
+			description:    "days",
+			expirationTime: "30d",
+			isValid:        true,
+			expectedOutput: "2592000",
+		},
+		{
+			description:    "months",
+			expirationTime: "30M",
+			isValid:        true,
+			expectedOutput: "77760000",
+		},
+		{
+			description:    "leading zero",
+			expirationTime: "0030M",
+			isValid:        true,
+			expectedOutput: "77760000",
+		},
+		{
+			description:    "invalid unit",
+			expirationTime: "30x",
+			isValid:        false,
+		},
+		{
+			description:    "invalid unit 2",
+			expirationTime: "3000abcdef",
+			isValid:        false,
+		},
+		{
+			description:    "invalid unit 3",
+			expirationTime: "3000abcdef000",
+			isValid:        false,
+		},
+		{
+			description:    "invalid time",
+			expirationTime: "x",
+			isValid:        false,
+		},
+		{
+			description:    "empty",
+			expirationTime: "",
+			isValid:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			output, err := ConvertToSeconds(tt.expirationTime)
+
+			if tt.isValid && err != nil {
+				t.Errorf("failed on valid input")
+			}
+			if !tt.isValid && err == nil {
+				t.Errorf("did not fail on invalid input")
+			}
+			if !tt.isValid {
+				return
+			}
+			if *output != tt.expectedOutput {
+				t.Errorf("expected output to be %s, got %s", tt.expectedOutput, *output)
+			}
+		})
+	}
+}

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -535,33 +536,37 @@ func TestConvertToSeconds(t *testing.T) {
 
 func TestWriteConfigFile(t *testing.T) {
 	tests := []struct {
-		description string
-		location    string
-		kubeconfig  string
-		isValid     bool
-		expectedErr string
+		description     string
+		location        string
+		kubeconfig      string
+		isValid         bool
+		isLocationDir   bool
+		isLocationEmpty bool
+		expectedErr     string
 	}{
 		{
 			description: "base",
-			location:    "base/config",
+			location:    filepath.Join("base", "config"),
 			kubeconfig:  "kubeconfig",
 			isValid:     true,
 		},
 		{
-			description: "empty location",
-			location:    "",
-			kubeconfig:  "kubeconfig",
-			isValid:     false,
+			description:     "empty location",
+			location:        "",
+			kubeconfig:      "kubeconfig",
+			isValid:         false,
+			isLocationEmpty: true,
 		},
 		{
-			description: "path is only dir",
-			location:    "only_dir/",
-			kubeconfig:  "kubeconfig",
-			isValid:     false,
+			description:   "path is only dir",
+			location:      "only_dir",
+			kubeconfig:    "kubeconfig",
+			isValid:       false,
+			isLocationDir: true,
 		},
 		{
 			description: "empty kubeconfig",
-			location:    "empty/config",
+			location:    filepath.Join("empty", "config"),
 			kubeconfig:  "",
 			isValid:     false,
 		},
@@ -570,10 +575,14 @@ func TestWriteConfigFile(t *testing.T) {
 	baseTestDir := "test_data/"
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			testLocation := baseTestDir + tt.location
+			testLocation := filepath.Join(baseTestDir, tt.location)
 			// make sure empty case still works
-			if tt.location == "" {
+			if tt.isLocationEmpty {
 				testLocation = ""
+			}
+			// filepath Join cleans trailing separators
+			if tt.isLocationDir {
+				testLocation += string(filepath.Separator)
 			}
 			err := WriteConfigFile(testLocation, tt.kubeconfig)
 


### PR DESCRIPTION
## Some notes on implementation

This command is creating a kubeconfig and writing it to a file. By default, this location is ~/.kube/config (which is default for kubernetes) but can be changed via flag.
This choice is informed by behavior in GCP and AWS:
- https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html#create-kubeconfig-automatically
- https://cloud.google.com/sdk/gcloud/reference/container/clusters/get-credentials

When setting the expiration time, I created a helper function to save the user from writing large timeouts (eg. 3 months) in seconds (the unit the API ingests)