### PR TITLE
Re-add APT installation instructions with new domain

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,9 +20,44 @@ brew install stackit
 
 ### Linux
 
-Currently, you can install via [Homebrew](https://brew.sh/) or refer to one of the installation methods below.
+#### Debian/Ubuntu (`APT`)
 
-> We are currently working on distributing the CLI on package managers for Linux.
+The STACKIT CLI can be installed through the [`APT`](https://ubuntu.com/server/docs/package-management) package manager.
+
+##### Before you begin
+
+To install the STACKIT CLI package, you will need to have the `curl` and `gnupg` packages installed:
+```shell
+sudo apt-get update
+sudo apt-get install curl gnupg
+```
+
+##### Installing
+
+1. Import the STACKIT public key:
+
+```shell
+curl https://object.storage.eu01.onstackit.cloud/stackit-public-key/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/stackit.gpg
+```
+
+2. Add the STACKIT CLI package repository as a package source:
+
+```shell
+echo "deb [signed-by=/usr/share/keyrings/stackit.gpg] https://object.storage.eu01.onstackit.cloud/stackit-cli-apt stackit main" | sudo tee -a /etc/apt/sources.list.d/stackit.list
+```
+
+3. Update repository information and install the `stackit` package:
+
+```shell
+sudo apt-get update
+sudo apt-get install stackit
+```
+
+#### Any distribution
+
+Alternatively, you can install via [Homebrew](https://brew.sh/) or refer to one of the installation methods below.
+
+> We are currently working on distributing the CLI on more package managers for Linux.
 
 ### Windows
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -27,6 +27,7 @@ The STACKIT CLI can be installed through the [`APT`](https://ubuntu.com/server/d
 ##### Before you begin
 
 To install the STACKIT CLI package, you will need to have the `curl` and `gnupg` packages installed:
+
 ```shell
 sudo apt-get update
 sudo apt-get install curl gnupg
@@ -37,13 +38,13 @@ sudo apt-get install curl gnupg
 1. Import the STACKIT public key:
 
 ```shell
-curl https://object.storage.eu01.onstackit.cloud/stackit-public-key/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/stackit.gpg
+curl https://packages.stackit.cloud/keys/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/stackit.gpg
 ```
 
 2. Add the STACKIT CLI package repository as a package source:
 
 ```shell
-echo "deb [signed-by=/usr/share/keyrings/stackit.gpg] https://object.storage.eu01.onstackit.cloud/stackit-cli-apt stackit main" | sudo tee -a /etc/apt/sources.list.d/stackit.list
+echo "deb [signed-by=/usr/share/keyrings/stackit.gpg] https://packages.stackit.cloud/apt/cli stackit main" | sudo tee -a /etc/apt/sources.list.d/stackit.list
 ```
 
 3. Update repository information and install the `stackit` package:


### PR DESCRIPTION
- Reverts stackitcloud/stackit-cli#162
- Adjusts URL to new domain