### PR TITLE
ref 644868 - server backup subcommands

### DIFF
--- a/docs/stackit_beta_server_backup.md
+++ b/docs/stackit_beta_server_backup.md
@@ -29,7 +29,13 @@ stackit beta server backup [flags]
 ### SEE ALSO
 
 * [stackit beta server](./stackit_beta_server.md)	 - Provides functionality for Server
+* [stackit beta server backup create](./stackit_beta_server_backup_create.md)	 - Creates a Server Backup.
+* [stackit beta server backup delete](./stackit_beta_server_backup_delete.md)	 - Deletes a Server Backup.
+* [stackit beta server backup describe](./stackit_beta_server_backup_describe.md)	 - Shows details of a Server Backup
 * [stackit beta server backup disable](./stackit_beta_server_backup_disable.md)	 - Disables Server Backup service
 * [stackit beta server backup enable](./stackit_beta_server_backup_enable.md)	 - Enables Server Backup service
+* [stackit beta server backup list](./stackit_beta_server_backup_list.md)	 - Lists all server backups
+* [stackit beta server backup restore](./stackit_beta_server_backup_restore.md)	 - Restores a Server Backup.
 * [stackit beta server backup schedule](./stackit_beta_server_backup_schedule.md)	 - Provides functionality for Server Backup Schedule
+* [stackit beta server backup volume-backup](./stackit_beta_server_backup_volume-backup.md)	 - Provides functionality for Server Backup Volume Backups
 

--- a/docs/stackit_beta_server_backup_create.md
+++ b/docs/stackit_beta_server_backup_create.md
@@ -1,0 +1,46 @@
+## stackit beta server backup create
+
+Creates a Server Backup.
+
+### Synopsis
+
+Creates a Server Backup. Operation always is async.
+
+```
+stackit beta server backup create [flags]
+```
+
+### Examples
+
+```
+  Create a Server Backup with name "mybackup"
+  $ stackit beta server backup create --server-id xxx --name=mybackup
+
+  Create a Server Backup with name "mybackup" and retention period of 5 days
+  $ stackit beta server backup create --server-id xxx --name=mybackup --retention-period=5
+```
+
+### Options
+
+```
+  -h, --help                   Help for "stackit beta server backup create"
+  -b, --name string            Backup name
+  -d, --retention-period int   Backup retention period (in days) (default 14)
+  -s, --server-id string       Server ID
+  -i, --volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+

--- a/docs/stackit_beta_server_backup_delete.md
+++ b/docs/stackit_beta_server_backup_delete.md
@@ -1,0 +1,40 @@
+## stackit beta server backup delete
+
+Deletes a Server Backup.
+
+### Synopsis
+
+Deletes a Server Backup. Operation always is async.
+
+```
+stackit beta server backup delete BACKUP_ID [flags]
+```
+
+### Examples
+
+```
+  Delete a Server Backup with ID "xxx" for server "zzz"
+  $ stackit beta server backup delete xxx --server-id=zzz
+```
+
+### Options
+
+```
+  -h, --help               Help for "stackit beta server backup delete"
+  -s, --server-id string   Server ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+

--- a/docs/stackit_beta_server_backup_describe.md
+++ b/docs/stackit_beta_server_backup_describe.md
@@ -1,0 +1,43 @@
+## stackit beta server backup describe
+
+Shows details of a Server Backup
+
+### Synopsis
+
+Shows details of a Server Backup.
+
+```
+stackit beta server backup describe BACKUP_ID [flags]
+```
+
+### Examples
+
+```
+  Get details of a Server Backup with id "my-backup-id"
+  $ stackit beta server backup describe my-backup-id
+
+  Get details of a Server Backup with id "my-backup-id" in JSON format
+  $ stackit beta server backup describe my-backup-id --output-format json
+```
+
+### Options
+
+```
+  -h, --help               Help for "stackit beta server backup describe"
+  -s, --server-id string   Server ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+

--- a/docs/stackit_beta_server_backup_list.md
+++ b/docs/stackit_beta_server_backup_list.md
@@ -1,0 +1,44 @@
+## stackit beta server backup list
+
+Lists all server backups
+
+### Synopsis
+
+Lists all server backups.
+
+```
+stackit beta server backup list [flags]
+```
+
+### Examples
+
+```
+  List all backups for a server with ID "xxx"
+  $ stackit beta server backup list --server-id xxx
+
+  List all backups for a server with ID "xxx" in JSON format
+  $ stackit beta server backup list --server-id xxx --output-format json
+```
+
+### Options
+
+```
+  -h, --help               Help for "stackit beta server backup list"
+      --limit int          Maximum number of entries to list
+  -s, --server-id string   Server ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+

--- a/docs/stackit_beta_server_backup_restore.md
+++ b/docs/stackit_beta_server_backup_restore.md
@@ -1,0 +1,45 @@
+## stackit beta server backup restore
+
+Restores a Server Backup.
+
+### Synopsis
+
+Restores a Server Backup. Operation always is async.
+
+```
+stackit beta server backup restore BACKUP_ID [flags]
+```
+
+### Examples
+
+```
+  Restore a Server Backup with ID "xxx" for server "zzz"
+  $ stackit beta server backup restore xxx --server-id=zzz
+
+  Restore a Server Backup with ID "xxx" for server "zzz" and start the server afterwards
+  $ stackit beta server backup restore xxx --server-id=zzz --start-server-after-restore
+```
+
+### Options
+
+```
+  -h, --help                         Help for "stackit beta server backup restore"
+  -s, --server-id string             Server ID
+  -u, --start-server-after-restore   Should the server start after the backup restoring.
+  -i, --volume-ids strings           Backup volume IDs, as comma separated UUID values. (default [])
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+

--- a/docs/stackit_beta_server_backup_schedule_create.md
+++ b/docs/stackit_beta_server_backup_schedule_create.md
@@ -26,7 +26,7 @@ stackit beta server backup schedule create [flags]
   -b, --backup-name string            Backup name
   -d, --backup-retention-period int   Backup retention period (in days) (default 14)
   -n, --backup-schedule-name string   Backup schedule name
-  -i, --backup-volume-ids string      Backup volume ids, as comma separated UUID values.
+  -i, --backup-volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
   -e, --enabled                       Is the server backup schedule enabled (default true)
   -h, --help                          Help for "stackit beta server backup schedule create"
   -r, --rrule string                  Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")

--- a/docs/stackit_beta_server_backup_schedule_update.md
+++ b/docs/stackit_beta_server_backup_schedule_update.md
@@ -26,7 +26,7 @@ stackit beta server backup schedule update SCHEDULE_ID [flags]
   -b, --backup-name string            Backup name
   -d, --backup-retention-period int   Backup retention period (in days) (default 14)
   -n, --backup-schedule-name string   Backup schedule name
-  -i, --backup-volume-ids string      Backup volume ids, as comma separated UUID values.
+  -i, --backup-volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
   -e, --enabled                       Is the server backup schedule enabled (default true)
   -h, --help                          Help for "stackit beta server backup schedule update"
   -r, --rrule string                  Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")

--- a/docs/stackit_beta_server_backup_volume-backup.md
+++ b/docs/stackit_beta_server_backup_volume-backup.md
@@ -1,0 +1,34 @@
+## stackit beta server backup volume-backup
+
+Provides functionality for Server Backup Volume Backups
+
+### Synopsis
+
+Provides functionality for Server Backup Volume Backups.
+
+```
+stackit beta server backup volume-backup [flags]
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit beta server backup volume-backup"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup](./stackit_beta_server_backup.md)	 - Provides functionality for Server Backup
+* [stackit beta server backup volume-backup delete](./stackit_beta_server_backup_volume-backup_delete.md)	 - Deletes a Server Volume Backup.
+* [stackit beta server backup volume-backup restore](./stackit_beta_server_backup_volume-backup_restore.md)	 - Restore a Server Volume Backup to a volume.
+

--- a/docs/stackit_beta_server_backup_volume-backup_delete.md
+++ b/docs/stackit_beta_server_backup_volume-backup_delete.md
@@ -1,0 +1,41 @@
+## stackit beta server backup volume-backup delete
+
+Deletes a Server Volume Backup.
+
+### Synopsis
+
+Deletes a Server Volume Backup. Operation always is async.
+
+```
+stackit beta server backup volume-backup delete VOLUME_BACKUP_ID [flags]
+```
+
+### Examples
+
+```
+  Delete a Server Volume Backup with ID "xxx" for server "zzz" and backup "bbb"
+  $ stackit beta server backup volume-backup delete xxx --server-id=zzz --backup-id=bbb
+```
+
+### Options
+
+```
+  -b, --backup-id string   Backup ID
+  -h, --help               Help for "stackit beta server backup volume-backup delete"
+  -s, --server-id string   Server ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup volume-backup](./stackit_beta_server_backup_volume-backup.md)	 - Provides functionality for Server Backup Volume Backups
+

--- a/docs/stackit_beta_server_backup_volume-backup_restore.md
+++ b/docs/stackit_beta_server_backup_volume-backup_restore.md
@@ -1,0 +1,42 @@
+## stackit beta server backup volume-backup restore
+
+Restore a Server Volume Backup to a volume.
+
+### Synopsis
+
+Restore a Server Volume Backup to a volume. Operation always is async.
+
+```
+stackit beta server backup volume-backup restore VOLUME_BACKUP_ID [flags]
+```
+
+### Examples
+
+```
+  Restore a Server Volume Backup with ID "xxx" for server "zzz" and backup "bbb" to volume "rrr"
+  $ stackit beta server backup volume-backup restore xxx --server-id=zzz --backup-id=bbb --restore-volume-id=rrr
+```
+
+### Options
+
+```
+  -b, --backup-id string           Backup ID
+  -h, --help                       Help for "stackit beta server backup volume-backup restore"
+  -r, --restore-volume-id string   Restore Volume ID
+  -s, --server-id string           Server ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit beta server backup volume-backup](./stackit_beta_server_backup_volume-backup.md)	 - Provides functionality for Server Backup Volume Backups
+

--- a/internal/cmd/beta/server/backup/backup.go
+++ b/internal/cmd/beta/server/backup/backup.go
@@ -1,9 +1,15 @@
 package backup
 
 import (
+	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/create"
+	del "github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/delete"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/describe"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/disable"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/enable"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/list"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/restore"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/schedule"
+	volumebackup "github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/volume-backup"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -26,5 +32,11 @@ func NewCmd(p *print.Printer) *cobra.Command {
 func addSubcommands(cmd *cobra.Command, p *print.Printer) {
 	cmd.AddCommand(enable.NewCmd(p))
 	cmd.AddCommand(disable.NewCmd(p))
+	cmd.AddCommand(describe.NewCmd(p))
+	cmd.AddCommand(list.NewCmd(p))
 	cmd.AddCommand(schedule.NewCmd(p))
+	cmd.AddCommand(create.NewCmd(p))
+	cmd.AddCommand(restore.NewCmd(p))
+	cmd.AddCommand(del.NewCmd(p))
+	cmd.AddCommand(volumebackup.NewCmd(p))
 }

--- a/internal/cmd/beta/server/backup/create/create_test.go
+++ b/internal/cmd/beta/server/backup/create/create_test.go
@@ -23,18 +23,15 @@ var testClient = &serverbackup.APIClient{}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
-var testVolumeId = uuid.NewString()
+var testBackupVolumeId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
 		projectIdFlag:             testProjectId,
 		serverIdFlag:              testServerId,
-		backupScheduleNameFlag:    "example-backup-schedule-name",
-		enabledFlag:               "true",
-		rruleFlag:                 defaultRrule,
 		backupNameFlag:            "example-backup-name",
 		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       testVolumeId,
+		backupVolumeIdsFlag:       testBackupVolumeId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -49,12 +46,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		ServerId:              testServerId,
-		BackupScheduleName:    "example-backup-schedule-name",
-		Enabled:               defaultEnabled,
-		Rrule:                 defaultRrule,
 		BackupName:            "example-backup-name",
 		BackupRetentionPeriod: int64(14),
-		BackupVolumeIds:       []string{testVolumeId},
+		BackupVolumeIds:       []string{testBackupVolumeId},
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -62,25 +56,20 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId)
-	request = request.CreateBackupSchedulePayload(fixturePayload())
+func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupRequest)) serverbackup.ApiCreateBackupRequest {
+	request := testClient.CreateBackup(testCtx, testProjectId, testServerId)
+	request = request.CreateBackupPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
 	}
 	return request
 }
 
-func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
-	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
-		},
+func fixturePayload(mods ...func(payload *serverbackup.CreateBackupPayload)) serverbackup.CreateBackupPayload {
+	payload := serverbackup.CreateBackupPayload{
+		Name:            utils.Ptr("example-backup-name"),
+		RetentionPeriod: utils.Ptr(int64(14)),
+		VolumeIds:       utils.Ptr([]string{testBackupVolumeId}),
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -188,7 +177,7 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description     string
 		model           *inputModel
-		expectedRequest serverbackup.ApiCreateBackupScheduleRequest
+		expectedRequest serverbackup.ApiCreateBackupRequest
 		isValid         bool
 	}{
 		{

--- a/internal/cmd/beta/server/backup/delete/delete.go
+++ b/internal/cmd/beta/server/backup/delete/delete.go
@@ -1,0 +1,114 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	backupIdArg  = "BACKUP_ID"
+	serverIdFlag = "server-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	BackupId string
+	ServerId string
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("delete %s", backupIdArg),
+		Short: "Deletes a Server Backup.",
+		Long:  "Deletes a Server Backup. Operation always is async.",
+		Args:  args.SingleArg(backupIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Delete a Server Backup with ID "xxx" for server "zzz"`,
+				"$ stackit beta server backup delete xxx --server-id=zzz"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to delete server backup %q? (This cannot be undone)", model.BackupId)
+				err = p.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			err = req.Execute()
+			if err != nil {
+				return fmt.Errorf("delete Server Backup: %w", err)
+			}
+
+			p.Info("Triggered deletion of server backup %q\n", model.BackupId)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	backupId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		BackupId:        backupId,
+		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDeleteBackupRequest {
+	req := apiClient.DeleteBackup(ctx, model.ProjectId, model.ServerId, model.BackupId)
+	return req
+}

--- a/internal/cmd/beta/server/backup/delete/delete_test.go
+++ b/internal/cmd/beta/server/backup/delete/delete_test.go
@@ -1,4 +1,4 @@
-package create
+package delete
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -20,21 +19,24 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &serverbackup.APIClient{}
-
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
-var testVolumeId = uuid.NewString()
+var testBackupId = uuid.NewString()
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testBackupId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:             testProjectId,
-		serverIdFlag:              testServerId,
-		backupScheduleNameFlag:    "example-backup-schedule-name",
-		enabledFlag:               "true",
-		rruleFlag:                 defaultRrule,
-		backupNameFlag:            "example-backup-name",
-		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       testVolumeId,
+		projectIdFlag: testProjectId,
+		serverIdFlag:  testServerId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -48,13 +50,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		ServerId:              testServerId,
-		BackupScheduleName:    "example-backup-schedule-name",
-		Enabled:               defaultEnabled,
-		Rrule:                 defaultRrule,
-		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
-		BackupVolumeIds:       []string{testVolumeId},
+		ServerId: testServerId,
+		BackupId: testBackupId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -62,61 +59,50 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId)
-	request = request.CreateBackupSchedulePayload(fixturePayload())
+func fixtureRequest(mods ...func(request *serverbackup.ApiDeleteBackupRequest)) serverbackup.ApiDeleteBackupRequest {
+	request := testClient.DeleteBackup(testCtx, testProjectId, testServerId, testBackupId)
 	for _, mod := range mods {
 		mod(&request)
 	}
 	return request
 }
 
-func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
-	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
-		},
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
+		argValues     []string
 		flagValues    map[string]string
-		aclValues     []string
 		isValid       bool
 		expectedModel *inputModel
 	}{
 		{
 			description:   "base",
+			argValues:     fixtureArgValues(),
 			flagValues:    fixtureFlagValues(),
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "with defaults",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, backupRetentionPeriodFlag)
-			}),
-			isValid:       true,
-			expectedModel: fixtureInputModel(),
+			description: "no values",
+			argValues:   []string{},
+			flagValues:  map[string]string{},
+			isValid:     false,
 		},
 		{
-			description: "no values",
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
 			flagValues:  map[string]string{},
 			isValid:     false,
 		},
 		{
 			description: "project id missing",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, projectIdFlag)
 			}),
@@ -124,6 +110,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = ""
 			}),
@@ -131,6 +118,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = "invalid-uuid"
 			}),
@@ -157,6 +145,14 @@ func TestParseInput(t *testing.T) {
 				}
 			}
 
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
 			err = cmd.ValidateRequiredFlags()
 			if err != nil {
 				if !tt.isValid {
@@ -165,12 +161,12 @@ func TestParseInput(t *testing.T) {
 				t.Fatalf("error validating flags: %v", err)
 			}
 
-			model, err := parseInput(p, cmd)
+			model, err := parseInput(p, cmd, tt.argValues)
 			if err != nil {
 				if !tt.isValid {
 					return
 				}
-				t.Fatalf("error parsing flags: %v", err)
+				t.Fatalf("error parsing input: %v", err)
 			}
 
 			if !tt.isValid {
@@ -188,26 +184,18 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description     string
 		model           *inputModel
-		expectedRequest serverbackup.ApiCreateBackupScheduleRequest
-		isValid         bool
+		expectedRequest serverbackup.ApiDeleteBackupRequest
 	}{
 		{
 			description:     "base",
 			model:           fixtureInputModel(),
-			isValid:         true,
 			expectedRequest: fixtureRequest(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
-			if err != nil {
-				if !tt.isValid {
-					return
-				}
-				t.Fatalf("error building request: %v", err)
-			}
+			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/beta/server/backup/describe/describe.go
+++ b/internal/cmd/beta/server/backup/describe/describe.go
@@ -1,0 +1,161 @@
+package describe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	backupIdArg  = "BACKUP_ID"
+	serverIdFlag = "server-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	ServerId string
+	BackupId string
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("describe %s", backupIdArg),
+		Short: "Shows details of a Server Backup",
+		Long:  "Shows details of a Server Backup.",
+		Args:  args.SingleArg(backupIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Get details of a Server Backup with id "my-backup-id"`,
+				"$ stackit beta server backup describe my-backup-id"),
+			examples.NewExample(
+				`Get details of a Server Backup with id "my-backup-id" in JSON format`,
+				"$ stackit beta server backup describe my-backup-id --output-format json"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd, args)
+			if err != nil {
+				return err
+			}
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("read server backup: %w", err)
+			}
+
+			return outputResult(p, model.OutputFormat, resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	backupId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
+		BackupId:        backupId,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiGetBackupRequest {
+	req := apiClient.GetBackup(ctx, model.ProjectId, model.ServerId, model.BackupId)
+	return req
+}
+
+func outputResult(p *print.Printer, outputFormat string, backup *serverbackup.Backup) error {
+	switch outputFormat {
+	case print.JSONOutputFormat:
+		details, err := json.MarshalIndent(backup, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal server backup: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	case print.YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true))
+		if err != nil {
+			return fmt.Errorf("marshal server backup: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	default:
+		table := tables.NewTable()
+		table.AddRow("ID", *backup.Id)
+		table.AddSeparator()
+		table.AddRow("NAME", *backup.Name)
+		table.AddSeparator()
+		table.AddRow("SIZE (GB)", *backup.Size)
+		table.AddSeparator()
+		table.AddRow("STATUS", *backup.Status)
+		table.AddSeparator()
+		table.AddRow("CREATED AT", *backup.CreatedAt)
+		table.AddSeparator()
+		table.AddRow("EXPIRES AT", *backup.ExpireAt)
+		table.AddSeparator()
+
+		lastRestored := ""
+		if backup.LastRestoredAt != nil {
+			lastRestored = *backup.LastRestoredAt
+		}
+		table.AddRow("LAST RESTORED AT", lastRestored)
+		table.AddSeparator()
+		table.AddRow("VOLUME BACKUPS", len(*backup.VolumeBackups))
+		table.AddSeparator()
+
+		err := table.Display(p)
+		if err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+
+		return nil
+	}
+}

--- a/internal/cmd/beta/server/backup/describe/describe_test.go
+++ b/internal/cmd/beta/server/backup/describe/describe_test.go
@@ -1,4 +1,4 @@
-package create
+package describe
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -20,21 +19,24 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &serverbackup.APIClient{}
-
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
-var testVolumeId = uuid.NewString()
+var testBackupId = uuid.NewString()
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testBackupId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:             testProjectId,
-		serverIdFlag:              testServerId,
-		backupScheduleNameFlag:    "example-backup-schedule-name",
-		enabledFlag:               "true",
-		rruleFlag:                 defaultRrule,
-		backupNameFlag:            "example-backup-name",
-		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       testVolumeId,
+		projectIdFlag: testProjectId,
+		serverIdFlag:  testServerId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -48,13 +50,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		ServerId:              testServerId,
-		BackupScheduleName:    "example-backup-schedule-name",
-		Enabled:               defaultEnabled,
-		Rrule:                 defaultRrule,
-		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
-		BackupVolumeIds:       []string{testVolumeId},
+		ServerId: testServerId,
+		BackupId: testBackupId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -62,61 +59,50 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId)
-	request = request.CreateBackupSchedulePayload(fixturePayload())
+func fixtureRequest(mods ...func(request *serverbackup.ApiGetBackupRequest)) serverbackup.ApiGetBackupRequest {
+	request := testClient.GetBackup(testCtx, testProjectId, testServerId, testBackupId)
 	for _, mod := range mods {
 		mod(&request)
 	}
 	return request
 }
 
-func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
-	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
-		},
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
+		argValues     []string
 		flagValues    map[string]string
-		aclValues     []string
 		isValid       bool
 		expectedModel *inputModel
 	}{
 		{
 			description:   "base",
+			argValues:     fixtureArgValues(),
 			flagValues:    fixtureFlagValues(),
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "with defaults",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, backupRetentionPeriodFlag)
-			}),
-			isValid:       true,
-			expectedModel: fixtureInputModel(),
+			description: "no values",
+			argValues:   []string{},
+			flagValues:  map[string]string{},
+			isValid:     false,
 		},
 		{
-			description: "no values",
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
 			flagValues:  map[string]string{},
 			isValid:     false,
 		},
 		{
 			description: "project id missing",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, projectIdFlag)
 			}),
@@ -124,6 +110,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = ""
 			}),
@@ -131,6 +118,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = "invalid-uuid"
 			}),
@@ -157,6 +145,14 @@ func TestParseInput(t *testing.T) {
 				}
 			}
 
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
 			err = cmd.ValidateRequiredFlags()
 			if err != nil {
 				if !tt.isValid {
@@ -165,7 +161,7 @@ func TestParseInput(t *testing.T) {
 				t.Fatalf("error validating flags: %v", err)
 			}
 
-			model, err := parseInput(p, cmd)
+			model, err := parseInput(p, cmd, tt.argValues)
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -188,8 +184,8 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description     string
 		model           *inputModel
-		expectedRequest serverbackup.ApiCreateBackupScheduleRequest
 		isValid         bool
+		expectedRequest serverbackup.ApiGetBackupRequest
 	}{
 		{
 			description:     "base",
@@ -201,13 +197,7 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
-			if err != nil {
-				if !tt.isValid {
-					return
-				}
-				t.Fatalf("error building request: %v", err)
-			}
+			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/beta/server/backup/list/list.go
+++ b/internal/cmd/beta/server/backup/list/list.go
@@ -1,0 +1,165 @@
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	limitFlag    = "limit"
+	serverIdFlag = "server-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	ServerId string
+	Limit    *int64
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all server backups",
+		Long:  "Lists all server backups.",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`List all backups for a server with ID "xxx"`,
+				"$ stackit beta server backup list --server-id xxx"),
+			examples.NewExample(
+				`List all backups for a server with ID "xxx" in JSON format`,
+				"$ stackit beta server backup list --server-id xxx --output-format json"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("list server backups: %w", err)
+			}
+			backups := *resp.Items
+			if len(backups) == 0 {
+				p.Info("No backups found for server %s\n", model.ServerId)
+				return nil
+			}
+
+			// Truncate output
+			if model.Limit != nil && len(backups) > int(*model.Limit) {
+				backups = backups[:*model.Limit]
+			}
+			return outputResult(p, model.OutputFormat, backups)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Int64(limitFlag, 0, "Maximum number of entries to list")
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
+	if limit != nil && *limit < 1 {
+		return nil, &errors.FlagValidationError{
+			Flag:    limitFlag,
+			Details: "must be greater than 0",
+		}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
+		Limit:           limit,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiListBackupsRequest {
+	req := apiClient.ListBackups(ctx, model.ProjectId, model.ServerId)
+	return req
+}
+
+func outputResult(p *print.Printer, outputFormat string, backups []serverbackup.Backup) error {
+	switch outputFormat {
+	case print.JSONOutputFormat:
+		details, err := json.MarshalIndent(backups, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal Server Backup list: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	case print.YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(backups, yaml.IndentSequence(true))
+		if err != nil {
+			return fmt.Errorf("marshal Server Backup list: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	default:
+		table := tables.NewTable()
+		table.SetHeader("ID", "NAME", "SIZE (GB)", "STATUS", "CREATED AT", "EXPIRES AT", "LAST RESTORED AT", "VOLUME BACKUPS")
+		for i := range backups {
+			s := backups[i]
+
+			lastRestored := ""
+			if s.LastRestoredAt != nil {
+				lastRestored = *s.LastRestoredAt
+			}
+			table.AddRow(*s.Id, *s.Name, *s.Size, *s.Status, *s.CreatedAt, *s.ExpireAt, lastRestored, len(*s.VolumeBackups))
+		}
+		err := table.Display(p)
+		if err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+		return nil
+	}
+}

--- a/internal/cmd/beta/server/backup/restore/restore.go
+++ b/internal/cmd/beta/server/backup/restore/restore.go
@@ -1,0 +1,135 @@
+package restore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	backupIdArg                 = "BACKUP_ID"
+	serverIdFlag                = "server-id"
+	startServerAfterRestoreFlag = "start-server-after-restore"
+	backupVolumeIdsFlag         = "volume-ids"
+
+	defaultStartServerAfterRestore = false
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	BackupId                string
+	ServerId                string
+	StartServerAfterRestore bool
+	BackupVolumeIds         []string
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("restore %s", backupIdArg),
+		Short: "Restores a Server Backup.",
+		Long:  "Restores a Server Backup. Operation always is async.",
+		Args:  args.SingleArg(backupIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Restore a Server Backup with ID "xxx" for server "zzz"`,
+				"$ stackit beta server backup restore xxx --server-id=zzz"),
+			examples.NewExample(
+				`Restore a Server Backup with ID "xxx" for server "zzz" and start the server afterwards`,
+				"$ stackit beta server backup restore xxx --server-id=zzz --start-server-after-restore"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to restore server backup %q? (This cannot be undone)", model.BackupId)
+				err = p.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			err = req.Execute()
+			if err != nil {
+				return fmt.Errorf("restore Server Backup: %w", err)
+			}
+
+			p.Info("Triggered restoring of server backup %q\n", model.BackupId)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+	cmd.Flags().VarP(flags.UUIDSliceFlag(), backupVolumeIdsFlag, "i", "Backup volume IDs, as comma separated UUID values.")
+	cmd.Flags().BoolP(startServerAfterRestoreFlag, "u", defaultStartServerAfterRestore, "Should the server start after the backup restoring.")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	backupId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel:         globalFlags,
+		BackupId:                backupId,
+		ServerId:                flags.FlagToStringValue(p, cmd, serverIdFlag),
+		BackupVolumeIds:         flags.FlagToStringSliceValue(p, cmd, backupVolumeIdsFlag),
+		StartServerAfterRestore: flags.FlagToBoolValue(p, cmd, startServerAfterRestoreFlag),
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiRestoreBackupRequest {
+	req := apiClient.RestoreBackup(ctx, model.ProjectId, model.ServerId, model.BackupId)
+	payload := serverbackup.RestoreBackupPayload{
+		StartServerAfterRestore: &model.StartServerAfterRestore,
+		VolumeIds:               &model.BackupVolumeIds,
+	}
+	if model.BackupVolumeIds == nil {
+		payload.VolumeIds = nil
+	}
+	req = req.RestoreBackupPayload(payload)
+	return req
+}

--- a/internal/cmd/beta/server/backup/restore/restore_test.go
+++ b/internal/cmd/beta/server/backup/restore/restore_test.go
@@ -1,4 +1,4 @@
-package create
+package restore
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -20,21 +19,24 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &serverbackup.APIClient{}
-
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
-var testVolumeId = uuid.NewString()
+var testBackupId = uuid.NewString()
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testBackupId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:             testProjectId,
-		serverIdFlag:              testServerId,
-		backupScheduleNameFlag:    "example-backup-schedule-name",
-		enabledFlag:               "true",
-		rruleFlag:                 defaultRrule,
-		backupNameFlag:            "example-backup-name",
-		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       testVolumeId,
+		projectIdFlag: testProjectId,
+		serverIdFlag:  testServerId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -48,13 +50,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		ServerId:              testServerId,
-		BackupScheduleName:    "example-backup-schedule-name",
-		Enabled:               defaultEnabled,
-		Rrule:                 defaultRrule,
-		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
-		BackupVolumeIds:       []string{testVolumeId},
+		ServerId: testServerId,
+		BackupId: testBackupId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -62,61 +59,52 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId)
-	request = request.CreateBackupSchedulePayload(fixturePayload())
+func fixtureRequest(mods ...func(request *serverbackup.ApiRestoreBackupRequest)) serverbackup.ApiRestoreBackupRequest {
+	request := testClient.RestoreBackup(testCtx, testProjectId, testServerId, testBackupId)
+	startServerAfterRestore := false
+	request = request.RestoreBackupPayload(serverbackup.RestoreBackupPayload{StartServerAfterRestore: &startServerAfterRestore})
 	for _, mod := range mods {
 		mod(&request)
 	}
 	return request
 }
 
-func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
-	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
-		},
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
+		argValues     []string
 		flagValues    map[string]string
-		aclValues     []string
 		isValid       bool
 		expectedModel *inputModel
 	}{
 		{
 			description:   "base",
+			argValues:     fixtureArgValues(),
 			flagValues:    fixtureFlagValues(),
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "with defaults",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, backupRetentionPeriodFlag)
-			}),
-			isValid:       true,
-			expectedModel: fixtureInputModel(),
+			description: "no values",
+			argValues:   []string{},
+			flagValues:  map[string]string{},
+			isValid:     false,
 		},
 		{
-			description: "no values",
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
 			flagValues:  map[string]string{},
 			isValid:     false,
 		},
 		{
 			description: "project id missing",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, projectIdFlag)
 			}),
@@ -124,6 +112,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = ""
 			}),
@@ -131,6 +120,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = "invalid-uuid"
 			}),
@@ -157,6 +147,14 @@ func TestParseInput(t *testing.T) {
 				}
 			}
 
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
 			err = cmd.ValidateRequiredFlags()
 			if err != nil {
 				if !tt.isValid {
@@ -165,12 +163,12 @@ func TestParseInput(t *testing.T) {
 				t.Fatalf("error validating flags: %v", err)
 			}
 
-			model, err := parseInput(p, cmd)
+			model, err := parseInput(p, cmd, tt.argValues)
 			if err != nil {
 				if !tt.isValid {
 					return
 				}
-				t.Fatalf("error parsing flags: %v", err)
+				t.Fatalf("error parsing input: %v", err)
 			}
 
 			if !tt.isValid {
@@ -188,26 +186,18 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description     string
 		model           *inputModel
-		expectedRequest serverbackup.ApiCreateBackupScheduleRequest
-		isValid         bool
+		expectedRequest serverbackup.ApiRestoreBackupRequest
 	}{
 		{
 			description:     "base",
 			model:           fixtureInputModel(),
-			isValid:         true,
 			expectedRequest: fixtureRequest(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
-			if err != nil {
-				if !tt.isValid {
-					return
-				}
-				t.Fatalf("error building request: %v", err)
-			}
+			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/beta/server/backup/schedule/update/update_test.go
+++ b/internal/cmd/beta/server/backup/schedule/update/update_test.go
@@ -23,6 +23,7 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &serverbackup.APIClient{}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
+var testVolumeId = uuid.NewString()
 var testBackupScheduleId = "5"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
@@ -44,7 +45,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		rruleFlag:                 defaultRrule,
 		backupNameFlag:            "example-backup-name",
 		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       defaultVolumeIds,
+		backupVolumeIdsFlag:       testVolumeId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -65,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		Rrule:                 utils.Ptr(defaultRrule),
 		BackupName:            utils.Ptr("example-backup-name"),
 		BackupRetentionPeriod: utils.Ptr(int64(14)),
-		BackupVolumeIds:       utils.Ptr(defaultVolumeIds),
+		BackupVolumeIds:       []string{testVolumeId},
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -83,7 +84,7 @@ func fixtureBackupSchedule(mods ...func(schedule *serverbackup.BackupSchedule)) 
 		BackupProperties: &serverbackup.BackupProperties{
 			Name:            utils.Ptr("example-backup-name"),
 			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       nil,
+			VolumeIds:       utils.Ptr([]string{testVolumeId}),
 		},
 	}
 	for _, mod := range mods {
@@ -100,7 +101,7 @@ func fixturePayload(mods ...func(payload *serverbackup.UpdateBackupSchedulePaylo
 		BackupProperties: &serverbackup.BackupProperties{
 			Name:            utils.Ptr("example-backup-name"),
 			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       nil,
+			VolumeIds:       utils.Ptr([]string{testVolumeId}),
 		},
 	}
 	for _, mod := range mods {

--- a/internal/cmd/beta/server/backup/volume-backup/delete/delete.go
+++ b/internal/cmd/beta/server/backup/volume-backup/delete/delete.go
@@ -1,0 +1,118 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	volumeBackupIdArg = "VOLUME_BACKUP_ID"
+	serverIdFlag      = "server-id"
+	backupIdFlag      = "backup-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	BackupId string
+	VolumeId string
+	ServerId string
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("delete %s", volumeBackupIdArg),
+		Short: "Deletes a Server Volume Backup.",
+		Long:  "Deletes a Server Volume Backup. Operation always is async.",
+		Args:  args.SingleArg(volumeBackupIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Delete a Server Volume Backup with ID "xxx" for server "zzz" and backup "bbb"`,
+				"$ stackit beta server backup volume-backup delete xxx --server-id=zzz --backup-id=bbb"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to delete server volume backup %q? (This cannot be undone)", model.VolumeId)
+				err = p.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			err = req.Execute()
+			if err != nil {
+				return fmt.Errorf("delete Server Volume Backup: %w", err)
+			}
+
+			p.Info("Triggered deletion of server volume backup %q\n", model.VolumeId)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+	cmd.Flags().VarP(flags.UUIDFlag(), backupIdFlag, "b", "Backup ID")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	volumeId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		VolumeId:        volumeId,
+		BackupId:        flags.FlagToStringValue(p, cmd, backupIdFlag),
+		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDeleteVolumeBackupRequest {
+	req := apiClient.DeleteVolumeBackup(ctx, model.ProjectId, model.ServerId, model.BackupId, model.VolumeId)
+	return req
+}

--- a/internal/cmd/beta/server/backup/volume-backup/delete/delete_test.go
+++ b/internal/cmd/beta/server/backup/volume-backup/delete/delete_test.go
@@ -1,4 +1,4 @@
-package create
+package delete
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -20,21 +19,26 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &serverbackup.APIClient{}
-
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
+var testBackupId = uuid.NewString()
 var testVolumeId = uuid.NewString()
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testVolumeId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:             testProjectId,
-		serverIdFlag:              testServerId,
-		backupScheduleNameFlag:    "example-backup-schedule-name",
-		enabledFlag:               "true",
-		rruleFlag:                 defaultRrule,
-		backupNameFlag:            "example-backup-name",
-		backupRetentionPeriodFlag: "14",
-		backupVolumeIdsFlag:       testVolumeId,
+		projectIdFlag: testProjectId,
+		serverIdFlag:  testServerId,
+		backupIdFlag:  testBackupId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -48,13 +52,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		ServerId:              testServerId,
-		BackupScheduleName:    "example-backup-schedule-name",
-		Enabled:               defaultEnabled,
-		Rrule:                 defaultRrule,
-		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
-		BackupVolumeIds:       []string{testVolumeId},
+		ServerId: testServerId,
+		VolumeId: testVolumeId,
+		BackupId: testBackupId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -62,61 +62,50 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId)
-	request = request.CreateBackupSchedulePayload(fixturePayload())
+func fixtureRequest(mods ...func(request *serverbackup.ApiDeleteVolumeBackupRequest)) serverbackup.ApiDeleteVolumeBackupRequest {
+	request := testClient.DeleteVolumeBackup(testCtx, testProjectId, testServerId, testBackupId, testVolumeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
 	return request
 }
 
-func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
-	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
-		},
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
+		argValues     []string
 		flagValues    map[string]string
-		aclValues     []string
 		isValid       bool
 		expectedModel *inputModel
 	}{
 		{
 			description:   "base",
+			argValues:     fixtureArgValues(),
 			flagValues:    fixtureFlagValues(),
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "with defaults",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, backupRetentionPeriodFlag)
-			}),
-			isValid:       true,
-			expectedModel: fixtureInputModel(),
+			description: "no values",
+			argValues:   []string{},
+			flagValues:  map[string]string{},
+			isValid:     false,
 		},
 		{
-			description: "no values",
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
 			flagValues:  map[string]string{},
 			isValid:     false,
 		},
 		{
 			description: "project id missing",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, projectIdFlag)
 			}),
@@ -124,6 +113,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 1",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = ""
 			}),
@@ -131,6 +121,7 @@ func TestParseInput(t *testing.T) {
 		},
 		{
 			description: "project id invalid 2",
+			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				flagValues[projectIdFlag] = "invalid-uuid"
 			}),
@@ -157,6 +148,14 @@ func TestParseInput(t *testing.T) {
 				}
 			}
 
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
 			err = cmd.ValidateRequiredFlags()
 			if err != nil {
 				if !tt.isValid {
@@ -165,12 +164,12 @@ func TestParseInput(t *testing.T) {
 				t.Fatalf("error validating flags: %v", err)
 			}
 
-			model, err := parseInput(p, cmd)
+			model, err := parseInput(p, cmd, tt.argValues)
 			if err != nil {
 				if !tt.isValid {
 					return
 				}
-				t.Fatalf("error parsing flags: %v", err)
+				t.Fatalf("error parsing input: %v", err)
 			}
 
 			if !tt.isValid {
@@ -188,26 +187,18 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description     string
 		model           *inputModel
-		expectedRequest serverbackup.ApiCreateBackupScheduleRequest
-		isValid         bool
+		expectedRequest serverbackup.ApiDeleteVolumeBackupRequest
 	}{
 		{
 			description:     "base",
 			model:           fixtureInputModel(),
-			isValid:         true,
 			expectedRequest: fixtureRequest(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
-			if err != nil {
-				if !tt.isValid {
-					return
-				}
-				t.Fatalf("error building request: %v", err)
-			}
+			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/beta/server/backup/volume-backup/restore/restore.go
+++ b/internal/cmd/beta/server/backup/volume-backup/restore/restore.go
@@ -1,0 +1,126 @@
+package restore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+)
+
+const (
+	volumeBackupIdArg   = "VOLUME_BACKUP_ID"
+	serverIdFlag        = "server-id"
+	backupIdFlag        = "backup-id"
+	restoreVolumeIdFlag = "restore-volume-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	VolumeBackupId  string
+	BackupId        string
+	ServerId        string
+	RestoreVolumeId string
+}
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("restore %s", volumeBackupIdArg),
+		Short: "Restore a Server Volume Backup to a volume.",
+		Long:  "Restore a Server Volume Backup to a volume. Operation always is async.",
+		Args:  args.SingleArg(volumeBackupIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Restore a Server Volume Backup with ID "xxx" for server "zzz" and backup "bbb" to volume "rrr"`,
+				"$ stackit beta server backup volume-backup restore xxx --server-id=zzz --backup-id=bbb --restore-volume-id=rrr"),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to restore volume backup %q? (This cannot be undone)", model.VolumeBackupId)
+				err = p.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			err = req.Execute()
+			if err != nil {
+				return fmt.Errorf("restore Server Volume Backup: %w", err)
+			}
+
+			p.Info("Triggered restoring of server volume backup %q\n", model.VolumeBackupId)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
+	cmd.Flags().VarP(flags.UUIDFlag(), backupIdFlag, "b", "Backup ID")
+	cmd.Flags().VarP(flags.UUIDFlag(), restoreVolumeIdFlag, "r", "Restore Volume ID")
+
+	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	volumeBackupId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		VolumeBackupId:  volumeBackupId,
+		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
+		BackupId:        flags.FlagToStringValue(p, cmd, backupIdFlag),
+		RestoreVolumeId: flags.FlagToStringValue(p, cmd, restoreVolumeIdFlag),
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiRestoreVolumeBackupRequest {
+	req := apiClient.RestoreVolumeBackup(ctx, model.ProjectId, model.ServerId, model.BackupId, model.VolumeBackupId)
+	payload := serverbackup.RestoreVolumeBackupPayload{
+		RestoreVolumeId: &model.RestoreVolumeId,
+	}
+	req = req.RestoreVolumeBackupPayload(payload)
+	return req
+}

--- a/internal/cmd/beta/server/backup/volume-backup/volumebackup.go
+++ b/internal/cmd/beta/server/backup/volume-backup/volumebackup.go
@@ -1,0 +1,28 @@
+package volumebackup
+
+import (
+	del "github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/volume-backup/delete"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/beta/server/backup/volume-backup/restore"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(p *print.Printer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "volume-backup",
+		Short: "Provides functionality for Server Backup Volume Backups",
+		Long:  "Provides functionality for Server Backup Volume Backups.",
+		Args:  args.NoArgs,
+		Run:   utils.CmdHelp,
+	}
+	addSubcommands(cmd, p)
+	return cmd
+}
+
+func addSubcommands(cmd *cobra.Command, p *print.Printer) {
+	cmd.AddCommand(del.NewCmd(p))
+	cmd.AddCommand(restore.NewCmd(p))
+}


### PR DESCRIPTION
adds various `server backup` subcommands

Testing Done:
* tested locally
* ran linters / formatters / `make test` / `make generate-docs`