### PR TITLE
Change config handling: only create config file & directory if needed

### DIFF
--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -37,11 +37,6 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit config list"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := viper.ReadInConfig()
-			if err != nil {
-				return fmt.Errorf("read config file: %w", err)
-			}
-
 			configData := viper.AllSettings()
 
 			// Sort the config options by key
@@ -84,7 +79,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				table.AddRow(key, valueString)
 				table.AddSeparator()
 			}
-			err = table.Display(p)
+			err := table.Display(p)
 			if err != nil {
 				return fmt.Errorf("render table: %w", err)
 			}

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -82,7 +82,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 
 			err = config.Write()
 			if err != nil {
-				return fmt.Errorf("writing config file: %w", err)
+				return fmt.Errorf("write config to file: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -80,9 +80,9 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				viper.Set(config.ProjectNameKey, "")
 			}
 
-			err = viper.WriteConfig()
+			err = config.Write()
 			if err != nil {
-				return fmt.Errorf("write new config to file: %w", err)
+				return fmt.Errorf("writing config file: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -146,7 +146,7 @@ func NewCmd() *cobra.Command {
 
 			err := config.Write()
 			if err != nil {
-				return fmt.Errorf("writing config file: %w", err)
+				return fmt.Errorf("write config to file: %w", err)
 			}
 			return nil
 		},

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -144,9 +144,9 @@ func NewCmd() *cobra.Command {
 				viper.Set(config.SKECustomEndpointKey, "")
 			}
 
-			err := viper.WriteConfig()
+			err := config.Write()
 			if err != nil {
-				return fmt.Errorf("write updated config to file: %w", err)
+				return fmt.Errorf("writing config file: %w", err)
 			}
 			return nil
 		},

--- a/internal/pkg/auth/storage.go
+++ b/internal/pkg/auth/storage.go
@@ -136,7 +136,7 @@ func GetAuthField(key authFieldKey) (string, error) {
 		var errFallback error
 		value, errFallback = getAuthFieldFromEncodedTextFile(key)
 		if errFallback != nil {
-			return "", fmt.Errorf("read from keyring failed (%w), read from encoded file also failed: %w", err, errFallback)
+			return "", fmt.Errorf("read from keyring: %w, read from encoded file as fallback: %w", err, errFallback)
 		}
 	}
 	return value, nil

--- a/internal/pkg/auth/storage.go
+++ b/internal/pkg/auth/storage.go
@@ -136,7 +136,7 @@ func GetAuthField(key authFieldKey) (string, error) {
 		var errFallback error
 		value, errFallback = getAuthFieldFromEncodedTextFile(key)
 		if errFallback != nil {
-			return "", fmt.Errorf("write to keyring failed (%w), tried write to encoded text file: %w", err, errFallback)
+			return "", fmt.Errorf("read from keyring failed (%w), read from encoded file also failed: %w", err, errFallback)
 		}
 	}
 	return value, nil

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -91,7 +91,13 @@ func InitConfig() {
 			cobra.CheckErr(err)
 		}
 	}
-	defer f.Close() //nolint:errcheck // file close errors are hard to handle
+	defer func() {
+		if f != nil {
+			if err := f.Close(); err != nil {
+				cobra.CheckErr(err)
+			}
+		}
+	}()
 
 	setConfigDefaults()
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,8 +78,6 @@ func InitConfig() {
 	configFolderPath := filepath.Join(home, configFolder)
 	configFilePath := filepath.Join(configFolderPath, fmt.Sprintf("%s.%s", configFileName, configFileExtension))
 
-	viper.SetConfigName(configFileName)
-
 	// Write config dir path to global variable
 	folderPath = configFolderPath
 
@@ -88,10 +85,13 @@ func InitConfig() {
 	// see https://github.com/spf13/viper/issues/851#issuecomment-789393451
 	viper.SetConfigFile(configFilePath)
 
-	err = viper.ReadInConfig()
-	if !errors.As(err, &viper.ConfigFileNotFoundError{}) {
-		cobra.CheckErr(err)
+	f, err := os.Open(configFilePath)
+	if !os.IsNotExist(err) {
+		if err := viper.ReadConfig(f); err != nil {
+			cobra.CheckErr(err)
+		}
 	}
+	defer f.Close() //nolint:errcheck // file close errors are hard to handle
 
 	setConfigDefaults()
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -71,7 +71,7 @@ var ConfigKeys = []string{
 	SKECustomEndpointKey,
 }
 
-var FolderPath string
+var folderPath string
 
 func InitConfig() {
 	home, err := os.UserHomeDir()
@@ -80,20 +80,18 @@ func InitConfig() {
 	configFilePath := filepath.Join(configFolderPath, fmt.Sprintf("%s.%s", configFileName, configFileExtension))
 
 	viper.SetConfigName(configFileName)
-	viper.SetConfigType(configFileExtension)
-	viper.AddConfigPath(configFolderPath)
 
 	// Write config dir path to global variable
-	FolderPath = configFolderPath
+	folderPath = configFolderPath
+
+	// This hack is required to allow creating the config file with `viper.WriteConfig`
+	// see https://github.com/spf13/viper/issues/851#issuecomment-789393451
+	viper.SetConfigFile(configFilePath)
 
 	err = viper.ReadInConfig()
 	if !errors.As(err, &viper.ConfigFileNotFoundError{}) {
 		cobra.CheckErr(err)
 	}
-
-	// This hack is required to allow creating the config file with `viper.WriteConfig`
-	// see https://github.com/spf13/viper/issues/851#issuecomment-789393451
-	viper.SetConfigFile(configFilePath)
 
 	setConfigDefaults()
 
@@ -101,10 +99,10 @@ func InitConfig() {
 	viper.SetEnvPrefix("stackit")
 }
 
-func CreateFolderIfNotExists() error {
-	_, err := os.Stat(FolderPath)
+func createFolderIfNotExists() error {
+	_, err := os.Stat(folderPath)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(FolderPath, os.ModePerm)
+		err := os.MkdirAll(folderPath, os.ModePerm)
 		if err != nil {
 			return err
 		}
@@ -116,7 +114,7 @@ func CreateFolderIfNotExists() error {
 
 // Write saves the config file (wrapping `viper.WriteConfig`) and ensures that its directory exists
 func Write() error {
-	if err := CreateFolderIfNotExists(); err != nil {
+	if err := createFolderIfNotExists(); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
 	return viper.WriteConfig()

--- a/internal/pkg/projectname/project_name.go
+++ b/internal/pkg/projectname/project_name.go
@@ -43,7 +43,7 @@ func GetProjectName(ctx context.Context, cmd *cobra.Command, p *print.Printer) (
 	// (So next time we can just pull it from there)
 	if !isProjectIdSetInFlags(cmd) {
 		viper.Set(config.ProjectNameKey, projectName)
-		err = viper.WriteConfig()
+		err = config.Write()
 		if err != nil {
 			return "", fmt.Errorf("write new config to file: %w", err)
 		}


### PR DESCRIPTION
This PR tries to solve #153 by only creating the config file & directory on commands that actually need to write the config, e.g., `set` & `unset`.

Every command that needs to write the config should now use the `config.Write` function instead of directly calling `viper.WriteConfig`. The `config.Write` function ensures that the config directory exists and creates it if necessary. Oddly, `viper` doesn't support this out of the box...

I additionally found that `viper.WriteConfig` also writes the default values (set with `viper.SetDefault`) to the config. This means that the defaults are not being used after the config file is first written. I don't think that's something we can/should easily change, but we should definitely keep it in mind that future default changes might not reach the users if they already have a config file.