### PR TITLE
Only write to config file when needed

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -87,11 +87,6 @@ func InitConfig() {
 	cobra.CheckErr(err)
 	setConfigDefaults()
 
-	err = viper.WriteConfigAs(configFilePath)
-	cobra.CheckErr(err)
-
-	// Needs to be done after WriteConfigAs, otherwise it would write
-	// the environment variables to the config file
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("stackit")
 }


### PR DESCRIPTION
- Addresses #153 
- We only need to **write** the `Viper` configuration to the config file on `stackit config set/unset` it is persisted
- For other cases, it's enough to set the defaults (for empty keys) or simply **read** the previously set values from the config file