### PR TITLE
Document config file location in command

### DIFF
--- a/docs/stackit_config.md
+++ b/docs/stackit_config.md
@@ -7,9 +7,9 @@ Provides functionality for CLI configuration options
 Provides functionality for CLI configuration options
 The configuration is stored in a file in the user's config directory, which is OS dependent.
 Windows: %APPDATA%\stackit
-Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit
+Linux: $XDG_CONFIG_HOME/stackit
 macOS: $HOME/Library/Application Support/stackit
-The configuration file is named `cli-config.json` and is created automatically when setting a configuration option.
+The configuration file is named `cli-config.json` and is created automatically in your first CLI run.
 
 ```
 stackit config [flags]

--- a/docs/stackit_config.md
+++ b/docs/stackit_config.md
@@ -4,7 +4,12 @@ Provides functionality for CLI configuration options
 
 ### Synopsis
 
-Provides functionality for CLI configuration options.
+Provides functionality for CLI configuration options
+The configuration is stored in a file in the user's config directory, which is OS dependent.
+Windows: %APPDATA%\stackit
+Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit
+macOS: $HOME/Library/Application Support/stackit
+The configuration file is named `cli-config.json` and is created automatically when setting a configuration option.
 
 ```
 stackit config [flags]

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/jedib0t/go-pretty/v6 v6.5.8
 	github.com/lmittmann/tint v1.0.4
+	github.com/mattn/go-colorable v0.1.13
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
@@ -28,10 +29,7 @@ require (
 	golang.org/x/text v0.15.0
 )
 
-require (
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
-)
+require github.com/mattn/go-isatty v0.0.17 // indirect
 
 require (
 	github.com/alessio/shellescape v1.4.2 // indirect

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -17,7 +17,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
-		Long:  fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", "Provides functionality for CLI configuration options", "The configuration is stored in a file in the user's config directory, which is OS dependent.", "Windows: %APPDATA%\\stackit", "Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit", "macOS: $HOME/Library/Application Support/stackit", "The configuration file is named `cli-config.json` and is created automatically when setting a configuration option."),
+		Long:  fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", "Provides functionality for CLI configuration options", "The configuration is stored in a file in the user's config directory, which is OS dependent.", "Windows: %APPDATA%\\stackit", "Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit", "macOS: $HOME/Library/Application Support/stackit", "The configuration file is named `cli-config.json` and is created automatically in your first CLI run."),
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/list"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/set"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/config/unset"
@@ -15,7 +17,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
-		Long:  "Provides functionality for CLI configuration options.",
+		Long:  fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", "Provides functionality for CLI configuration options", "The configuration is stored in a file in the user's config directory, which is OS dependent.", "Windows: %APPDATA%\\stackit", "Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit", "macOS: $HOME/Library/Application Support/stackit", "The configuration file is named `cli-config.json` and is created automatically when setting a configuration option."),
 		Args:  args.NoArgs,
 		Run:   utils.CmdHelp,
 	}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -17,9 +17,15 @@ func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Provides functionality for CLI configuration options",
-		Long:  fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", "Provides functionality for CLI configuration options", "The configuration is stored in a file in the user's config directory, which is OS dependent.", "Windows: %APPDATA%\\stackit", "Linux: $XDG_CONFIG_HOME/stackit or $HOME/.config/stackit", "macOS: $HOME/Library/Application Support/stackit", "The configuration file is named `cli-config.json` and is created automatically in your first CLI run."),
-		Args:  args.NoArgs,
-		Run:   utils.CmdHelp,
+		Long: fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", "Provides functionality for CLI configuration options",
+			"The configuration is stored in a file in the user's config directory, which is OS dependent.",
+			"Windows: %APPDATA%\\stackit",
+			"Linux: $XDG_CONFIG_HOME/stackit",
+			"macOS: $HOME/Library/Application Support/stackit",
+			"The configuration file is named `cli-config.json` and is created automatically in your first CLI run.",
+		),
+		Args: args.NoArgs,
+		Run:  utils.CmdHelp,
 	}
 	addSubcommands(cmd, p)
 	return cmd


### PR DESCRIPTION
Includes a `go mod tidy` that was missed in the previous PR