### PR TITLE
Improvements for `argus grafana` commands

### DIFF
--- a/docs/stackit_argus_grafana_describe.md
+++ b/docs/stackit_argus_grafana_describe.md
@@ -9,28 +9,27 @@ The Grafana dashboard URL and initial credentials (admin user and password) will
 The initial password is shown by default, if you want to hide it use the "--hide-password" flag.
 
 ```
-stackit argus grafana describe [flags]
+stackit argus grafana describe INSTANCE_ID [flags]
 ```
 
 ### Examples
 
 ```
   Get details of the Grafana configuration of an Argus instance with ID "xxx"
-  $ stackit argus credentials describe --instance-id xxx
+  $ stackit argus credentials describe xxx
 
   Get details of the Grafana configuration of an Argus instance with ID "xxx" in a table format
-  $ stackit argus credentials describe --instance-id xxx --output-format pretty
+  $ stackit argus credentials describe xxx --output-format pretty
 
   Get details of the Grafana configuration of an Argus instance with ID "xxx" and hide the initial admin password
-  $ stackit argus credentials describe --instance-id xxx --output-format pretty --hide-password
+  $ stackit argus credentials describe xxx --output-format pretty --hide-password
 ```
 
 ### Options
 
 ```
-  -h, --help                 Help for "stackit argus grafana describe"
-      --hide-password        Show the initial admin password in the "pretty" output format
-      --instance-id string   Instance ID
+  -h, --help            Help for "stackit argus grafana describe"
+      --hide-password   Show the initial admin password in the "pretty" output format
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/argus/grafana/describe/describe.go
+++ b/internal/cmd/argus/grafana/describe/describe.go
@@ -13,13 +13,14 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/argus/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/argus"
 )
 
 const (
-	instanceIdFlag   = "instance-id"
+	instanceIdArg    = "INSTANCE_ID"
 	hidePasswordFlag = "hide-password"
 )
 
@@ -31,28 +32,28 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", instanceIdArg),
 		Short: "Shows details of the Grafana configuration of an Argus instance",
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			"Shows details of the Grafana configuration of an Argus instance.",
 			`The Grafana dashboard URL and initial credentials (admin user and password) will be shown in the "pretty" output format. These credentials are only valid for first login. Please change the password after first login. After changing, the initial password is no longer valid.`,
 			`The initial password is shown by default, if you want to hide it use the "--hide-password" flag.`,
 		),
-		Args: args.NoArgs,
+		Args: args.SingleArg(instanceIdArg, utils.ValidateUUID),
 		Example: examples.Build(
 			examples.NewExample(
 				`Get details of the Grafana configuration of an Argus instance with ID "xxx"`,
-				"$ stackit argus credentials describe --instance-id xxx"),
+				"$ stackit argus credentials describe xxx"),
 			examples.NewExample(
 				`Get details of the Grafana configuration of an Argus instance with ID "xxx" in a table format`,
-				"$ stackit argus credentials describe --instance-id xxx --output-format pretty"),
+				"$ stackit argus credentials describe xxx --output-format pretty"),
 			examples.NewExample(
 				`Get details of the Grafana configuration of an Argus instance with ID "xxx" and hide the initial admin password`,
-				"$ stackit argus credentials describe --instance-id xxx --output-format pretty --hide-password"),
+				"$ stackit argus credentials describe xxx --output-format pretty --hide-password"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			model, err := parseInput(cmd)
+			model, err := parseInput(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -82,14 +83,12 @@ func NewCmd(p *print.Printer) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "Instance ID")
 	cmd.Flags().Bool(hidePasswordFlag, false, `Show the initial admin password in the "pretty" output format`)
-
-	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
-	cobra.CheckErr(err)
 }
 
-func parseInput(cmd *cobra.Command) (*inputModel, error) {
+func parseInput(cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	instanceId := inputArgs[0]
+
 	globalFlags := globalflags.Parse(cmd)
 	if globalFlags.ProjectId == "" {
 		return nil, &errors.ProjectIdError{}
@@ -97,7 +96,7 @@ func parseInput(cmd *cobra.Command) (*inputModel, error) {
 
 	return &inputModel{
 		GlobalFlagModel: globalFlags,
-		InstanceId:      flags.FlagToStringValue(cmd, instanceIdFlag),
+		InstanceId:      instanceId,
 		HidePassword:    flags.FlagToBoolValue(cmd, hidePasswordFlag),
 	}, nil
 }

--- a/internal/cmd/argus/grafana/describe/describe_test.go
+++ b/internal/cmd/argus/grafana/describe/describe_test.go
@@ -21,10 +21,19 @@ var testClient = &argus.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testInstanceId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
+
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:  testProjectId,
-		instanceIdFlag: testInstanceId,
+		projectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -72,12 +81,20 @@ func TestParseInput(t *testing.T) {
 	}{
 		{
 			description:   "base",
+			argValues:     fixtureArgValues(),
 			flagValues:    fixtureFlagValues(),
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
 		{
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
 			description: "hide password",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[hidePasswordFlag] = "true"
 			}),
@@ -94,11 +111,13 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "no flag values",
+			argValues:   fixtureArgValues(),
 			flagValues:  map[string]string{},
 			isValid:     false,
 		},
 		{
 			description: "project id missing",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, projectIdFlag)
 			}),
@@ -106,6 +125,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = ""
 			}),
@@ -113,31 +133,23 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
 		{
-			description: "instance id missing",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, instanceIdFlag)
-			}),
-			isValid: false,
-		},
-		{
 			description: "instance id invalid 1",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[instanceIdFlag] = ""
-			}),
-			isValid: false,
+			argValues:   []string{""},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
 		},
 		{
 			description: "instance id invalid 2",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[instanceIdFlag] = "invalid-uuid"
-			}),
-			isValid: false,
+			argValues:   []string{"invalid-uuid"},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
 		},
 		{
 			description: "credentials id invalid 1",
@@ -187,7 +199,7 @@ func TestParseInput(t *testing.T) {
 				t.Fatalf("error validating flags: %v", err)
 			}
 
-			model, err := parseInput(cmd)
+			model, err := parseInput(cmd, tt.argValues)
 			if err != nil {
 				if !tt.isValid {
 					return

--- a/internal/cmd/argus/grafana/single-sign-on/single_sign_on.go
+++ b/internal/cmd/argus/grafana/single-sign-on/single_sign_on.go
@@ -14,8 +14,9 @@ import (
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "single-sign-on",
-		Short: "Enable or disable single sign-on for Grafana in Argus instances",
+		Use:     "single-sign-on",
+		Aliases: []string{"sso"},
+		Short:   "Enable or disable single sign-on for Grafana in Argus instances",
 		Long: fmt.Sprintf("%s\n%s",
 			"Enable or disable single sign-on for Grafana in Argus instances.",
 			"When enabled for an instance, overwrites the generic OAuth2 authentication and configures STACKIT single sign-on for that instance.",


### PR DESCRIPTION
- Move instance ID to argument in `argus grafana describe` command
- Add `sso` alias for `single-sign-on` command