### PR TITLE
Change recovery date format for PostgresFlex clone command

### DIFF
--- a/internal/cmd/postgresflex/instance/clone/clone.go
+++ b/internal/cmd/postgresflex/instance/clone/clone.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -28,7 +27,7 @@ const (
 	storageClassFlag      = "storage-class"
 	storageSizeFlag       = "storage-size"
 	recoveryTimestampFlag = "recovery-timestamp"
-	recoveryDateFormat    = time.RFC3339
+	recoveryDateFormat    = "2006-01-02T15:04:05-07:00"
 )
 
 type inputModel struct {

--- a/internal/cmd/postgresflex/instance/clone/clone_test.go
+++ b/internal/cmd/postgresflex/instance/clone/clone_test.go
@@ -93,7 +93,7 @@ func fixtureRequiredInputModel(mods ...func(model *inputModel)) *inputModel {
 	if err != nil {
 		return &inputModel{}
 	}
-	recoveryTimestampString := testRecoveryTimestamp.Format(time.RFC3339)
+	recoveryTimestampString := testRecoveryTimestamp.Format(recoveryDateFormat)
 
 	model := &inputModel{
 		GlobalFlagModel: &globalflags.GlobalFlagModel{
@@ -114,7 +114,7 @@ func fixtureStandardInputModel(mods ...func(model *inputModel)) *inputModel {
 	if err != nil {
 		return &inputModel{}
 	}
-	recoveryTimestampString := testRecoveryTimestamp.Format(time.RFC3339)
+	recoveryTimestampString := testRecoveryTimestamp.Format(recoveryDateFormat)
 
 	model := &inputModel{
 		GlobalFlagModel: &globalflags.GlobalFlagModel{
@@ -146,7 +146,7 @@ func fixturePayload(mods ...func(payload *postgresflex.CloneInstancePayload)) po
 	if err != nil {
 		return postgresflex.CloneInstancePayload{}
 	}
-	recoveryTimestampString := testRecoveryTimestamp.Format(time.RFC3339)
+	recoveryTimestampString := testRecoveryTimestamp.Format(recoveryDateFormat)
 
 	payload := postgresflex.CloneInstancePayload{
 		Timestamp: utils.Ptr(recoveryTimestampString),
@@ -354,7 +354,7 @@ func TestBuildRequest(t *testing.T) {
 	if err != nil {
 		return
 	}
-	recoveryTimestampString := testRecoveryTimestamp.Format(time.RFC3339)
+	recoveryTimestampString := testRecoveryTimestamp.Format(recoveryDateFormat)
 
 	tests := []struct {
 		description       string


### PR DESCRIPTION
time.RFC3339 truncates the time zone, when zone is given as 00:00. 