### PR TITLE
feat: Update golangci-lint version to 1.62.0 and go version to 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request, workflow_dispatch]
 
 env:
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.23"
 
 jobs:
   main:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackitcloud/stackit-cli
 
-go 1.22
+go 1.23
 
 require (
 	github.com/fatih/color v1.18.0

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -14,13 +14,12 @@ linters-settings:
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/freiheit-com/nmww
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/stretchr/testify
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - github.com/stretchr/testify: "do not use a testing framework"
+    rules:
+      main:
+        list-mode: lax # Everything is allowed unless it is denied
+        deny:
+          - pkg: "github.com/stretchr/testify"
+            desc: Do not use a testing framework
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -75,7 +74,6 @@ linters:
     - unused
     # additional linters
     - errorlint
-    - exportloopref
     - gochecknoinits
     - gocritic
     - gofmt
@@ -91,9 +89,6 @@ linters:
     - forcetypeassert
     - errcheck
   disable:
-    - structcheck # deprecated
-    - deadcode # deprecated
-    - varcheck # deprecated
     - noctx # false positive: finds errors with http.NewRequest that dont make sense
     - unparam # false positives
 issues:

--- a/internal/cmd/auth/activate-service-account/activate_service_account.go
+++ b/internal/cmd/auth/activate-service-account/activate_service_account.go
@@ -51,7 +51,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Activate service account authentication in the STACKIT CLI using the service account token`,
 				"$ stackit auth activate-service-account --service-account-token my-service-account-token"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			model := parseInput(p, cmd)
 
 			tokenCustomEndpoint, err := storeFlags()

--- a/internal/cmd/auth/login/login.go
+++ b/internal/cmd/auth/login/login.go
@@ -24,7 +24,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Login to the STACKIT CLI. This command will open a browser window where you can login to your STACKIT account`,
 				"$ stackit auth login"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			err := auth.AuthorizeUser(p, false)
 			if err != nil {
 				return fmt.Errorf("authorization failed: %w", err)

--- a/internal/cmd/auth/logout/logout.go
+++ b/internal/cmd/auth/logout/logout.go
@@ -22,7 +22,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Log out of the STACKIT CLI.`,
 				"$ stackit auth logout"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			err := auth.LogoutUser()
 			if err != nil {
 				return fmt.Errorf("log out failed: %w", err)

--- a/internal/cmd/beta/network-area/create/create.go
+++ b/internal/cmd/beta/network-area/create/create.go
@@ -63,7 +63,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`$ stackit beta network-area create --name network-area-3 --organization-id xxx --network-ranges "1.1.1.0/24,192.123.1.0/24" --transfer-network "192.160.0.0/24" --default-prefix-length 25 --max-prefix-length 29 --min-prefix-length 24`,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network-area/list/list.go
+++ b/internal/cmd/beta/network-area/list/list.go
@@ -52,7 +52,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta network-area list --organization-id xxx --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network-area/network-range/create/create.go
+++ b/internal/cmd/beta/network-area/network-range/create/create.go
@@ -43,7 +43,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`$ stackit beta network-area network-range create --network-area-id xxx --organization-id yyy --network-range "1.1.1.0/24"`,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network-area/network-range/list/list.go
+++ b/internal/cmd/beta/network-area/network-range/list/list.go
@@ -53,7 +53,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta network-area network-range list --network-area-id xxx --organization-id yyy --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network-area/route/create/create.go
+++ b/internal/cmd/beta/network-area/route/create/create.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta network-area route create --labels key=value,foo=bar --organization-id yyy --network-area-id xxx --prefix 1.1.1.0/24 --next-hop 1.1.1.1",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network-area/route/list/list.go
+++ b/internal/cmd/beta/network-area/route/list/list.go
@@ -53,7 +53,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta network-area route list --network-area-id xxx --organization-id yyy --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network/create/create.go
+++ b/internal/cmd/beta/network/create/create.go
@@ -58,7 +58,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`$ stackit beta network create --name network-1  --ipv6-dns-name-servers "2001:4860:4860::8888,2001:4860:4860::8844" --ipv6-prefix-length 56`,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/network/list/list.go
+++ b/internal/cmd/beta/network/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta network list --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/backup/create/create.go
+++ b/internal/cmd/beta/server/backup/create/create.go
@@ -50,7 +50,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a Server Backup with name "mybackup" and retention period of 5 days`,
 				`$ stackit beta server backup create --server-id xxx --name=mybackup --retention-period=5`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/beta/server/backup/disable/disable.go
+++ b/internal/cmd/beta/server/backup/disable/disable.go
@@ -37,7 +37,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Disable Server Backup functionality for your server.`,
 				"$ stackit beta server backup disable --server-id=zzz"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/backup/enable/enable.go
+++ b/internal/cmd/beta/server/backup/enable/enable.go
@@ -37,7 +37,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Enable Server Backup functionality for your server`,
 				"$ stackit beta server backup enable --server-id=zzz"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/backup/list/list.go
+++ b/internal/cmd/beta/server/backup/list/list.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all backups for a server with ID "xxx" in JSON format`,
 				"$ stackit beta server backup list --server-id xxx --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/backup/schedule/create/create.go
+++ b/internal/cmd/beta/server/backup/schedule/create/create.go
@@ -58,7 +58,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a Server Backup Schedule with name "myschedule", backup name "mybackup" and retention period of 5 days`,
 				`$ stackit beta server backup schedule create --server-id xxx --backup-name=mybackup --backup-schedule-name=myschedule --backup-retention-period=5`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/beta/server/backup/schedule/list/list.go
+++ b/internal/cmd/beta/server/backup/schedule/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all backup schedules for a server with ID "xxx" in JSON format`,
 				"$ stackit beta server backup schedule list --server-id xxx --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/command/create/create.go
+++ b/internal/cmd/beta/server/command/create/create.go
@@ -47,7 +47,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a server command for server with ID "xxx", template name "RunShellScript" and a script provided on the command line`,
 				`$ stackit beta server command create --server-id xxx --template-name=RunShellScript --params script='echo hello'`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/beta/server/command/list/list.go
+++ b/internal/cmd/beta/server/command/list/list.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all commands for a server with ID "xxx" in JSON format`,
 				"$ stackit beta server command list --server-id xxx --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/server/command/template/list/list.go
+++ b/internal/cmd/beta/server/command/template/list/list.go
@@ -44,7 +44,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all commands templates in JSON format`,
 				"$ stackit beta server command template list --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/sqlserverflex/database/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 SQLServer Flex databases of instance with ID "xxx"`,
 				"$ stackit beta sqlserverflex database list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -71,7 +71,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a SQLServer Flex instance with name "my-instance", specify flavor by CPU and RAM, set storage size to 20 GB, and restrict access to a specific range of IP addresses. Other parameters are set to default values`,
 				`$ stackit beta sqlserverflex instance create --name my-instance --cpu 1 --ram 4 --storage-size 20  --acl 1.2.3.0/24`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/beta/sqlserverflex/instance/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 SQLServer Flex instances`,
 				"$ stackit beta sqlserverflex instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/sqlserverflex/options/options.go
+++ b/internal/cmd/beta/sqlserverflex/options/options.go
@@ -93,7 +93,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List SQL Server Flex user roles and database compatibilities for a given instance. The IDs of existing instances can be obtained by running "$ stackit beta sqlserverflex instance list"`,
 				"$ stackit beta sqlserverflex options --user-roles --db-compatibilities --instance-id <INSTANCE_ID>"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`$ stackit beta sqlserverflex user create --instance-id xxx --username johndoe --roles "##STACKIT_LoginManager##,##STACKIT_DatabaseManager##"`),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/sqlserverflex/user/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta sqlserverflex user list --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/volume/create/create.go
+++ b/internal/cmd/beta/volume/create/create.go
@@ -69,7 +69,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`$ stackit beta volume create --availability-zone eu01-1 --performance-class storage_premium_perf1 --size 64`,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/volume/list/list.go
+++ b/internal/cmd/beta/volume/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta volume list --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/beta/volume/performance-class/list/list.go
+++ b/internal/cmd/beta/volume/performance-class/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit beta volume performance-class list --limit 10",
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/config/list/list.go
+++ b/internal/cmd/config/list/list.go
@@ -47,7 +47,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List your active configuration in a json format`,
 				"$ stackit config list --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			configData := viper.AllSettings()
 
 			model := parseInput(p, cmd)

--- a/internal/cmd/config/profile/list/list.go
+++ b/internal/cmd/config/profile/list/list.go
@@ -34,7 +34,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List the configuration profiles in a json format`,
 				"$ stackit config profile list --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			model := parseInput(p, cmd)
 
 			profiles, err := config.ListProfiles()

--- a/internal/cmd/config/profile/unset/unset.go
+++ b/internal/cmd/config/profile/unset/unset.go
@@ -26,7 +26,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Unset the currently active configuration profile. The default profile will be used.`,
 				"$ stackit config profile unset"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			err := config.UnsetProfile(p)
 			if err != nil {
 				return fmt.Errorf("unset profile: %w", err)

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -74,7 +74,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Set the DNS custom endpoint. This endpoint will be used on all calls to the DNS API (unless overridden by the "STACKIT_DNS_CUSTOM_ENDPOINT" environment variable)`,
 				"$ stackit config set --dns-custom-endpoint https://dns.stackit.cloud"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			model, err := parseInput(p, cmd)
 			if err != nil {
 				return err

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -101,7 +101,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Unset the DNS custom endpoint stored in your configuration`,
 				"$ stackit config unset --dns-custom-endpoint"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			model := parseInput(p, cmd)
 
 			if model.Async {

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -54,7 +54,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a DNS record set with name "my-rr" with records "1.2.3.4" and "5.6.7.8" in zone with ID "xxx"`,
 				"$ stackit dns record-set create --zone-id xxx --name my-rr --record 1.2.3.4 --record 5.6.7.8"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/dns/record-set/list/list.go
+++ b/internal/cmd/dns/record-set/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -31,6 +32,7 @@ const (
 	limitFlag       = "limit"
 	pageSizeFlag    = "page-size"
 
+	defaultPage          = 1
 	pageSizeDefault      = 100
 	deleteSucceededState = "DELETE_SUCCEEDED"
 )
@@ -71,7 +73,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List the deleted DNS record-sets for zone with ID "xxx"`,
 				"$ stackit dns record-set list --zone-id xxx --deleted"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {
@@ -193,8 +195,20 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient dnsClient, p
 	if model.OrderByName != nil {
 		req = req.OrderByName(strings.ToUpper(*model.OrderByName))
 	}
-	req = req.PageSize(int32(model.PageSize))
-	req = req.Page(int32(page))
+
+	// check integer overflows
+	if model.PageSize > math.MaxInt32 || model.PageSize < math.MinInt32 {
+		req = req.PageSize(pageSizeDefault)
+	} else {
+		req = req.PageSize(int32(model.PageSize))
+	}
+
+	if page > math.MaxInt32 || page < math.MinInt32 {
+		req = req.Page(defaultPage)
+	} else {
+		req = req.Page(int32(page))
+	}
+
 	return req
 }
 

--- a/internal/cmd/dns/record-set/list/list_test.go
+++ b/internal/cmd/dns/record-set/list/list_test.go
@@ -489,7 +489,7 @@ func TestFetchRecordSets(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && tt.apiCallFails {
+			if tt.apiCallFails {
 				t.Fatalf("did not fail on invalid input")
 			}
 			if numAPICalls != tt.expectedNumAPICalls {

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -68,7 +68,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a DNS zone with name "my-zone", DNS name "www.my-zone.com" and default time to live of 1000ms`,
 				"$ stackit dns zone create --name my-zone --dns-name www.my-zone.com --default-ttl 1000"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/dns/zone/list/list_test.go
+++ b/internal/cmd/dns/zone/list/list_test.go
@@ -483,7 +483,7 @@ func TestFetchZones(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && tt.apiCallFails {
+			if tt.apiCallFails {
 				t.Fatalf("did not fail on invalid input")
 			}
 			if numAPICalls != tt.expectedNumAPICalls {

--- a/internal/cmd/load-balancer/create/create.go
+++ b/internal/cmd/load-balancer/create/create.go
@@ -59,7 +59,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`<Modify payload in file>`,
 				`$ stackit load-balancer create --payload @./payload.json`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/generate-payload/generate_payload.go
+++ b/internal/cmd/load-balancer/generate-payload/generate_payload.go
@@ -133,7 +133,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Generate a payload with values of an existing load balancer, and preview it in the terminal`,
 				`$ stackit load-balancer generate-payload --lb-name xxx`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/list/list.go
+++ b/internal/cmd/load-balancer/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 load balancers `,
 				"$ stackit load-balancer list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/observability-credentials/add/add.go
+++ b/internal/cmd/load-balancer/observability-credentials/add/add.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Add observability credentials to a load balancer with username "xxx" and display name "yyy", providing the path to a file with the password as flag`,
 				"$ stackit load-balancer observability-credentials add --username xxx --password @./password.txt --display-name yyy"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
+++ b/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
@@ -32,7 +32,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Delete observability credentials unused by any Load Balancer`,
 				"$ stackit load-balancer observability-credentials cleanup"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Load Balancer observability credentials`,
 				"$ stackit load-balancer observability-credentials list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/load-balancer/quota/quota.go
+++ b/internal/cmd/load-balancer/quota/quota.go
@@ -33,7 +33,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Get the configured load balancer quota for the project`,
 				"$ stackit load-balancer quota"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/logme/credentials/create/create.go
+++ b/internal/cmd/logme/credentials/create/create.go
@@ -44,7 +44,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for a LogMe instance and show the password in the output`,
 				"$ stackit logme credentials create --instance-id xxx --show-password"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/logme/credentials/list/list.go
+++ b/internal/cmd/logme/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials' IDs for a LogMe instance`,
 				"$ stackit logme credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/logme/instance/create/create.go
+++ b/internal/cmd/logme/instance/create/create.go
@@ -72,7 +72,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a LogMe instance with name "my-instance" and specify IP range which is allowed to access it`,
 				"$ stackit logme instance create --name my-instance --plan-id xxx --acl 1.2.3.0/24"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 LogMe instances`,
 				"$ stackit logme instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/logme/plans/plans.go
+++ b/internal/cmd/logme/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 LogMe service plans`,
 				"$ stackit logme plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for a MariaDB instance and show the password in the output`,
 				"$ stackit mariadb credentials create --instance-id xxx --show-password"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials' IDs for a MariaDB instance`,
 				"$ stackit mariadb credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -72,7 +72,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a MariaDB instance with name "my-instance" and specify IP range which is allowed to access it`,
 				"$ stackit mariadb instance create --name my-instance --plan-id xxx --acl 1.2.3.0/24"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 MariaDB instances`,
 				"$ stackit mariadb instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 MariaDB service plans`,
 				"$ stackit mariadb plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/backup/list/list.go
+++ b/internal/cmd/mongodbflex/backup/list/list.go
@@ -50,7 +50,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit mongodbflex backup list --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit mongodbflex backup restore-jobs --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/backup/restore/restore.go
+++ b/internal/cmd/mongodbflex/backup/restore/restore.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Restore a MongoDB Flex instance with ID "yyy", using backup from instance with ID "zzz" with backup ID "xxx"`,
 				`$ stackit mongodbflex backup restore --instance-id zzz --backup-instance-id yyy --backup-id xxx`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/mongodbflex/backup/schedule/schedule.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule.go
@@ -42,7 +42,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Get details of the backup schedule of a MongoDB Flex instance with ID "xxx" in JSON format`,
 				"$ stackit mongodbflex backup schedule --instance-id xxx --output-format json"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
+++ b/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
@@ -66,7 +66,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit mongodbflex backup update-schedule --instance-id xxx --store-for-days 5"),
 		),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -74,7 +74,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a MongoDB Flex instance with name "my-instance", allow access to a specific range of IP addresses, specify flavor by CPU and RAM and set storage size to 20 GB. Other parameters are set to default values`,
 				`$ stackit mongodbflex instance create --name my-instance --cpu 1 --ram 4 --acl 1.2.3.0/24 --storage-size 20`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 MongoDB Flex instances`,
 				"$ stackit mongodbflex instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List MongoDB Flex storage options for a given flavor. The flavor ID can be retrieved by running "$ stackit mongodbflex options --flavors"`,
 				"$ stackit mongodbflex options --storages --flavor-id <FLAVOR_ID>"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -57,7 +57,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit mongodbflex user create --instance-id xxx --role read --database default"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit mongodbflex user list --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/bucket/list/list.go
+++ b/internal/cmd/object-storage/bucket/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Object Storage buckets`,
 				"$ stackit object-storage bucket list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/credentials-group/create/create.go
+++ b/internal/cmd/object-storage/credentials-group/create/create.go
@@ -39,7 +39,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials group to hold Object Storage access credentials`,
 				"$ stackit object-storage credentials-group create --name example"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials groups`,
 				"$ stackit object-storage credentials-group list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/credentials/create/create.go
+++ b/internal/cmd/object-storage/credentials/create/create.go
@@ -47,7 +47,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for a credentials group with ID "xxx", including a specific expiration date`,
 				"$ stackit object-storage credentials create --credentials-group-id xxx --expire-date 2024-03-06T00:00:00.000Z"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/credentials/list/list.go
+++ b/internal/cmd/object-storage/credentials/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials for a credentials group with ID "xxx"`,
 				"$ stackit object-storage credentials list --credentials-group-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/disable/disable.go
+++ b/internal/cmd/object-storage/disable/disable.go
@@ -31,7 +31,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Disable Object Storage functionality for your project.`,
 				"$ stackit object-storage disable"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/object-storage/enable/enable.go
+++ b/internal/cmd/object-storage/enable/enable.go
@@ -31,7 +31,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Enable Object Storage functionality for your project`,
 				"$ stackit object-storage enable"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/credentials/create/create.go
+++ b/internal/cmd/observability/credentials/create/create.go
@@ -41,7 +41,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for Observability instance with ID "xxx"`,
 				"$ stackit observability credentials create --instance-id xxx"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/credentials/list/list.go
+++ b/internal/cmd/observability/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List the usernames of up to 10 credentials for an Observability instance`,
 				"$ stackit observability credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/instance/create/create.go
+++ b/internal/cmd/observability/instance/create/create.go
@@ -51,7 +51,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create an Observability instance with name "my-instance" and specify plan by ID`,
 				"$ stackit observability instance create --name my-instance --plan-id xxx"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/instance/list/list.go
+++ b/internal/cmd/observability/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Observability instances`,
 				"$ stackit observability instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/plans/plans.go
+++ b/internal/cmd/observability/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Observability service plans`,
 				"$ stackit observability plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/scrape-config/create/create.go
+++ b/internal/cmd/observability/scrape-config/create/create.go
@@ -58,7 +58,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`<Modify payload in file, if needed>`,
 				`$ stackit observability scrape-config create --payload @./payload.json --instance-id xxx`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/scrape-config/generate-payload/generate_payload.go
+++ b/internal/cmd/observability/scrape-config/generate-payload/generate_payload.go
@@ -59,7 +59,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Generate an Update payload with the values of an existing configuration named "my-config" for Observability instance xxx, and preview it in the terminal`,
 				`$ stackit observability scrape-config generate-payload --job-name my-config --instance-id xxx`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/observability/scrape-config/list/list.go
+++ b/internal/cmd/observability/scrape-config/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 scrape configurations of Observability instance "xxx"`,
 				"$ stackit observability scrape-config list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for an OpenSearch instance and show the password in the output`,
 				"$ stackit opensearch credentials create --instance-id xxx --show-password"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials' IDs for an OpenSearch instance`,
 				"$ stackit opensearch credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/opensearch/instance/create/create.go
+++ b/internal/cmd/opensearch/instance/create/create.go
@@ -74,7 +74,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create an OpenSearch instance with name "my-instance" and specify IP range which is allowed to access it`,
 				"$ stackit opensearch instance create --name my-instance --plan-id xxx --acl 1.2.3.0/24"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 OpenSearch instances`,
 				"$ stackit opensearch instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 OpenSearch service plans`,
 				"$ stackit opensearch plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 members of an organization`,
 				"$ stackit organization member list --organization-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -50,7 +50,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 roles and permissions of an organization`,
 				"$ stackit organization role list --organization-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/backup/list/list.go
+++ b/internal/cmd/postgresflex/backup/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit postgresflex backup list --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/backup/update-schedule/update_schedule.go
+++ b/internal/cmd/postgresflex/backup/update-schedule/update_schedule.go
@@ -40,7 +40,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit postgresflex backup update-schedule --instance-id xxx --schedule '6 6 * * *'"),
 		),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/postgresflex/instance/create/create.go
+++ b/internal/cmd/postgresflex/instance/create/create.go
@@ -74,7 +74,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a PostgreSQL Flex instance with name "my-instance", allow access to a specific range of IP addresses, specify flavor by CPU and RAM and set storage size to 20 GB. Other parameters are set to default values`,
 				`$ stackit postgresflex instance create --name my-instance --cpu 2 --ram 4 --acl 1.2.3.0/24 --storage-size 20`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 PostgreSQL Flex instances`,
 				"$ stackit postgresflex instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/options/options.go
+++ b/internal/cmd/postgresflex/options/options.go
@@ -62,7 +62,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List PostgreSQL Flex storage options for a given flavor. The flavor ID can be retrieved by running "$ stackit postgresflex options --flavors"`,
 				"$ stackit postgresflex options --storages --flavor-id <FLAVOR_ID>"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -56,7 +56,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit postgresflex user create --instance-id xxx --username johndoe --role createdb"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/user/list/list.go
+++ b/internal/cmd/postgresflex/user/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit postgresflex user list --instance-id xxx --limit 10"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/postgresflex/user/update/update_test.go
+++ b/internal/cmd/postgresflex/user/update/update_test.go
@@ -227,7 +227,7 @@ func TestBuildRequest(t *testing.T) {
 	}{
 		{
 			description:     "base",
-			model:           fixtureInputModel(func(model *inputModel) {}),
+			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
 		},
 	}

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -64,7 +64,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a STACKIT project with a network area`,
 				"$ stackit project create --parent-id xxxx --name my-project --network-area-id yyyy"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/project/delete/delete.go
+++ b/internal/cmd/project/delete/delete.go
@@ -34,7 +34,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Delete a STACKIT project by explicitly providing the project ID`,
 				"$ stackit project delete --project-id xxx"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {
@@ -69,7 +69,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			}
 
 			p.Info("Deleted project %q\n", projectLabel)
-			p.Warn(fmt.Sprintf("%s\n%s\n",
+			p.Warn("%s", fmt.Sprintf("%s\n%s\n",
 				"If this was your default project, consider configuring a new project ID by running:",
 				"  $ stackit config set --project-id <PROJECT_ID>",
 			))

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -63,7 +63,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all STACKIT projects that a certain user is a member of`,
 				"$ stackit project list --member example@email.com"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/project/list/list_test.go
+++ b/internal/cmd/project/list/list_test.go
@@ -483,7 +483,7 @@ func TestFetchProjects(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && tt.apiCallFails {
+			if tt.apiCallFails {
 				t.Fatalf("did not fail on invalid input")
 			}
 			if numAPICalls != tt.expectedNumAPICalls {

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -54,7 +54,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 members of a project`,
 				"$ stackit project member list --project-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 roles and permissions of a project`,
 				"$ stackit project role list --project-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/project/update/update.go
+++ b/internal/cmd/project/update/update.go
@@ -53,7 +53,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Update the name of a STACKIT project by explicitly providing the project ID`,
 				"$ stackit project update --name my-updated-project --project-id xxx"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/rabbitmq/credentials/create/create.go
+++ b/internal/cmd/rabbitmq/credentials/create/create.go
@@ -44,7 +44,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for a RabbitMQ instance and show the password in the output`,
 				"$ stackit rabbitmq credentials create --instance-id xxx --show-password"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/rabbitmq/credentials/list/list.go
+++ b/internal/cmd/rabbitmq/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials' IDs for a RabbitMQ instance`,
 				"$ stackit rabbitmq credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/rabbitmq/instance/create/create.go
+++ b/internal/cmd/rabbitmq/instance/create/create.go
@@ -74,7 +74,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a RabbitMQ instance with name "my-instance" and specify IP range which is allowed to access it`,
 				"$ stackit rabbitmq instance create --name my-instance --plan-id xxx --acl 1.2.3.0/24"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/rabbitmq/instance/list/list.go
+++ b/internal/cmd/rabbitmq/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 RabbitMQ instances`,
 				"$ stackit rabbitmq instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/rabbitmq/plans/plans.go
+++ b/internal/cmd/rabbitmq/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 RabbitMQ service plans`,
 				"$ stackit rabbitmq plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/redis/credentials/create/create.go
+++ b/internal/cmd/redis/credentials/create/create.go
@@ -45,7 +45,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create credentials for a Redis instance and show the password in the output`,
 				"$ stackit redis credentials create --instance-id xxx --show-password"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/redis/credentials/list/list.go
+++ b/internal/cmd/redis/credentials/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 credentials' IDs for a Redis instance`,
 				"$ stackit redis credentials list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/redis/instance/create/create.go
+++ b/internal/cmd/redis/instance/create/create.go
@@ -72,7 +72,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a Redis instance with name "my-instance" and specify IP range which is allowed to access it`,
 				"$ stackit redis instance create --name my-instance --plan-id xxx --acl 1.2.3.0/24"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/redis/instance/list/list.go
+++ b/internal/cmd/redis/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Redis instances`,
 				"$ stackit redis instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/redis/plans/plans.go
+++ b/internal/cmd/redis/plans/plans.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Redis service plans`,
 				"$ stackit redis plans --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,7 +46,7 @@ func NewRootCmd(version, date string, p *print.Printer) *cobra.Command {
 		SilenceErrors:     true, // Error is beautified in a custom way before being printed
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			p.Cmd = cmd
 			p.Verbosity = print.Level(globalflags.Parse(p, cmd).Verbosity)
 
@@ -82,7 +82,7 @@ func NewRootCmd(version, date string, p *print.Printer) *cobra.Command {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if flags.FlagToBoolValue(p, cmd, "version") {
 				p.Outputf("STACKIT CLI (beta)\n")
 
@@ -187,7 +187,7 @@ func Execute(version, date string) {
 	if err != nil {
 		err := beautifyUnknownAndMissingCommandsError(cmd, err)
 		p.Debug(print.ErrorLevel, "execute command: %v", err)
-		p.Error(err.Error())
+		p.Error("%s", err.Error())
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a Secrets Manager instance with name "my-instance" and specify IP range which is allowed to access it`,
 				`$ stackit secrets-manager instance create --name my-instance --acl 1.2.3.0/24`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			model, err := parseInput(p, cmd)

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -46,7 +46,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Secrets Manager instances`,
 				"$ stackit secrets-manager instance list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -52,7 +52,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ stackit secrets-manager user create --instance-id xxx --write"),
 		),
 		Args: args.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 Secrets Manager users with ID "xxx"`,
 				"$ stackit secrets-manager user list --instance-id xxx --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -39,7 +39,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a service account with name "my-service-account"`,
 				"$ stackit service-account create --name my-service-account"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -54,7 +54,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a key for the service account with email "my-service-account-1234567@sa.stackit.cloud" and provide the public key in a .pem file"`,
 				`$ stackit service-account key create --email my-service-account-1234567@sa.stackit.cloud --public-key @./public.pem`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -48,7 +48,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 keys belonging to the service account with email "my-service-account-1234567@sa.stackit.cloud"`,
 				"$ stackit service-account key list --email my-service-account-1234567@sa.stackit.cloud --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/key/update/update.go
+++ b/internal/cmd/service-account/key/update/update.go
@@ -90,7 +90,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("marshal key: %w", err)
 			}
-			p.Info(string(key))
+			p.Info("%s", string(key))
 			return nil
 		},
 	}

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -40,7 +40,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List all service accounts`,
 				"$ stackit service-account list"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -50,7 +50,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create an access token for the service account with email "my-service-account-1234567@sa.stackit.cloud" with a time to live of 10 days`,
 				"$ stackit service-account token create --email my-service-account-1234567@sa.stackit.cloud --ttl-days 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -52,7 +52,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 access tokens of the service account with email "my-service-account-1234567@sa.stackit.cloud"`,
 				"$ stackit service-account token list --email my-service-account-1234567@sa.stackit.cloud --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/cluster/generate-payload/generate_payload.go
+++ b/internal/cmd/ske/cluster/generate-payload/generate_payload.go
@@ -54,7 +54,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Generate a payload with values of a cluster, and preview it in the terminal`,
 				`$ stackit ske cluster generate-payload --cluster-name my-cluster`),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -47,7 +47,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List up to 10 SKE clusters`,
 				"$ stackit ske cluster list --limit 10"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -33,7 +33,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Get details regarding SKE functionality on your project`,
 				"$ stackit ske describe"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -34,7 +34,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Disable SKE functionality for your project, deleting all associated clusters`,
 				"$ stackit ske disable"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -34,7 +34,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Enable SKE functionality for your project`,
 				"$ stackit ske enable"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/cmd/ske/kubeconfig/login/login.go
+++ b/internal/cmd/ske/kubeconfig/login/login.go
@@ -54,7 +54,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				"$ kubectl cluster-info",
 				"$ kubectl get pods"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			if err := cache.Init(); err != nil {
@@ -223,7 +223,7 @@ func output(p *print.Printer, cacheKey string, kubeconfig *rest.Config) error {
 		return fmt.Errorf("marshal ExecCredential: %w", err)
 	}
 
-	p.Outputf(string(output))
+	p.Outputf("%s", string(output))
 	return nil
 }
 

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -56,7 +56,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`List SKE options regarding Kubernetes versions and machine images`,
 				"$ stackit ske options --kubernetes-versions --machine-images"),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			model, err := parseInput(p, cmd)
 			if err != nil {

--- a/internal/pkg/args/args_test.go
+++ b/internal/pkg/args/args_test.go
@@ -53,7 +53,7 @@ func TestSingleArg(t *testing.T) {
 		{
 			description: "valid",
 			args:        []string{"arg"},
-			validateFunc: func(value string) error {
+			validateFunc: func(_ string) error {
 				return nil
 			},
 			isValid: true,
@@ -76,7 +76,7 @@ func TestSingleArg(t *testing.T) {
 		{
 			description: "invalid_arg",
 			args:        []string{"arg"},
-			validateFunc: func(value string) error {
+			validateFunc: func(_ string) error {
 				return fmt.Errorf("error")
 			},
 			isValid: false,
@@ -118,7 +118,7 @@ func TestSingleOptionalArg(t *testing.T) {
 		{
 			description: "valid",
 			args:        []string{"arg"},
-			validateFunc: func(value string) error {
+			validateFunc: func(_ string) error {
 				return nil
 			},
 			isValid: true,
@@ -141,7 +141,7 @@ func TestSingleOptionalArg(t *testing.T) {
 		{
 			description: "invalid_arg",
 			args:        []string{"arg"},
-			validateFunc: func(value string) error {
+			validateFunc: func(_ string) error {
 				return fmt.Errorf("error")
 			},
 			isValid: false,

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -22,7 +22,7 @@ type tokenClaims struct {
 // It returns the configuration option that can be used to create an authenticated SDK client.
 //
 // If the user was logged in and the user session expired, reauthorizeUserRoutine is called to reauthenticate the user again.
-func AuthenticationConfig(p *print.Printer, reauthorizeUserRoutine func(p *print.Printer, isReauthentication bool) error) (authCfgOption sdkConfig.ConfigurationOption, err error) {
+func AuthenticationConfig(p *print.Printer, reauthorizeUserRoutine func(p *print.Printer, _ bool) error) (authCfgOption sdkConfig.ConfigurationOption, err error) {
 	flow, err := GetAuthFlow()
 	if err != nil {
 		return nil, fmt.Errorf("get authentication flow: %w", err)

--- a/internal/pkg/auth/auth_test.go
+++ b/internal/pkg/auth/auth_test.go
@@ -188,7 +188,7 @@ func TestAuthenticationConfig(t *testing.T) {
 			}
 
 			reauthorizeUserCalled := false
-			reauthenticateUser := func(p *print.Printer, isReauthentication bool) error {
+			reauthenticateUser := func(_ *print.Printer, _ bool) error {
 				if reauthorizeUserCalled {
 					t.Errorf("user reauthorized more than once")
 				}

--- a/internal/pkg/auth/storage.go
+++ b/internal/pkg/auth/storage.go
@@ -299,7 +299,7 @@ func createEncodedTextFile(activeProfile string) error {
 	textFileDir := config.GetProfileFolderPath(activeProfile)
 	textFilePath := filepath.Join(textFileDir, textFileName)
 
-	err := os.MkdirAll(textFileDir, os.ModePerm)
+	err := os.MkdirAll(textFileDir, 0o750)
 	if err != nil {
 		return fmt.Errorf("create file dir: %w", err)
 	}

--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -207,7 +207,7 @@ func AuthorizeUser(p *print.Printer, isReauthentication bool) error {
 		http.Redirect(w, r, loginSuccessURL, http.StatusSeeOther)
 	})
 
-	mux.HandleFunc(loginSuccessPath, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(loginSuccessPath, func(w http.ResponseWriter, _ *http.Request) {
 		defer cleanup(server)
 
 		email, err := GetAuthField(USER_EMAIL)

--- a/internal/pkg/auth/user_token_flow_test.go
+++ b/internal/pkg/auth/user_token_flow_test.go
@@ -278,7 +278,7 @@ func TestRoundTrip(t *testing.T) {
 				authorizeUserCalled: &authorizeUserCalled,
 				tokensRefreshed:     &tokensRefreshed,
 			}
-			authorizeUserRoutine := func(p *print.Printer, isReauthentication bool) error {
+			authorizeUserRoutine := func(_ *print.Printer, _ bool) error {
 				return reauthorizeUser(authorizeUserContext)
 			}
 

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -43,7 +43,7 @@ func PutObject(identifier string, data []byte) error {
 		return ErrorInvalidCacheIdentifier
 	}
 
-	err := os.MkdirAll(cacheFolderPath, os.ModePerm)
+	err := os.MkdirAll(cacheFolderPath, 0o750)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -46,7 +46,7 @@ func TestGetObject(t *testing.T) {
 
 			// setup
 			if tt.expectFile {
-				err := os.MkdirAll(cacheFolderPath, os.ModePerm)
+				err := os.MkdirAll(cacheFolderPath, 0o750)
 				if err != nil {
 					t.Fatalf("create cache folder: %s", err.Error())
 				}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -141,7 +141,7 @@ func InitConfig() {
 
 // Write saves the config file (wrapping `viper.WriteConfig`) and ensures that its directory exists
 func Write() error {
-	err := os.MkdirAll(configFolderPath, os.ModePerm)
+	err := os.MkdirAll(configFolderPath, 0o750)
 	if err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -37,7 +37,7 @@ func TestWrite(t *testing.T) {
 			configFolderPath = filepath.Dir(configPath)
 
 			if tt.folderExists {
-				err := os.MkdirAll(configFolderPath, os.ModePerm)
+				err := os.MkdirAll(configFolderPath, 0o750)
 				if err != nil {
 					t.Fatalf("expected error to be nil, got %v", err)
 				}

--- a/internal/pkg/config/profiles.go
+++ b/internal/pkg/config/profiles.go
@@ -100,7 +100,7 @@ func CreateProfile(p *print.Printer, profile string, setProfile, emptyProfile bo
 		return fmt.Errorf("profile %q already exists", profile)
 	}
 
-	err = os.MkdirAll(configFolderPath, os.ModePerm)
+	err = os.MkdirAll(configFolderPath, 0o750)
 	if err != nil {
 		return fmt.Errorf("create config folder: %w", err)
 	}
@@ -190,7 +190,7 @@ func SetProfile(p *print.Printer, profile string) error {
 		profileFilePath = getInitialProfileFilePath()
 	}
 
-	err = os.WriteFile(profileFilePath, []byte(profile), os.ModePerm)
+	err = os.WriteFile(profileFilePath, []byte(profile), 0o600)
 	if err != nil {
 		return fmt.Errorf("write profile to file: %w", err)
 	}

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -352,7 +352,7 @@ type SubcommandMissingError struct {
 }
 
 func (e *SubcommandMissingError) Error() string {
-	err := fmt.Errorf(SUBCOMMAND_MISSING)
+	err := fmt.Errorf("%s", SUBCOMMAND_MISSING)
 	return AppendUsageTip(err, e.Cmd).Error()
 }
 

--- a/internal/pkg/fileutils/file_utils_test.go
+++ b/internal/pkg/fileutils/file_utils_test.go
@@ -125,7 +125,7 @@ func TestCopyFile(t *testing.T) {
 			src := filepath.Join(basePath, "file-with-content.txt")
 			dst := filepath.Join(basePath, "file-with-content-copy.txt")
 
-			err := os.MkdirAll(basePath, os.ModePerm)
+			err := os.MkdirAll(basePath, 0o750)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -83,7 +83,7 @@ func TestEnumFlag(t *testing.T) {
 			flag := EnumFlag(tt.ignoreCase, "", options...)
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -236,7 +236,7 @@ func TestEnumSliceFlag(t *testing.T) {
 			flag := EnumSliceFlag(tt.ignoreCase, tt.defaultValue, options...)
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -302,7 +302,7 @@ func TestUUIDFlag(t *testing.T) {
 			flag := UUIDFlag()
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -400,7 +400,7 @@ func TestUUIDSliceFlag(t *testing.T) {
 			flag := UUIDSliceFlag()
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -513,7 +513,7 @@ func TestCIDRFlag(t *testing.T) {
 			flag := CIDRFlag()
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -615,7 +615,7 @@ func TestCIDRSliceFlag(t *testing.T) {
 			flag := CIDRSliceFlag()
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}
@@ -717,7 +717,7 @@ func TestReadFromFileFlag(t *testing.T) {
 			}
 			cmd := &cobra.Command{
 				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			}

--- a/internal/pkg/print/print_test.go
+++ b/internal/pkg/print/print_test.go
@@ -69,7 +69,7 @@ func TestOutputf(t *testing.T) {
 			}
 
 			if len(tt.args) == 0 {
-				p.Outputf(tt.message)
+				p.Outputf("%s", tt.message)
 			} else {
 				p.Outputf(tt.message, tt.args...)
 			}
@@ -360,7 +360,7 @@ func TestInfo(t *testing.T) {
 				Verbosity: tt.verbosity,
 			}
 
-			p.Info(tt.message)
+			p.Info("%s", tt.message)
 
 			expectedOutput := tt.message
 			output := buf.String()
@@ -419,7 +419,7 @@ func TestWarn(t *testing.T) {
 				Verbosity: tt.verbosity,
 			}
 
-			p.Warn(tt.message)
+			p.Warn("%s", tt.message)
 
 			expectedOutput := fmt.Sprintf("Warning: %s", tt.message)
 			output := buf.String()
@@ -478,7 +478,7 @@ func TestError(t *testing.T) {
 				Verbosity: tt.verbosity,
 			}
 
-			p.Error(tt.message)
+			p.Error("%s", tt.message)
 
 			expectedOutput := fmt.Sprintf("Error: %s\n", tt.message)
 			output := buf.String()

--- a/internal/pkg/services/object-storage/utils/utils_test.go
+++ b/internal/pkg/services/object-storage/utils/utils_test.go
@@ -314,7 +314,7 @@ func TestGetCredentialsName(t *testing.T) {
 				t.Fatalf("Failed to marshal mocked response: %v", err)
 			}
 
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				if tt.getCredentialsNameFails {
 					w.WriteHeader(http.StatusBadGateway)

--- a/scripts/generate.go
+++ b/scripts/generate.go
@@ -27,12 +27,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error removing old documentation directory: %v", err)
 	}
-	err = os.Mkdir(docsDir, os.ModePerm)
+	err = os.Mkdir(docsDir, 0o750)
 	if err != nil {
 		log.Fatalf("Error creating new documentation directory: %v", err)
 	}
 
-	filePrepender := func(filename string) string {
+	filePrepender := func(_ string) string {
 		return ""
 	}
 	linkHandler := func(filename string) string {

--- a/scripts/project.sh
+++ b/scripts/project.sh
@@ -14,7 +14,7 @@ if [ "$action" = "help" ]; then
 elif [ "$action" = "tools" ]; then
     cd ${ROOT_DIR}
     go mod download
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 else
     echo "Invalid action: '$action', please use $0 help for help"
 fi


### PR DESCRIPTION
Updated Linter and go version.
Removed deprecated linter:
- exportloopref 
- structcheck
- deadcode
- varcheck