### PR TITLE
Logging: update table.Display to use the print package

### DIFF
--- a/internal/cmd/argus/instance/describe/describe.go
+++ b/internal/cmd/argus/instance/describe/describe.go
@@ -60,7 +60,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read Argus instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -85,7 +85,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *argus.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *argus.GetInstanceResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *argus.GetInstanceResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 
@@ -110,7 +110,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *argus.GetIn
 		table.AddSeparator()
 		table.AddRow("GRAFANA URL", *instance.Instance.GrafanaUrl)
 		table.AddSeparator()
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/argus/instance/list/list.go
+++ b/internal/cmd/argus/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *argus.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []argus.ProjectInstanceFull, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []argus.ProjectInstanceFull) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []argus.Pro
 			instance := instances[i]
 			table.AddRow(*instance.Id, *instance.Name, *instance.PlanName, *instance.Status)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/argus/plans/plans.go
+++ b/internal/cmd/argus/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *argus.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []argus.Plan, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []argus.Plan) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -135,7 +135,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []argus.Plan, p
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -5,12 +5,13 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/set"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/unset"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
@@ -18,12 +19,12 @@ func NewCmd() *cobra.Command {
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}
-	addSubcommands(cmd)
+	addSubcommands(cmd, p)
 	return cmd
 }
 
-func addSubcommands(cmd *cobra.Command) {
-	cmd.AddCommand(list.NewCmd())
+func addSubcommands(cmd *cobra.Command, p *print.Printer) {
+	cmd.AddCommand(list.NewCmd(p))
 	cmd.AddCommand(set.NewCmd())
 	cmd.AddCommand(unset.NewCmd())
 }

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -5,12 +5,13 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/set"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/unset"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
@@ -18,12 +19,12 @@ func NewCmd() *cobra.Command {
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}
-	addSubcommands(cmd)
+	addSubcommands(cmd, p)
 	return cmd
 }
 
-func addSubcommands(cmd *cobra.Command) {
-	cmd.AddCommand(list.NewCmd())
-	cmd.AddCommand(set.NewCmd())
-	cmd.AddCommand(unset.NewCmd())
+func addSubcommands(cmd *cobra.Command, p *print.Printer) {
+	cmd.AddCommand(list.NewCmd(p))
+	cmd.AddCommand(set.NewCmd(p))
+	cmd.AddCommand(unset.NewCmd(p))
 }

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -24,7 +24,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 }
 
 func addSubcommands(cmd *cobra.Command, p *print.Printer) {
-	cmd.AddCommand(list.NewCmd(p))
+	cmd.AddCommand(list.NewCmd())
 	cmd.AddCommand(set.NewCmd(p))
-	cmd.AddCommand(unset.NewCmd(p))
+	cmd.AddCommand(unset.NewCmd())
 }

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -5,13 +5,12 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/set"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/unset"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 )
 
-func NewCmd(p *print.Printer) *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
@@ -19,12 +18,12 @@ func NewCmd(p *print.Printer) *cobra.Command {
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}
-	addSubcommands(cmd, p)
+	addSubcommands(cmd)
 	return cmd
 }
 
-func addSubcommands(cmd *cobra.Command, p *print.Printer) {
+func addSubcommands(cmd *cobra.Command) {
 	cmd.AddCommand(list.NewCmd())
-	cmd.AddCommand(set.NewCmd(p))
+	cmd.AddCommand(set.NewCmd())
 	cmd.AddCommand(unset.NewCmd())
 }

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -10,14 +10,13 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func NewCmd(p *print.Printer) *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists the current CLI configuration values",

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -10,13 +10,14 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists the current CLI configuration values",

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -10,13 +10,14 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists the current CLI configuration values",
@@ -83,7 +84,7 @@ func NewCmd() *cobra.Command {
 				table.AddRow(key, valueString)
 				table.AddSeparator()
 			}
-			err = table.Display(cmd)
+			err = table.Display(p)
 			if err != nil {
 				return fmt.Errorf("render table: %w", err)
 			}

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,7 +41,7 @@ type inputModel struct {
 	ProjectIdSet bool
 }
 
-func NewCmd(p *print.Printer) *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Sets CLI configuration options",
@@ -71,7 +70,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 
 			if model.SessionTimeLimit != nil {
-				p.Info("Authenticate again to apply changes to session time limit")
+				cmd.Println("Authenticate again to apply changes to session time limit")
 				viper.Set(config.SessionTimeLimitKey, *model.SessionTimeLimit)
 			}
 

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,7 +42,7 @@ type inputModel struct {
 	ProjectIdSet bool
 }
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Sets CLI configuration options",
@@ -70,7 +71,7 @@ func NewCmd() *cobra.Command {
 			}
 
 			if model.SessionTimeLimit != nil {
-				cmd.Println("Authenticate again to apply changes to session time limit")
+				p.Info("Authenticate again to apply changes to session time limit")
 				viper.Set(config.SessionTimeLimitKey, *model.SessionTimeLimit)
 			}
 

--- a/internal/cmd/config/set/set_test.go
+++ b/internal/cmd/config/set/set_test.go
@@ -120,7 +120,7 @@ func TestParseInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd(nil)
+			cmd := NewCmd()
 			err := globalflags.Configure(cmd.Flags())
 			if err != nil {
 				t.Fatalf("configure global flags: %v", err)

--- a/internal/cmd/config/set/set_test.go
+++ b/internal/cmd/config/set/set_test.go
@@ -120,7 +120,7 @@ func TestParseInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd()
+			cmd := NewCmd(nil)
 			err := globalflags.Configure(cmd.Flags())
 			if err != nil {
 				t.Fatalf("configure global flags: %v", err)

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -62,7 +63,7 @@ type inputModel struct {
 	SKECustomEndpoint             bool
 }
 
-func NewCmd() *cobra.Command {
+func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
 		Short: "Unsets CLI configuration options",

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -63,7 +62,7 @@ type inputModel struct {
 	SKECustomEndpoint             bool
 }
 
-func NewCmd(p *print.Printer) *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
 		Short: "Unsets CLI configuration options",

--- a/internal/cmd/config/unset/unset_test.go
+++ b/internal/cmd/config/unset/unset_test.go
@@ -185,7 +185,7 @@ func TestParseInput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd(nil)
+			cmd := NewCmd()
 
 			for flag, value := range tt.flagValues {
 				stringBool := fmt.Sprintf("%v", value)

--- a/internal/cmd/config/unset/unset_test.go
+++ b/internal/cmd/config/unset/unset_test.go
@@ -185,7 +185,7 @@ func TestParseInput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd()
+			cmd := NewCmd(nil)
 
 			for flag, value := range tt.flagValues {
 				stringBool := fmt.Sprintf("%v", value)

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -98,7 +98,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				}
 			}()
 
-			err = outputResponse(model, resp, p)
+			err = outputResponse(p, model, resp)
 			if err != nil {
 				return err
 			}
@@ -200,7 +200,7 @@ func buildRequest(model *inputModel, bearerToken string) (*http.Request, error) 
 	return req, nil
 }
 
-func outputResponse(model *inputModel, resp *http.Response, p *print.Printer) error {
+func outputResponse(p *print.Printer, model *inputModel, resp *http.Response) error {
 	output := make([]byte, 0)
 	if model.IncludeResponseHeaders {
 		respHeader, err := httputil.DumpResponse(resp, false)

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -67,7 +67,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 			recordSet := resp.Rrset
 
-			return outputResult(cmd, model.OutputFormat, recordSet, p)
+			return outputResult(p, model.OutputFormat, recordSet)
 		},
 	}
 	configureFlags(cmd)
@@ -101,7 +101,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *dns.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, recordSet *dns.RecordSet, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, recordSet *dns.RecordSet) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		records := *recordSet.Records
@@ -123,7 +123,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, recordSet *dns.Record
 		table.AddRow("TYPE", *recordSet.Type)
 		table.AddSeparator()
 		table.AddRow("RECORDS DATA", recordsDataJoin)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/dns/record-set/list/list.go
+++ b/internal/cmd/dns/record-set/list/list.go
@@ -96,7 +96,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				p.Info("No record sets found for zone %s matching the criteria\n", zoneLabel)
 				return nil
 			}
-			return outputResult(cmd, model.OutputFormat, recordSets, p)
+			return outputResult(p, model.OutputFormat, recordSets)
 		},
 	}
 
@@ -221,7 +221,7 @@ func fetchRecordSets(ctx context.Context, model *inputModel, apiClient dnsClient
 	return recordSets, nil
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, recordSets []dns.RecordSet, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, recordSets []dns.RecordSet) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(recordSets, "", "  ")
@@ -238,7 +238,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, recordSets []dns.Reco
 			rs := recordSets[i]
 			table.AddRow(*rs.Id, *rs.Name, *rs.State, *rs.Ttl, *rs.Type)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -61,7 +61,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 			zone := resp.Zone
 
-			return outputResult(cmd, model.OutputFormat, zone, p)
+			return outputResult(p, model.OutputFormat, zone)
 		},
 	}
 	return cmd
@@ -86,7 +86,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *dns.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, zone *dns.Zone, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, zone *dns.Zone) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -119,7 +119,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, zone *dns.Zone, p *pr
 		table.AddRow("EXPIRE TIME", *zone.ExpireTime)
 		table.AddSeparator()
 		table.AddRow("NEGATIVE CACHE", *zone.NegativeCache)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -92,7 +92,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return nil
 			}
 
-			return outputResult(cmd, model.OutputFormat, zones, p)
+			return outputResult(p, model.OutputFormat, zones)
 		},
 	}
 	configureFlags(cmd)
@@ -209,7 +209,7 @@ func fetchZones(ctx context.Context, model *inputModel, apiClient dnsClient) ([]
 	return zones, nil
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, zones []dns.Zone, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, zones []dns.Zone) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		// Show details
@@ -227,7 +227,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, zones []dns.Zone, p *
 			z := zones[i]
 			table.AddRow(*z.Id, *z.Name, *z.State, *z.Type, *z.DnsName, *z.RecordCount)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/logme/credentials/describe/describe.go
+++ b/internal/cmd/logme/credentials/describe/describe.go
@@ -65,7 +65,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("describe LogMe credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *logme.CredentialsResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *logme.CredentialsResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -114,7 +114,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials *logme.Cr
 		table.AddRow("PASSWORD", *credentials.Raw.Credentials.Password)
 		table.AddSeparator()
 		table.AddRow("URI", *credentials.Raw.Credentials.Uri)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/logme/credentials/list/list.go
+++ b/internal/cmd/logme/credentials/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []logme.CredentialsListItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []logme.CredentialsListItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []logme.C
 			c := credentials[i]
 			table.AddRow(*c.Id)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/logme/instance/describe/describe.go
+++ b/internal/cmd/logme/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read LogMe instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *logme.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *logme.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -109,7 +109,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *logme.Insta
 				table.AddRow("ACL", aclStr)
 			}
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []logme.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []logme.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []logme.Ins
 			instance := instances[i]
 			table.AddRow(*instance.InstanceId, *instance.Name, *instance.LastOperation.Type, *instance.LastOperation.State)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/logme/plans/plans.go
+++ b/internal/cmd/logme/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []logme.Offering, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []logme.Offering) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []logme.Offerin
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -65,7 +65,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("describe MariaDB credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *mariadb.CredentialsResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *mariadb.CredentialsResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -114,7 +114,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials *mariadb.
 		table.AddRow("PASSWORD", *credentials.Raw.Credentials.Password)
 		table.AddSeparator()
 		table.AddRow("URI", *credentials.Raw.Credentials.Uri)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []mariadb.CredentialsListItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []mariadb.CredentialsListItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []mariadb
 			c := credentials[i]
 			table.AddRow(*c.Id)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read MariaDB instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *mariadb.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *mariadb.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -109,7 +109,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *mariadb.Ins
 				table.AddRow("ACL", aclStr)
 			}
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []mariadb.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []mariadb.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []mariadb.I
 			instance := instances[i]
 			table.AddRow(*instance.InstanceId, *instance.Name, *instance.LastOperation.Type, *instance.LastOperation.State)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []mariadb.Offering, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []mariadb.Offering) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []mariadb.Offer
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read MongoDB Flex instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp.Item, p)
+			return outputResult(p, model.OutputFormat, resp.Item)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *mongodbflex.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		aclsArray := *instance.Acl.Items
@@ -122,7 +122,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *mongodbflex
 		table.AddSeparator()
 		table.AddRow("RAM", *instance.Flavor.Memory)
 		table.AddSeparator()
-		err = table.Display(cmd)
+		err = table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []mongodbflex.InstanceListInstance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []mongodbflex.InstanceListInstance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []mongodbfl
 			instance := instances[i]
 			table.AddRow(*instance.Id, *instance.Name, *instance.Status)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -76,7 +76,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 
 			// Call API
-			err = buildAndExecuteRequest(ctx, cmd, model, apiClient, p)
+			err = buildAndExecuteRequest(ctx, p, model, apiClient)
 			if err != nil {
 				return fmt.Errorf("get MongoDB Flex options: %w", err)
 			}
@@ -130,7 +130,7 @@ type mongoDBFlexOptionsClient interface {
 	ListStoragesExecute(ctx context.Context, projectId, flavorId string) (*mongodbflex.ListStoragesResponse, error)
 }
 
-func buildAndExecuteRequest(ctx context.Context, cmd *cobra.Command, model *inputModel, apiClient mongoDBFlexOptionsClient, p *print.Printer) error {
+func buildAndExecuteRequest(ctx context.Context, p *print.Printer, model *inputModel, apiClient mongoDBFlexOptionsClient) error {
 	var flavors *mongodbflex.ListFlavorsResponse
 	var versions *mongodbflex.ListVersionsResponse
 	var storages *mongodbflex.ListStoragesResponse
@@ -155,10 +155,10 @@ func buildAndExecuteRequest(ctx context.Context, cmd *cobra.Command, model *inpu
 		}
 	}
 
-	return outputResult(cmd, model, flavors, versions, storages, p)
+	return outputResult(p, model, flavors, versions, storages)
 }
 
-func outputResult(cmd *cobra.Command, model *inputModel, flavors *mongodbflex.ListFlavorsResponse, versions *mongodbflex.ListVersionsResponse, storages *mongodbflex.ListStoragesResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, model *inputModel, flavors *mongodbflex.ListFlavorsResponse, versions *mongodbflex.ListVersionsResponse, storages *mongodbflex.ListStoragesResponse) error {
 	options := &options{}
 	if flavors != nil {
 		options.Flavors = flavors.Flavors
@@ -182,11 +182,11 @@ func outputResult(cmd *cobra.Command, model *inputModel, flavors *mongodbflex.Li
 		p.Outputln(string(details))
 		return nil
 	default:
-		return outputResultAsTable(cmd, model, options)
+		return outputResultAsTable(p, model, options)
 	}
 }
 
-func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *options) error {
+func outputResultAsTable(p *print.Printer, model *inputModel, options *options) error {
 	content := ""
 	if model.Flavors {
 		content += renderFlavors(*options.Flavors)
@@ -198,7 +198,7 @@ func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *options
 		content += renderStorages(options.Storages.Storages)
 	}
 
-	err := pager.Display(cmd, content)
+	err := pager.Display(p, content)
 	if err != nil {
 		return fmt.Errorf("display output: %w", err)
 	}

--- a/internal/cmd/mongodbflex/options/options_test.go
+++ b/internal/cmd/mongodbflex/options/options_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
@@ -288,14 +289,16 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd(nil)
+			p := &print.Printer{}
+			cmd := NewCmd(p)
+			p.Cmd = cmd
 			client := &mongoDBFlexClientMocked{
 				listFlavorsFails:  tt.listFlavorsFails,
 				listVersionsFails: tt.listVersionsFails,
 				listStoragesFails: tt.listStoragesFails,
 			}
 
-			err := buildAndExecuteRequest(testCtx, cmd, tt.model, client, nil)
+			err := buildAndExecuteRequest(testCtx, p, tt.model, client)
 			if err != nil && tt.isValid {
 				t.Fatalf("error building and executing request: %v", err)
 			}

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -70,7 +70,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("get MongoDB Flex user: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, *resp.Item, p)
+			return outputResult(p, model.OutputFormat, *resp.Item)
 		},
 	}
 
@@ -105,7 +105,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, user mongodbflex.InstanceResponseUser, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, user mongodbflex.InstanceResponseUser) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -121,7 +121,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, user mongodbflex.Inst
 		table.AddSeparator()
 		table.AddRow("PORT", *user.Port)
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				users = users[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, users, p)
+			return outputResult(p, model.OutputFormat, users)
 		},
 	}
 
@@ -124,7 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, users []mongodbflex.ListUser, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, users []mongodbflex.ListUser) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(users, "", "  ")
@@ -141,7 +141,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, users []mongodbflex.L
 			user := users[i]
 			table.AddRow(*user.Id, *user.Username)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/object-storage/bucket/describe/describe.go
+++ b/internal/cmd/object-storage/bucket/describe/describe.go
@@ -59,7 +59,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read Object Storage bucket: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp.Bucket, p)
+			return outputResult(p, model.OutputFormat, resp.Bucket)
 		},
 	}
 	return cmd
@@ -84,7 +84,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, bucket *objectstorage.Bucket, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, bucket *objectstorage.Bucket) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -96,7 +96,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, bucket *objectstorage
 		table.AddSeparator()
 		table.AddRow("URL (Virtual Hosted Style)", *bucket.UrlVirtualHostedStyle)
 		table.AddSeparator()
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/object-storage/bucket/list/list.go
+++ b/internal/cmd/object-storage/bucket/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				buckets = buckets[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, buckets, p)
+			return outputResult(p, model.OutputFormat, buckets)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, buckets []objectstorage.Bucket, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, buckets []objectstorage.Bucket) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(buckets, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, buckets []objectstora
 			bucket := buckets[i]
 			table.AddRow(*bucket.Name, *bucket.Region, *bucket.UrlPathStyle, *bucket.UrlVirtualHostedStyle)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -73,7 +73,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentialsGroups) > int(*model.Limit) {
 				credentialsGroups = credentialsGroups[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentialsGroups, p)
+			return outputResult(p, model.OutputFormat, credentialsGroups)
 		},
 	}
 	configureFlags(cmd)
@@ -109,7 +109,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentialsGroups []objectstorage.CredentialsGroup, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentialsGroups []objectstorage.CredentialsGroup) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentialsGroups, "", "  ")
@@ -126,7 +126,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentialsGroups []o
 			c := credentialsGroups[i]
 			table.AddRow(*c.CredentialsGroupId, *c.DisplayName, *c.Urn)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/object-storage/credentials/list/list.go
+++ b/internal/cmd/object-storage/credentials/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -124,7 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []objectstorage.AccessKey, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []objectstorage.AccessKey) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -146,7 +146,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []objects
 			}
 			table.AddRow(*c.KeyId, *c.DisplayName, expiresAt)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -65,7 +65,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("describe OpenSearch credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *opensearch.CredentialsResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *opensearch.CredentialsResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -114,7 +114,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials *opensear
 		table.AddRow("PASSWORD", *credentials.Raw.Credentials.Password)
 		table.AddSeparator()
 		table.AddRow("URI", *credentials.Raw.Credentials.Uri)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []opensearch.CredentialsListItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []opensearch.CredentialsListItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []opensea
 			c := credentials[i]
 			table.AddRow(*c.Id)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read OpenSearch instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *opensearch.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *opensearch.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -109,7 +109,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *opensearch.
 				table.AddRow("ACL", aclStr)
 			}
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []opensearch.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []opensearch.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []opensearc
 			instance := instances[i]
 			table.AddRow(*instance.InstanceId, *instance.Name, *instance.LastOperation.Type, *instance.LastOperation.State)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []opensearch.Offering, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []opensearch.Offering) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []opensearch.Of
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -84,7 +84,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				members = members[:*model.Limit]
 			}
 
-			return outputResult(cmd, model, members, p)
+			return outputResult(p, model, members)
 		},
 	}
 	configureFlags(cmd)
@@ -131,7 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 	return req
 }
 
-func outputResult(cmd *cobra.Command, model *inputModel, members []authorization.Member, p *print.Printer) error {
+func outputResult(p *print.Printer, model *inputModel, members []authorization.Member) error {
 	sortFn := func(i, j int) bool {
 		switch model.SortBy {
 		case "subject":
@@ -172,7 +172,7 @@ func outputResult(cmd *cobra.Command, model *inputModel, members []authorization
 			table.EnableAutoMergeOnColumns(2)
 		}
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				roles = roles[:*model.Limit]
 			}
 
-			return outputRolesResult(cmd, model.OutputFormat, roles, p)
+			return outputRolesResult(p, model.OutputFormat, roles)
 		},
 	}
 	configureFlags(cmd)
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 	return apiClient.ListRoles(ctx, organizationResourceType, *model.OrganizationId)
 }
 
-func outputRolesResult(cmd *cobra.Command, outputFormat string, roles []authorization.Role, p *print.Printer) error {
+func outputRolesResult(p *print.Printer, outputFormat string, roles []authorization.Role) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		// Show details
@@ -139,7 +139,7 @@ func outputRolesResult(cmd *cobra.Command, outputFormat string, roles []authoriz
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1, 2)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/postgresflex/instance/describe/describe.go
+++ b/internal/cmd/postgresflex/instance/describe/describe.go
@@ -64,7 +64,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read PostgreSQL Flex instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp.Item, p)
+			return outputResult(p, model.OutputFormat, resp.Item)
 		},
 	}
 	return cmd
@@ -89,7 +89,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *postgresflex.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *postgresflex.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		aclsArray := *instance.Acl.Items
@@ -124,7 +124,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *postgresfle
 		table.AddSeparator()
 		table.AddRow("RAM", *instance.Flavor.Memory)
 		table.AddSeparator()
-		err = table.Display(cmd)
+		err = table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -81,7 +81,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -118,7 +118,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []postgresflex.InstanceListInstance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []postgresflex.InstanceListInstance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -136,7 +136,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []postgresf
 			instance := instances[i]
 			table.AddRow(*instance.Id, *instance.Name, caser.String(*instance.Status))
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/postgresflex/options/options.go
+++ b/internal/cmd/postgresflex/options/options.go
@@ -76,7 +76,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 
 			// Call API
-			err = buildAndExecuteRequest(ctx, cmd, model, apiClient, p)
+			err = buildAndExecuteRequest(ctx, p, model, apiClient)
 			if err != nil {
 				return fmt.Errorf("get PostgreSQL Flex options: %w", err)
 			}
@@ -130,7 +130,7 @@ type postgresFlexOptionsClient interface {
 	ListStoragesExecute(ctx context.Context, projectId, flavorId string) (*postgresflex.ListStoragesResponse, error)
 }
 
-func buildAndExecuteRequest(ctx context.Context, cmd *cobra.Command, model *inputModel, apiClient postgresFlexOptionsClient, p *print.Printer) error {
+func buildAndExecuteRequest(ctx context.Context, p *print.Printer, model *inputModel, apiClient postgresFlexOptionsClient) error {
 	var flavors *postgresflex.ListFlavorsResponse
 	var versions *postgresflex.ListVersionsResponse
 	var storages *postgresflex.ListStoragesResponse
@@ -155,10 +155,10 @@ func buildAndExecuteRequest(ctx context.Context, cmd *cobra.Command, model *inpu
 		}
 	}
 
-	return outputResult(cmd, model, flavors, versions, storages, p)
+	return outputResult(p, model, flavors, versions, storages)
 }
 
-func outputResult(cmd *cobra.Command, model *inputModel, flavors *postgresflex.ListFlavorsResponse, versions *postgresflex.ListVersionsResponse, storages *postgresflex.ListStoragesResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, model *inputModel, flavors *postgresflex.ListFlavorsResponse, versions *postgresflex.ListVersionsResponse, storages *postgresflex.ListStoragesResponse) error {
 	options := &options{}
 	if flavors != nil {
 		options.Flavors = flavors.Flavors
@@ -182,11 +182,11 @@ func outputResult(cmd *cobra.Command, model *inputModel, flavors *postgresflex.L
 		p.Outputln(string(details))
 		return nil
 	default:
-		return outputResultAsTable(cmd, model, options)
+		return outputResultAsTable(p, model, options)
 	}
 }
 
-func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *options) error {
+func outputResultAsTable(p *print.Printer, model *inputModel, options *options) error {
 	content := ""
 	if model.Flavors {
 		content += renderFlavors(*options.Flavors)
@@ -198,7 +198,7 @@ func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *options
 		content += renderStorages(options.Storages.Storages)
 	}
 
-	err := pager.Display(cmd, content)
+	err := pager.Display(p, content)
 	if err != nil {
 		return fmt.Errorf("display output: %w", err)
 	}

--- a/internal/cmd/postgresflex/options/options_test.go
+++ b/internal/cmd/postgresflex/options/options_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
@@ -288,14 +289,16 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			cmd := NewCmd(nil)
+			p := &print.Printer{}
+			cmd := NewCmd(p)
+			p.Cmd = cmd
 			client := &postgresFlexClientMocked{
 				listFlavorsFails:  tt.listFlavorsFails,
 				listVersionsFails: tt.listVersionsFails,
 				listStoragesFails: tt.listStoragesFails,
 			}
 
-			err := buildAndExecuteRequest(testCtx, cmd, tt.model, client, nil)
+			err := buildAndExecuteRequest(testCtx, p, tt.model, client)
 			if err != nil && tt.isValid {
 				t.Fatalf("error building and executing request: %v", err)
 			}

--- a/internal/cmd/postgresflex/user/describe/describe.go
+++ b/internal/cmd/postgresflex/user/describe/describe.go
@@ -69,7 +69,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("get MongoDB Flex user: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, *resp.Item, p)
+			return outputResult(p, model.OutputFormat, *resp.Item)
 		},
 	}
 
@@ -104,7 +104,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, user postgresflex.UserResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, user postgresflex.UserResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -118,7 +118,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, user postgresflex.Use
 		table.AddSeparator()
 		table.AddRow("PORT", *user.Port)
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/postgresflex/user/list/list.go
+++ b/internal/cmd/postgresflex/user/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				users = users[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, users, p)
+			return outputResult(p, model.OutputFormat, users)
 		},
 	}
 
@@ -124,7 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, users []postgresflex.ListUsersResponseItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, users []postgresflex.ListUsersResponseItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(users, "", "  ")
@@ -141,7 +141,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, users []postgresflex.
 			user := users[i]
 			table.AddRow(*user.Id, *user.Username)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -64,7 +64,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read project details: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -93,7 +93,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *resourceman
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, project *resourcemanager.ProjectResponseWithParents, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, project *resourcemanager.ProjectResponseWithParents) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -106,7 +106,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, project *resourcemana
 		table.AddRow("STATE", *project.LifecycleState)
 		table.AddSeparator()
 		table.AddRow("PARENT ID", *project.Parent.Id)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -81,7 +81,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return nil
 			}
 
-			return outputResult(cmd, model.OutputFormat, projects, p)
+			return outputResult(p, model.OutputFormat, projects)
 		},
 	}
 	configureFlags(cmd)
@@ -195,7 +195,7 @@ func fetchProjects(ctx context.Context, model *inputModel, apiClient resourceMan
 	return projects, nil
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, projects []resourcemanager.ProjectResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, projects []resourcemanager.ProjectResponse) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(projects, "", "  ")
@@ -213,7 +213,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, projects []resourcema
 			table.AddRow(*p.ProjectId, *p.Name, *p.LifecycleState, *p.Parent.Id)
 		}
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -87,7 +87,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				members = members[:*model.Limit]
 			}
 
-			return outputResult(cmd, model, members, p)
+			return outputResult(p, model, members)
 		},
 	}
 	configureFlags(cmd)
@@ -132,7 +132,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 	return req
 }
 
-func outputResult(cmd *cobra.Command, model *inputModel, members []authorization.Member, p *print.Printer) error {
+func outputResult(p *print.Printer, model *inputModel, members []authorization.Member) error {
 	sortFn := func(i, j int) bool {
 		switch model.SortBy {
 		case "subject":
@@ -173,7 +173,7 @@ func outputResult(cmd *cobra.Command, model *inputModel, members []authorization
 			table.EnableAutoMergeOnColumns(2)
 		}
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				roles = roles[:*model.Limit]
 			}
 
-			return outputRolesResult(cmd, model.OutputFormat, roles, p)
+			return outputRolesResult(p, model.OutputFormat, roles)
 		},
 	}
 	configureFlags(cmd)
@@ -117,7 +117,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 	return apiClient.ListRoles(ctx, projectResourceType, model.GlobalFlagModel.ProjectId)
 }
 
-func outputRolesResult(cmd *cobra.Command, outputFormat string, roles []authorization.Role, p *print.Printer) error {
+func outputRolesResult(p *print.Printer, outputFormat string, roles []authorization.Role) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		// Show details
@@ -140,7 +140,7 @@ func outputRolesResult(cmd *cobra.Command, outputFormat string, roles []authoriz
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1, 2)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/rabbitmq/credentials/describe/describe.go
+++ b/internal/cmd/rabbitmq/credentials/describe/describe.go
@@ -65,7 +65,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("describe RabbitMQ credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *rabbitmq.CredentialsResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *rabbitmq.CredentialsResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -114,7 +114,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials *rabbitmq
 		table.AddRow("PASSWORD", *credentials.Raw.Credentials.Password)
 		table.AddSeparator()
 		table.AddRow("URI", *credentials.Raw.Credentials.Uri)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/rabbitmq/credentials/list/list.go
+++ b/internal/cmd/rabbitmq/credentials/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []rabbitmq.CredentialsListItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []rabbitmq.CredentialsListItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []rabbitm
 			c := credentials[i]
 			table.AddRow(*c.Id)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/rabbitmq/instance/describe/describe.go
+++ b/internal/cmd/rabbitmq/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read RabbitMQ instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *rabbitmq.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *rabbitmq.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -109,7 +109,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *rabbitmq.In
 				table.AddRow("ACL", aclStr)
 			}
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/rabbitmq/instance/list/list.go
+++ b/internal/cmd/rabbitmq/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []rabbitmq.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []rabbitmq.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []rabbitmq.
 			instance := instances[i]
 			table.AddRow(*instance.InstanceId, *instance.Name, *instance.LastOperation.Type, *instance.LastOperation.State)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/rabbitmq/plans/plans.go
+++ b/internal/cmd/rabbitmq/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []rabbitmq.Offering, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []rabbitmq.Offering) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []rabbitmq.Offe
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/redis/credentials/describe/describe.go
+++ b/internal/cmd/redis/credentials/describe/describe.go
@@ -65,7 +65,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("describe Redis credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *redis.CredentialsResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *redis.CredentialsResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -114,7 +114,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials *redis.Cr
 		table.AddRow("PASSWORD", *credentials.Raw.Credentials.Password)
 		table.AddSeparator()
 		table.AddRow("URI", *credentials.Raw.Credentials.Uri)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/redis/credentials/list/list.go
+++ b/internal/cmd/redis/credentials/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(cmd, model.OutputFormat, credentials, p)
+			return outputResult(p, model.OutputFormat, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials []redis.CredentialsListItem, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials []redis.CredentialsListItem) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(credentials, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, credentials []redis.C
 			c := credentials[i]
 			table.AddRow(*c.Id)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/redis/instance/describe/describe.go
+++ b/internal/cmd/redis/instance/describe/describe.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read Redis instance: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -87,7 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *redis.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *redis.Instance) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -109,7 +109,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *redis.Insta
 				table.AddRow("ACL", aclStr)
 			}
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/redis/instance/list/list.go
+++ b/internal/cmd/redis/instance/list/list.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []redis.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []redis.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -133,7 +133,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []redis.Ins
 			instance := instances[i]
 			table.AddRow(*instance.InstanceId, *instance.Name, *instance.LastOperation.Type, *instance.LastOperation.State)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/redis/plans/plans.go
+++ b/internal/cmd/redis/plans/plans.go
@@ -79,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, plans, p)
+			return outputResult(p, model.OutputFormat, plans)
 		},
 	}
 
@@ -116,7 +116,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, plans []redis.Offering, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, plans []redis.Offering) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(plans, "", "  ")
@@ -138,7 +138,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, plans []redis.Offerin
 			table.AddSeparator()
 		}
 		table.EnableAutoMergeOnColumns(1)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -49,12 +49,15 @@ func NewRootCmd(version, date string, p *print.Printer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.FlagToBoolValue(cmd, "version") {
 				p.Outputf("STACKIT CLI (BETA)\n")
+				p.Outputf("STACKIT CLI (BETA)\n")
 
 				parsedDate, err := time.Parse(time.RFC3339, date)
 				if err != nil {
 					p.Outputf("Version: %s\n", version)
+					p.Outputf("Version: %s\n", version)
 					return nil
 				}
+				p.Outputf("Version: %s (%s)\n", version, parsedDate.Format(time.DateOnly))
 				p.Outputf("Version: %s (%s)\n", version, parsedDate.Format(time.DateOnly))
 				return nil
 			}
@@ -91,8 +94,9 @@ func configureFlags(cmd *cobra.Command) error {
 
 func addSubcommands(cmd *cobra.Command, p *print.Printer) {
 	cmd.AddCommand(argus.NewCmd(p))
+	cmd.AddCommand(argus.NewCmd(p))
 	cmd.AddCommand(auth.NewCmd(p))
-	cmd.AddCommand(config.NewCmd())
+	cmd.AddCommand(config.NewCmd(p))
 	cmd.AddCommand(curl.NewCmd(p))
 	cmd.AddCommand(dns.NewCmd(p))
 	cmd.AddCommand(logme.NewCmd(p))
@@ -102,7 +106,19 @@ func addSubcommands(cmd *cobra.Command, p *print.Printer) {
 	cmd.AddCommand(opensearch.NewCmd(p))
 	cmd.AddCommand(organization.NewCmd(p))
 	cmd.AddCommand(postgresflex.NewCmd(p))
+	cmd.AddCommand(logme.NewCmd(p))
+	cmd.AddCommand(mariadb.NewCmd(p))
+	cmd.AddCommand(mongodbflex.NewCmd(p))
+	cmd.AddCommand(objectstorage.NewCmd(p))
+	cmd.AddCommand(opensearch.NewCmd(p))
+	cmd.AddCommand(organization.NewCmd(p))
+	cmd.AddCommand(postgresflex.NewCmd(p))
 	cmd.AddCommand(project.NewCmd(p))
+	cmd.AddCommand(rabbitmq.NewCmd(p))
+	cmd.AddCommand(redis.NewCmd(p))
+	cmd.AddCommand(secretsmanager.NewCmd(p))
+	cmd.AddCommand(serviceaccount.NewCmd(p))
+	cmd.AddCommand(ske.NewCmd(p))
 	cmd.AddCommand(rabbitmq.NewCmd(p))
 	cmd.AddCommand(redis.NewCmd(p))
 	cmd.AddCommand(secretsmanager.NewCmd(p))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -96,7 +96,7 @@ func addSubcommands(cmd *cobra.Command, p *print.Printer) {
 	cmd.AddCommand(argus.NewCmd(p))
 	cmd.AddCommand(argus.NewCmd(p))
 	cmd.AddCommand(auth.NewCmd(p))
-	cmd.AddCommand(config.NewCmd())
+	cmd.AddCommand(config.NewCmd(p))
 	cmd.AddCommand(curl.NewCmd(p))
 	cmd.AddCommand(dns.NewCmd(p))
 	cmd.AddCommand(logme.NewCmd(p))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -96,7 +96,7 @@ func addSubcommands(cmd *cobra.Command, p *print.Printer) {
 	cmd.AddCommand(argus.NewCmd(p))
 	cmd.AddCommand(argus.NewCmd(p))
 	cmd.AddCommand(auth.NewCmd(p))
-	cmd.AddCommand(config.NewCmd(p))
+	cmd.AddCommand(config.NewCmd())
 	cmd.AddCommand(curl.NewCmd(p))
 	cmd.AddCommand(dns.NewCmd(p))
 	cmd.AddCommand(logme.NewCmd(p))

--- a/internal/cmd/secrets-manager/instance/describe/describe.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe.go
@@ -68,7 +68,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read Secrets Manager instance ACLs: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, instance, aclList, p)
+			return outputResult(p, model.OutputFormat, instance, aclList)
 		},
 	}
 	return cmd
@@ -98,7 +98,7 @@ func buildListACLsRequest(ctx context.Context, model *inputModel, apiClient *sec
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instance *secretsmanager.Instance, aclList *secretsmanager.AclList, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instance *secretsmanager.Instance, aclList *secretsmanager.AclList) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 
@@ -125,7 +125,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instance *secretsmana
 
 			table.AddRow("ACL", strings.Join(cidrs, ","))
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -80,7 +80,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, instances, p)
+			return outputResult(p, model.OutputFormat, instances)
 		},
 	}
 
@@ -117,7 +117,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, instances []secretsmanager.Instance, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, instances []secretsmanager.Instance) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(instances, "", "  ")
@@ -134,7 +134,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, instances []secretsma
 			instance := instances[i]
 			table.AddRow(*instance.Id, *instance.Name, *instance.State, *instance.SecretCount)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/secrets-manager/user/describe/describe.go
+++ b/internal/cmd/secrets-manager/user/describe/describe.go
@@ -66,7 +66,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("get Secrets Manager user: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, *resp, p)
+			return outputResult(p, model.OutputFormat, *resp)
 		},
 	}
 
@@ -101,7 +101,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, user secretsmanager.User, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, user secretsmanager.User) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
@@ -119,7 +119,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, user secretsmanager.U
 		}
 		table.AddRow("WRITE ACCESS", *user.Write)
 
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				users = users[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, users, p)
+			return outputResult(p, model.OutputFormat, users)
 		},
 	}
 
@@ -124,7 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, users []secretsmanager.User, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, users []secretsmanager.User) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(users, "", "  ")
@@ -141,7 +141,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, users []secretsmanage
 			user := users[i]
 			table.AddRow(*user.Id, *user.Username, *user.Description, *user.Write)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -58,7 +58,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return nil
 			}
 
-			return outputResult(jwks, p)
+			return outputResult(p, jwks)
 		},
 	}
 
@@ -78,7 +78,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 	return req
 }
 
-func outputResult(serviceAccounts []serviceaccount.JWK, p *print.Printer) error {
+func outputResult(p *print.Printer, serviceAccounts []serviceaccount.JWK) error {
 	details, err := json.MarshalIndent(serviceAccounts, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal JWK list: %w", err)

--- a/internal/cmd/service-account/key/describe/describe.go
+++ b/internal/cmd/service-account/key/describe/describe.go
@@ -61,7 +61,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read service account key: %w", err)
 			}
 
-			return outputResult(resp, p)
+			return outputResult(p, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -103,7 +103,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 	return req
 }
 
-func outputResult(key *serviceaccount.GetServiceAccountKeyResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, key *serviceaccount.GetServiceAccountKeyResponse) error {
 	marshaledKey, err := json.MarshalIndent(key, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal service account key: %w", err)

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -77,7 +77,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				keys = keys[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, keys, p)
+			return outputResult(p, model.OutputFormat, keys)
 		},
 	}
 
@@ -127,7 +127,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, keys []serviceaccount.ServiceAccountKeyListResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, keys []serviceaccount.ServiceAccountKeyListResponse) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(keys, "", "  ")
@@ -148,7 +148,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, keys []serviceaccount
 			}
 			table.AddRow(*k.Id, *k.Active, *k.CreatedAt, validUntil)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -73,7 +73,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				serviceAccounts = serviceAccounts[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, serviceAccounts, p)
+			return outputResult(p, model.OutputFormat, serviceAccounts)
 		},
 	}
 
@@ -110,7 +110,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, serviceAccounts []serviceaccount.ServiceAccount, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, serviceAccounts []serviceaccount.ServiceAccount) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(serviceAccounts, "", "  ")
@@ -125,7 +125,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, serviceAccounts []ser
 			account := serviceAccounts[i]
 			table.AddRow(*account.Id, *account.Email)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -81,7 +81,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				tokensMetadata = tokensMetadata[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, tokensMetadata, p)
+			return outputResult(p, model.OutputFormat, tokensMetadata)
 		},
 	}
 
@@ -131,7 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, tokensMetadata []serviceaccount.AccessTokenMetadata, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, tokensMetadata []serviceaccount.AccessTokenMetadata) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(tokensMetadata, "", "  ")
@@ -148,7 +148,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, tokensMetadata []serv
 			t := tokensMetadata[i]
 			table.AddRow(*t.Id, *t.Active, *t.CreatedAt, *t.ValidUntil)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -59,7 +59,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read SKE cluster: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -84,7 +84,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, cluster *ske.Cluster, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, cluster *ske.Cluster) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 
@@ -101,7 +101,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, cluster *ske.Cluster,
 		table.AddRow("VERSION", *cluster.Kubernetes.Version)
 		table.AddSeparator()
 		table.AddRow("ACL", acl)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/ske/cluster/generate-payload/generate_payload.go
+++ b/internal/cmd/ske/cluster/generate-payload/generate_payload.go
@@ -83,7 +83,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				}
 			}
 
-			return outputResult(payload, p)
+			return outputResult(p, payload)
 		},
 	}
 	configureFlags(cmd)
@@ -114,7 +114,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	return req
 }
 
-func outputResult(payload *ske.CreateOrUpdateClusterPayload, p *print.Printer) error {
+func outputResult(p *print.Printer, payload *ske.CreateOrUpdateClusterPayload) error {
 	payloadBytes, err := json.MarshalIndent(*payload, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -89,7 +89,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				clusters = clusters[:*model.Limit]
 			}
 
-			return outputResult(cmd, model.OutputFormat, clusters, p)
+			return outputResult(p, model.OutputFormat, clusters)
 		},
 	}
 
@@ -126,7 +126,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, clusters []ske.Cluster, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, clusters []ske.Cluster) error {
 	switch outputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(clusters, "", "  ")
@@ -147,7 +147,7 @@ func outputResult(cmd *cobra.Command, outputFormat string, clusters []ske.Cluste
 			}
 			table.AddRow(*c.Name, *c.Status.Aggregated, *c.Kubernetes.Version, len(*c.Nodepools), monitoring)
 		}
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/ske/credentials/describe/describe.go
+++ b/internal/cmd/ske/credentials/describe/describe.go
@@ -70,7 +70,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("get SKE credentials: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -95,14 +95,14 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, credentials *ske.Credentials, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, credentials *ske.Credentials) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
 		table.AddRow("SERVER", *credentials.Server)
 		table.AddSeparator()
 		table.AddRow("TOKEN", *credentials.Token)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -51,7 +51,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("read SKE project details: %w", err)
 			}
 
-			return outputResult(cmd, model.OutputFormat, resp, p)
+			return outputResult(p, model.OutputFormat, resp)
 		},
 	}
 	return cmd
@@ -73,14 +73,14 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 	return req
 }
 
-func outputResult(cmd *cobra.Command, outputFormat string, project *ske.ProjectResponse, p *print.Printer) error {
+func outputResult(p *print.Printer, outputFormat string, project *ske.ProjectResponse) error {
 	switch outputFormat {
 	case globalflags.PrettyOutputFormat:
 		table := tables.NewTable()
 		table.AddRow("ID", *project.ProjectId)
 		table.AddSeparator()
 		table.AddRow("STATE", *project.State)
-		err := table.Display(cmd)
+		err := table.Display(p)
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -76,7 +76,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return fmt.Errorf("get SKE provider options: %w", err)
 			}
 
-			return outputResult(cmd, model, resp, p)
+			return outputResult(p, model, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -123,7 +123,7 @@ func buildRequest(ctx context.Context, apiClient *ske.APIClient) ske.ApiListProv
 	return req
 }
 
-func outputResult(cmd *cobra.Command, model *inputModel, options *ske.ProviderOptions, p *print.Printer) error {
+func outputResult(p *print.Printer, model *inputModel, options *ske.ProviderOptions) error {
 	switch model.OutputFormat {
 	case globalflags.JSONOutputFormat:
 		details, err := json.MarshalIndent(options, "", "  ")
@@ -133,11 +133,11 @@ func outputResult(cmd *cobra.Command, model *inputModel, options *ske.ProviderOp
 		p.Outputln(string(details))
 		return nil
 	default:
-		return outputResultAsTable(cmd, model, options)
+		return outputResultAsTable(p, model, options)
 	}
 }
 
-func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *ske.ProviderOptions) error {
+func outputResultAsTable(p *print.Printer, model *inputModel, options *ske.ProviderOptions) error {
 	content := ""
 	if model.AvailabilityZones {
 		content += renderAvailabilityZones(options)
@@ -159,7 +159,7 @@ func outputResultAsTable(cmd *cobra.Command, model *inputModel, options *ske.Pro
 		content += renderVolumeTypes(options)
 	}
 
-	err := pager.Display(cmd, content)
+	err := pager.Display(p, content)
 	if err != nil {
 		return fmt.Errorf("display output: %w", err)
 	}

--- a/internal/pkg/pager/pager.go
+++ b/internal/pkg/pager/pager.go
@@ -5,14 +5,14 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 )
 
 // Shows the content in the command's stdout using the "less" command
-func Display(cmd *cobra.Command, content string) error {
+func Display(p *print.Printer, content string) error {
 	lessCmd := exec.Command("less", "-F", "-S", "-w")
 	lessCmd.Stdin = strings.NewReader(content)
-	lessCmd.Stdout = cmd.OutOrStdout()
+	lessCmd.Stdout = p.OutOrStdout()
 
 	err := lessCmd.Run()
 	if err != nil {

--- a/internal/pkg/tables/tables.go
+++ b/internal/pkg/tables/tables.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/pager"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/spf13/cobra"
 )
 
 type Table struct {
@@ -57,6 +57,6 @@ func (t *Table) Render() string {
 }
 
 // Displays the table in the command's stdout
-func (t *Table) Display(cmd *cobra.Command) error {
-	return pager.Display(cmd, t.Render())
+func (t *Table) Display(p *print.Printer) error {
+	return pager.Display(p, t.Render())
 }


### PR DESCRIPTION
This PR updates the table.Display method to use the Printer.OutOrStdout method.

This means changing the signature of most outputResult methods from describe and list commands, since it no longer requires cmd.

With this PR, only the spinner and the confirmation prompt still rely on cmd to print.