### PR TITLE
Add repology packaging status badge to INSTALLATION.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -2,6 +2,8 @@
 
 ## Package managers
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/stackit-cli.svg?columns=3)](https://repology.org/project/stackit-cli/versions)
+
 ### macOS
 
 The STACKIT CLI can be installed through the [Homebrew](https://brew.sh/) package manager.


### PR DESCRIPTION
This PR adds the [repology](https://repology.org/) [packaging status badge](https://repology.org/project/stackit-cli/badges) for the STACKIT CLI to the `INSTALLATION.md`.

This allows future users to quickly see which (native/official) repositories have the STACKIT CLI packaged and enables a fast installation using their most favorite package manager.

In the future, we can increase the `columns` parameter once the list gets too long.