### PR TITLE
Fix command usages

### DIFF
--- a/docs/stackit_beta_key-pair_delete.md
+++ b/docs/stackit_beta_key-pair_delete.md
@@ -7,7 +7,7 @@ Deletes a key pair
 Deletes a key pair.
 
 ```
-stackit beta key-pair delete [flags]
+stackit beta key-pair delete KEY_PAIR_NAME [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_key-pair_describe.md
+++ b/docs/stackit_beta_key-pair_describe.md
@@ -7,7 +7,7 @@ Describes a key pair
 Describes a key pair.
 
 ```
-stackit beta key-pair describe [flags]
+stackit beta key-pair describe KEY_PAIR_NAME [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_key-pair_update.md
+++ b/docs/stackit_beta_key-pair_update.md
@@ -7,7 +7,7 @@ Updates a key pair
 Updates a key pair.
 
 ```
-stackit beta key-pair update [flags]
+stackit beta key-pair update KEY_PAIR_NAME [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_delete.md
+++ b/docs/stackit_beta_network-area_delete.md
@@ -9,7 +9,7 @@ If the SNA is attached to any projects, the deletion will fail
 
 
 ```
-stackit beta network-area delete [flags]
+stackit beta network-area delete AREA_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_describe.md
+++ b/docs/stackit_beta_network-area_describe.md
@@ -7,7 +7,7 @@ Shows details of a STACKIT Network Area
 Shows details of a STACKIT Network Area in an organization.
 
 ```
-stackit beta network-area describe [flags]
+stackit beta network-area describe AREA_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_network-range_delete.md
+++ b/docs/stackit_beta_network-area_network-range_delete.md
@@ -7,7 +7,7 @@ Deletes a network range in a STACKIT Network Area (SNA)
 Deletes a network range in a STACKIT Network Area (SNA).
 
 ```
-stackit beta network-area network-range delete [flags]
+stackit beta network-area network-range delete NETWORK_RANGE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_network-range_describe.md
+++ b/docs/stackit_beta_network-area_network-range_describe.md
@@ -7,7 +7,7 @@ Shows details of a network range in a STACKIT Network Area (SNA)
 Shows details of a network range in a STACKIT Network Area (SNA).
 
 ```
-stackit beta network-area network-range describe [flags]
+stackit beta network-area network-range describe NETWORK_RANGE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_route_delete.md
+++ b/docs/stackit_beta_network-area_route_delete.md
@@ -7,7 +7,7 @@ Deletes a static route in a STACKIT Network Area (SNA)
 Deletes a static route in a STACKIT Network Area (SNA).
 
 ```
-stackit beta network-area route delete [flags]
+stackit beta network-area route delete ROUTE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_route_describe.md
+++ b/docs/stackit_beta_network-area_route_describe.md
@@ -7,7 +7,7 @@ Shows details of a static route in a STACKIT Network Area (SNA)
 Shows details of a static route in a STACKIT Network Area (SNA).
 
 ```
-stackit beta network-area route describe [flags]
+stackit beta network-area route describe ROUTE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_route_update.md
+++ b/docs/stackit_beta_network-area_route_update.md
@@ -9,7 +9,7 @@ This command is currently asynchonous only due to limitations in the waiting fun
 
 
 ```
-stackit beta network-area route update [flags]
+stackit beta network-area route update ROUTE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-area_update.md
+++ b/docs/stackit_beta_network-area_update.md
@@ -7,7 +7,7 @@ Updates a STACKIT Network Area (SNA)
 Updates a STACKIT Network Area (SNA) in an organization.
 
 ```
-stackit beta network-area update [flags]
+stackit beta network-area update AREA_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-interface_delete.md
+++ b/docs/stackit_beta_network-interface_delete.md
@@ -7,7 +7,7 @@ Deletes a network interface
 Deletes a network interface.
 
 ```
-stackit beta network-interface delete [flags]
+stackit beta network-interface delete NIC_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-interface_describe.md
+++ b/docs/stackit_beta_network-interface_describe.md
@@ -7,7 +7,7 @@ Describes a network interface
 Describes a network interface.
 
 ```
-stackit beta network-interface describe [flags]
+stackit beta network-interface describe NIC_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network-interface_update.md
+++ b/docs/stackit_beta_network-interface_update.md
@@ -7,7 +7,7 @@ Updates a network interface
 Updates a network interface.
 
 ```
-stackit beta network-interface update [flags]
+stackit beta network-interface update NIC_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network_delete.md
+++ b/docs/stackit_beta_network_delete.md
@@ -9,7 +9,7 @@ If the network is still in use, the deletion will fail
 
 
 ```
-stackit beta network delete [flags]
+stackit beta network delete NETWORK_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network_describe.md
+++ b/docs/stackit_beta_network_describe.md
@@ -7,7 +7,7 @@ Shows details of a network
 Shows details of a network.
 
 ```
-stackit beta network describe [flags]
+stackit beta network describe NETWORK_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_network_update.md
+++ b/docs/stackit_beta_network_update.md
@@ -7,7 +7,7 @@ Updates a network
 Updates a network.
 
 ```
-stackit beta network update [flags]
+stackit beta network update NETWORK_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_public-ip_associate.md
+++ b/docs/stackit_beta_public-ip_associate.md
@@ -7,7 +7,7 @@ Associates a Public IP with a network interface or a virtual IP
 Associates a Public IP with a network interface or a virtual IP.
 
 ```
-stackit beta public-ip associate [flags]
+stackit beta public-ip associate PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_public-ip_delete.md
+++ b/docs/stackit_beta_public-ip_delete.md
@@ -9,7 +9,7 @@ If the public IP is still in use, the deletion will fail
 
 
 ```
-stackit beta public-ip delete [flags]
+stackit beta public-ip delete PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_public-ip_describe.md
+++ b/docs/stackit_beta_public-ip_describe.md
@@ -7,7 +7,7 @@ Shows details of a Public IP
 Shows details of a Public IP.
 
 ```
-stackit beta public-ip describe [flags]
+stackit beta public-ip describe PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_public-ip_disassociate.md
+++ b/docs/stackit_beta_public-ip_disassociate.md
@@ -7,7 +7,7 @@ Disassociates a Public IP from a network interface or a virtual IP
 Disassociates a Public IP from a network interface or a virtual IP.
 
 ```
-stackit beta public-ip disassociate [flags]
+stackit beta public-ip disassociate PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_public-ip_update.md
+++ b/docs/stackit_beta_public-ip_update.md
@@ -7,7 +7,7 @@ Updates a Public IP
 Updates a Public IP.
 
 ```
-stackit beta public-ip update [flags]
+stackit beta public-ip update PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_security-group_delete.md
+++ b/docs/stackit_beta_security-group_delete.md
@@ -7,7 +7,7 @@ Deletes a security group
 Deletes a security group by its internal ID.
 
 ```
-stackit beta security-group delete [flags]
+stackit beta security-group delete GROUP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_security-group_describe.md
+++ b/docs/stackit_beta_security-group_describe.md
@@ -7,7 +7,7 @@ Describes security groups
 Describes security groups by its internal ID.
 
 ```
-stackit beta security-group describe [flags]
+stackit beta security-group describe GROUP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_security-group_rule_delete.md
+++ b/docs/stackit_beta_security-group_rule_delete.md
@@ -9,7 +9,7 @@ If the security group rule is still in use, the deletion will fail
 
 
 ```
-stackit beta security-group rule delete [flags]
+stackit beta security-group rule delete SECURITY_GROUP_RULE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_security-group_rule_describe.md
+++ b/docs/stackit_beta_security-group_rule_describe.md
@@ -7,7 +7,7 @@ Shows details of a security group rule
 Shows details of a security group rule.
 
 ```
-stackit beta security-group rule describe [flags]
+stackit beta security-group rule describe SECURITY_GROUP_RULE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_security-group_update.md
+++ b/docs/stackit_beta_security-group_update.md
@@ -7,7 +7,7 @@ Updates a security group
 Updates a named security group
 
 ```
-stackit beta security-group update [flags]
+stackit beta security-group update GROUP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_console.md
+++ b/docs/stackit_beta_server_console.md
@@ -7,7 +7,7 @@ Gets a URL for server remote console
 Gets a URL for server remote console.
 
 ```
-stackit beta server console [flags]
+stackit beta server console SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_deallocate.md
+++ b/docs/stackit_beta_server_deallocate.md
@@ -7,7 +7,7 @@ Deallocates an existing server
 Deallocates an existing server.
 
 ```
-stackit beta server deallocate [flags]
+stackit beta server deallocate SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_delete.md
+++ b/docs/stackit_beta_server_delete.md
@@ -9,7 +9,7 @@ If the server is still in use, the deletion will fail
 
 
 ```
-stackit beta server delete [flags]
+stackit beta server delete SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_describe.md
+++ b/docs/stackit_beta_server_describe.md
@@ -7,7 +7,7 @@ Shows details of a server
 Shows details of a server.
 
 ```
-stackit beta server describe [flags]
+stackit beta server describe SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_log.md
+++ b/docs/stackit_beta_server_log.md
@@ -7,7 +7,7 @@ Gets server console log
 Gets server console log.
 
 ```
-stackit beta server log [flags]
+stackit beta server log SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_public-ip_attach.md
+++ b/docs/stackit_beta_server_public-ip_attach.md
@@ -7,7 +7,7 @@ Attaches a public IP to a server
 Attaches a public IP to a server.
 
 ```
-stackit beta server public-ip attach [flags]
+stackit beta server public-ip attach PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_public-ip_detach.md
+++ b/docs/stackit_beta_server_public-ip_detach.md
@@ -7,7 +7,7 @@ Detaches a public IP from a server
 Detaches a public IP from a server.
 
 ```
-stackit beta server public-ip detach [flags]
+stackit beta server public-ip detach PUBLIC_IP_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_reboot.md
+++ b/docs/stackit_beta_server_reboot.md
@@ -7,7 +7,7 @@ Reboots a server
 Reboots a server.
 
 ```
-stackit beta server reboot [flags]
+stackit beta server reboot SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_rescue.md
+++ b/docs/stackit_beta_server_rescue.md
@@ -7,7 +7,7 @@ Rescues an existing server
 Rescues an existing server.
 
 ```
-stackit beta server rescue [flags]
+stackit beta server rescue SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_resize.md
+++ b/docs/stackit_beta_server_resize.md
@@ -7,7 +7,7 @@ Resizes the server to the given machine type
 Resizes the server to the given machine type.
 
 ```
-stackit beta server resize [flags]
+stackit beta server resize SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_service-account_attach.md
+++ b/docs/stackit_beta_server_service-account_attach.md
@@ -7,7 +7,7 @@ Attach a service account to a server
 Attach a service account to a server
 
 ```
-stackit beta server service-account attach [flags]
+stackit beta server service-account attach SERVICE_ACCOUNT_EMAIL [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_service-account_detach.md
+++ b/docs/stackit_beta_server_service-account_detach.md
@@ -7,7 +7,7 @@ Detach a service account from a server
 Detach a service account from a server
 
 ```
-stackit beta server service-account detach [flags]
+stackit beta server service-account detach SERVICE_ACCOUNT_EMAIL [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_start.md
+++ b/docs/stackit_beta_server_start.md
@@ -7,7 +7,7 @@ Starts an existing server or allocates the server if deallocated
 Starts an existing server or allocates the server if deallocated.
 
 ```
-stackit beta server start [flags]
+stackit beta server start SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_stop.md
+++ b/docs/stackit_beta_server_stop.md
@@ -7,7 +7,7 @@ Stops an existing server
 Stops an existing server.
 
 ```
-stackit beta server stop [flags]
+stackit beta server stop SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_unrescue.md
+++ b/docs/stackit_beta_server_unrescue.md
@@ -7,7 +7,7 @@ Unrescues an existing server
 Unrescues an existing server.
 
 ```
-stackit beta server unrescue [flags]
+stackit beta server unrescue SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_update.md
+++ b/docs/stackit_beta_server_update.md
@@ -7,7 +7,7 @@ Updates a server
 Updates a server.
 
 ```
-stackit beta server update [flags]
+stackit beta server update SERVER_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_volume_attach.md
+++ b/docs/stackit_beta_server_volume_attach.md
@@ -7,7 +7,7 @@ Attaches a volume to a server
 Attaches a volume to a server.
 
 ```
-stackit beta server volume attach [flags]
+stackit beta server volume attach VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_volume_describe.md
+++ b/docs/stackit_beta_server_volume_describe.md
@@ -7,7 +7,7 @@ Describes a server volume attachment
 Describes a server volume attachment.
 
 ```
-stackit beta server volume describe [flags]
+stackit beta server volume describe VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_volume_detach.md
+++ b/docs/stackit_beta_server_volume_detach.md
@@ -7,7 +7,7 @@ Detaches a volume from a server
 Detaches a volume from a server.
 
 ```
-stackit beta server volume detach [flags]
+stackit beta server volume detach VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_server_volume_update.md
+++ b/docs/stackit_beta_server_volume_update.md
@@ -7,7 +7,7 @@ Updates an attached volume of a server
 Updates an attached volume of a server.
 
 ```
-stackit beta server volume update [flags]
+stackit beta server volume update VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_volume_delete.md
+++ b/docs/stackit_beta_volume_delete.md
@@ -9,7 +9,7 @@ If the volume is still in use, the deletion will fail
 
 
 ```
-stackit beta volume delete [flags]
+stackit beta volume delete VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_volume_describe.md
+++ b/docs/stackit_beta_volume_describe.md
@@ -7,7 +7,7 @@ Shows details of a volume
 Shows details of a volume.
 
 ```
-stackit beta volume describe [flags]
+stackit beta volume describe VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_volume_performance-class_describe.md
+++ b/docs/stackit_beta_volume_performance-class_describe.md
@@ -7,7 +7,7 @@ Shows details of a volume performance class
 Shows details of a volume performance class.
 
 ```
-stackit beta volume performance-class describe [flags]
+stackit beta volume performance-class describe VOLUME_PERFORMANCE_CLASS [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_volume_resize.md
+++ b/docs/stackit_beta_volume_resize.md
@@ -7,7 +7,7 @@ Resizes a volume
 Resizes a volume.
 
 ```
-stackit beta volume resize [flags]
+stackit beta volume resize VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_beta_volume_update.md
+++ b/docs/stackit_beta_volume_update.md
@@ -7,7 +7,7 @@ Updates a volume
 Updates a volume.
 
 ```
-stackit beta volume update [flags]
+stackit beta volume update VOLUME_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_dns_zone_clone.md
+++ b/docs/stackit_dns_zone_clone.md
@@ -7,7 +7,7 @@ Clones a DNS zone
 Clones an existing DNS zone with all record sets to a new zone with a different name.
 
 ```
-stackit dns zone clone [flags]
+stackit dns zone clone ZONE_ID [flags]
 ```
 
 ### Examples

--- a/docs/stackit_load-balancer_observability-credentials_update.md
+++ b/docs/stackit_load-balancer_observability-credentials_update.md
@@ -7,7 +7,7 @@ Updates observability credentials for Load Balancer
 Updates existing observability credentials (username and password) for Load Balancer. The credentials can be for Observability or another monitoring tool.
 
 ```
-stackit load-balancer observability-credentials update [flags]
+stackit load-balancer observability-credentials update CREDENTIALS_REF [flags]
 ```
 
 ### Examples

--- a/internal/cmd/beta/key-pair/delete/delete.go
+++ b/internal/cmd/beta/key-pair/delete/delete.go
@@ -25,7 +25,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", keyPairNameArg),
 		Short: "Deletes a key pair",
 		Long:  "Deletes a key pair.",
 		Args:  args.SingleArg(keyPairNameArg, nil),

--- a/internal/cmd/beta/key-pair/describe/describe.go
+++ b/internal/cmd/beta/key-pair/describe/describe.go
@@ -35,7 +35,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", keyPairNameArg),
 		Short: "Describes a key pair",
 		Long:  "Describes a key pair.",
 		Args:  args.SingleArg(keyPairNameArg, nil),

--- a/internal/cmd/beta/key-pair/update/update.go
+++ b/internal/cmd/beta/key-pair/update/update.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", keyPairNameArg),
 		Short: "Updates a key pair",
 		Long:  "Updates a key pair.",
 		Args:  args.SingleArg(keyPairNameArg, nil),

--- a/internal/cmd/beta/network-area/delete/delete.go
+++ b/internal/cmd/beta/network-area/delete/delete.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", areaIdArg),
 		Short: "Deletes a STACKIT Network Area (SNA)",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a STACKIT Network Area (SNA) in an organization.",

--- a/internal/cmd/beta/network-area/describe/describe.go
+++ b/internal/cmd/beta/network-area/describe/describe.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", areaIdArg),
 		Short: "Shows details of a STACKIT Network Area",
 		Long:  "Shows details of a STACKIT Network Area in an organization.",
 		Args:  args.SingleArg(areaIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-area/network-range/delete/delete.go
+++ b/internal/cmd/beta/network-area/network-range/delete/delete.go
@@ -33,7 +33,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", networkRangeIdArg),
 		Short: "Deletes a network range in a STACKIT Network Area (SNA)",
 		Long:  "Deletes a network range in a STACKIT Network Area (SNA).",
 		Args:  args.SingleArg(networkRangeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-area/network-range/describe/describe.go
+++ b/internal/cmd/beta/network-area/network-range/describe/describe.go
@@ -35,7 +35,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", networkRangeIdArg),
 		Short: "Shows details of a network range in a STACKIT Network Area (SNA)",
 		Long:  "Shows details of a network range in a STACKIT Network Area (SNA).",
 		Args:  args.SingleArg(networkRangeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-area/route/delete/delete.go
+++ b/internal/cmd/beta/network-area/route/delete/delete.go
@@ -33,7 +33,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", routeIdArg),
 		Short: "Deletes a static route in a STACKIT Network Area (SNA)",
 		Long:  "Deletes a static route in a STACKIT Network Area (SNA).",
 		Args:  args.SingleArg(routeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-area/route/describe/describe.go
+++ b/internal/cmd/beta/network-area/route/describe/describe.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", routeIdArg),
 		Short: "Shows details of a static route in a STACKIT Network Area (SNA)",
 		Long:  "Shows details of a static route in a STACKIT Network Area (SNA).",
 		Args:  args.SingleArg(routeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-area/route/update/update.go
+++ b/internal/cmd/beta/network-area/route/update/update.go
@@ -38,7 +38,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", routeIdArg),
 		Short: "Updates a static route in a STACKIT Network Area (SNA)",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Updates a static route in a STACKIT Network Area (SNA).",

--- a/internal/cmd/beta/network-area/update/update.go
+++ b/internal/cmd/beta/network-area/update/update.go
@@ -45,7 +45,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", areaIdArg),
 		Short: "Updates a STACKIT Network Area (SNA)",
 		Long:  "Updates a STACKIT Network Area (SNA) in an organization.",
 		Args:  args.SingleArg(areaIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-interface/delete/delete.go
+++ b/internal/cmd/beta/network-interface/delete/delete.go
@@ -29,7 +29,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", nicIdArg),
 		Short: "Deletes a network interface",
 		Long:  "Deletes a network interface.",
 		Args:  args.SingleArg(nicIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-interface/describe/describe.go
+++ b/internal/cmd/beta/network-interface/describe/describe.go
@@ -34,7 +34,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", nicIdArg),
 		Short: "Describes a network interface",
 		Long:  "Describes a network interface.",
 		Args:  args.SingleArg(nicIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network-interface/update/update.go
+++ b/internal/cmd/beta/network-interface/update/update.go
@@ -49,7 +49,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", nicIdArg),
 		Short: "Updates a network interface",
 		Long:  "Updates a network interface.",
 		Args:  args.SingleArg(nicIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network/delete/delete.go
+++ b/internal/cmd/beta/network/delete/delete.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", networkIdArg),
 		Short: "Deletes a network",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a network.",

--- a/internal/cmd/beta/network/describe/describe.go
+++ b/internal/cmd/beta/network/describe/describe.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", networkIdArg),
 		Short: "Shows details of a network",
 		Long:  "Shows details of a network.",
 		Args:  args.SingleArg(networkIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/network/update/update.go
+++ b/internal/cmd/beta/network/update/update.go
@@ -46,7 +46,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", networkIdArg),
 		Short: "Updates a network",
 		Long:  "Updates a network.",
 		Args:  args.SingleArg(networkIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/public-ip/associate/associate.go
+++ b/internal/cmd/beta/public-ip/associate/associate.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "associate",
+		Use:   fmt.Sprintf("associate %s", publicIpIdArg),
 		Short: "Associates a Public IP with a network interface or a virtual IP",
 		Long:  "Associates a Public IP with a network interface or a virtual IP.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/public-ip/delete/delete.go
+++ b/internal/cmd/beta/public-ip/delete/delete.go
@@ -27,7 +27,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", publicIpIdArg),
 		Short: "Deletes a Public IP",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a Public IP.",

--- a/internal/cmd/beta/public-ip/describe/describe.go
+++ b/internal/cmd/beta/public-ip/describe/describe.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", publicIpIdArg),
 		Short: "Shows details of a Public IP",
 		Long:  "Shows details of a Public IP.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/public-ip/disassociate/disassociate.go
+++ b/internal/cmd/beta/public-ip/disassociate/disassociate.go
@@ -28,7 +28,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "disassociate",
+		Use:   fmt.Sprintf("disassociate %s", publicIpIdArg),
 		Short: "Disassociates a Public IP from a network interface or a virtual IP",
 		Long:  "Disassociates a Public IP from a network interface or a virtual IP.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/public-ip/update/update.go
+++ b/internal/cmd/beta/public-ip/update/update.go
@@ -35,7 +35,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", publicIpIdArg),
 		Short: "Updates a Public IP",
 		Long:  "Updates a Public IP.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/security-group/delete/delete.go
+++ b/internal/cmd/beta/security-group/delete/delete.go
@@ -26,7 +26,7 @@ const groupIdArg = "GROUP_ID"
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", groupIdArg),
 		Short: "Deletes a security group",
 		Long:  "Deletes a security group by its internal ID.",
 		Args:  args.SingleArg(groupIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/security-group/describe/describe.go
+++ b/internal/cmd/beta/security-group/describe/describe.go
@@ -28,7 +28,7 @@ const groupIdArg = "GROUP_ID"
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", groupIdArg),
 		Short: "Describes security groups",
 		Long:  "Describes security groups by its internal ID.",
 		Args:  args.SingleArg(groupIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/security-group/rule/delete/delete.go
+++ b/internal/cmd/beta/security-group/rule/delete/delete.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", securityGroupRuleIdArg),
 		Short: "Deletes a security group rule",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a security group rule.",

--- a/internal/cmd/beta/security-group/rule/describe/describe.go
+++ b/internal/cmd/beta/security-group/rule/describe/describe.go
@@ -34,7 +34,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", securityGroupRuleIdArg),
 		Short: "Shows details of a security group rule",
 		Long:  "Shows details of a security group rule.",
 		Args:  args.SingleArg(securityGroupRuleIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/security-group/update/update.go
+++ b/internal/cmd/beta/security-group/update/update.go
@@ -36,7 +36,7 @@ const (
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", groupNameArg),
 		Short: "Updates a security group",
 		Long:  "Updates a named security group",
 		Args:  args.SingleArg(groupNameArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/console/console.go
+++ b/internal/cmd/beta/server/console/console.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "console",
+		Use:   fmt.Sprintf("console %s", serverIdArg),
 		Short: "Gets a URL for server remote console",
 		Long:  "Gets a URL for server remote console.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/deallocate/deallocate.go
+++ b/internal/cmd/beta/server/deallocate/deallocate.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "deallocate",
+		Use:   fmt.Sprintf("deallocate %s", serverIdArg),
 		Short: "Deallocates an existing server",
 		Long:  "Deallocates an existing server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/delete/delete.go
+++ b/internal/cmd/beta/server/delete/delete.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", serverIdArg),
 		Short: "Deletes a server",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a server.",

--- a/internal/cmd/beta/server/describe/describe.go
+++ b/internal/cmd/beta/server/describe/describe.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", serverIdArg),
 		Short: "Shows details of a server",
 		Long:  "Shows details of a server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/log/log.go
+++ b/internal/cmd/beta/server/log/log.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "log",
+		Use:   fmt.Sprintf("log %s", serverIdArg),
 		Short: "Gets server console log",
 		Long:  "Gets server console log.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/public-ip/attach/attach.go
+++ b/internal/cmd/beta/server/public-ip/attach/attach.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "attach",
+		Use:   fmt.Sprintf("attach %s", publicIpIdArg),
 		Short: "Attaches a public IP to a server",
 		Long:  "Attaches a public IP to a server.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/public-ip/detach/detach.go
+++ b/internal/cmd/beta/server/public-ip/detach/detach.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "detach",
+		Use:   fmt.Sprintf("detach %s", publicIpIdArg),
 		Short: "Detaches a public IP from a server",
 		Long:  "Detaches a public IP from a server.",
 		Args:  args.SingleArg(publicIpIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/reboot/reboot.go
+++ b/internal/cmd/beta/server/reboot/reboot.go
@@ -34,7 +34,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reboot",
+		Use:   fmt.Sprintf("reboot %s", serverIdArg),
 		Short: "Reboots a server",
 		Long:  "Reboots a server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/rescue/rescue.go
+++ b/internal/cmd/beta/server/rescue/rescue.go
@@ -34,7 +34,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rescue",
+		Use:   fmt.Sprintf("rescue %s", serverIdArg),
 		Short: "Rescues an existing server",
 		Long:  "Rescues an existing server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/resize/resize.go
+++ b/internal/cmd/beta/server/resize/resize.go
@@ -34,7 +34,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resize",
+		Use:   fmt.Sprintf("resize %s", serverIdArg),
 		Short: "Resizes the server to the given machine type",
 		Long:  "Resizes the server to the given machine type.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/service-account/attach/attach.go
+++ b/internal/cmd/beta/server/service-account/attach/attach.go
@@ -33,7 +33,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "attach",
+		Use:   fmt.Sprintf("attach %s", serviceAccMailArg),
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
 		Args:  args.SingleArg(serviceAccMailArg, nil),

--- a/internal/cmd/beta/server/service-account/detach/detach.go
+++ b/internal/cmd/beta/server/service-account/detach/detach.go
@@ -33,7 +33,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "detach",
+		Use:   fmt.Sprintf("detach %s", serviceAccMailArg),
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
 		Args:  args.SingleArg(serviceAccMailArg, nil),

--- a/internal/cmd/beta/server/start/start.go
+++ b/internal/cmd/beta/server/start/start.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   fmt.Sprintf("start %s", serverIdArg),
 		Short: "Starts an existing server or allocates the server if deallocated",
 		Long:  "Starts an existing server or allocates the server if deallocated.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/stop/stop.go
+++ b/internal/cmd/beta/server/stop/stop.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stop",
+		Use:   fmt.Sprintf("stop %s", serverIdArg),
 		Short: "Stops an existing server",
 		Long:  "Stops an existing server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/unrescue/unrescue.go
+++ b/internal/cmd/beta/server/unrescue/unrescue.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unrescue",
+		Use:   fmt.Sprintf("unrescue %s", serverIdArg),
 		Short: "Unrescues an existing server",
 		Long:  "Unrescues an existing server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/update/update.go
+++ b/internal/cmd/beta/server/update/update.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", serverIdArg),
 		Short: "Updates a server",
 		Long:  "Updates a server.",
 		Args:  args.SingleArg(serverIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/volume/attach/attach.go
+++ b/internal/cmd/beta/server/volume/attach/attach.go
@@ -37,7 +37,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "attach",
+		Use:   fmt.Sprintf("attach %s", volumeIdArg),
 		Short: "Attaches a volume to a server",
 		Long:  "Attaches a volume to a server.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/volume/describe/describe.go
+++ b/internal/cmd/beta/server/volume/describe/describe.go
@@ -33,7 +33,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", volumeIdArg),
 		Short: "Describes a server volume attachment",
 		Long:  "Describes a server volume attachment.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/volume/detach/detach.go
+++ b/internal/cmd/beta/server/volume/detach/detach.go
@@ -31,7 +31,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "detach",
+		Use:   fmt.Sprintf("detach %s", volumeIdArg),
 		Short: "Detaches a volume from a server",
 		Long:  "Detaches a volume from a server.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/server/volume/update/update.go
+++ b/internal/cmd/beta/server/volume/update/update.go
@@ -37,7 +37,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", volumeIdArg),
 		Short: "Updates an attached volume of a server",
 		Long:  "Updates an attached volume of a server.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/volume/delete/delete.go
+++ b/internal/cmd/beta/volume/delete/delete.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   fmt.Sprintf("delete %s", volumeIdArg),
 		Short: "Deletes a volume",
 		Long: fmt.Sprintf("%s\n%s\n",
 			"Deletes a volume.",

--- a/internal/cmd/beta/volume/describe/describe.go
+++ b/internal/cmd/beta/volume/describe/describe.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", volumeIdArg),
 		Short: "Shows details of a volume",
 		Long:  "Shows details of a volume.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/volume/performance-class/describe/describe.go
+++ b/internal/cmd/beta/volume/performance-class/describe/describe.go
@@ -30,7 +30,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
+		Use:   fmt.Sprintf("describe %s", volumePerformanceClassArg),
 		Short: "Shows details of a volume performance class",
 		Long:  "Shows details of a volume performance class.",
 		Args:  args.SingleArg(volumePerformanceClassArg, nil),

--- a/internal/cmd/beta/volume/resize/resize.go
+++ b/internal/cmd/beta/volume/resize/resize.go
@@ -32,7 +32,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resize",
+		Use:   fmt.Sprintf("resize %s", volumeIdArg),
 		Short: "Resizes a volume",
 		Long:  "Resizes a volume.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/beta/volume/update/update.go
+++ b/internal/cmd/beta/volume/update/update.go
@@ -38,7 +38,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", volumeIdArg),
 		Short: "Updates a volume",
 		Long:  "Updates a volume.",
 		Args:  args.SingleArg(volumeIdArg, utils.ValidateUUID),

--- a/internal/cmd/dns/zone/clone/clone.go
+++ b/internal/cmd/dns/zone/clone/clone.go
@@ -41,7 +41,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clone",
+		Use:   fmt.Sprintf("clone %s", zoneIdArg),
 		Short: "Clones a DNS zone",
 		Long:  "Clones an existing DNS zone with all record sets to a new zone with a different name.",
 		Args:  args.SingleArg(zoneIdArg, utils.ValidateUUID),

--- a/internal/cmd/load-balancer/observability-credentials/update/update.go
+++ b/internal/cmd/load-balancer/observability-credentials/update/update.go
@@ -37,7 +37,7 @@ type inputModel struct {
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   fmt.Sprintf("update %s", credentialsRefArg),
 		Short: "Updates observability credentials for Load Balancer",
 		Long:  "Updates existing observability credentials (username and password) for Load Balancer. The credentials can be for Observability or another monitoring tool.",
 		Args:  args.SingleArg(credentialsRefArg, nil),


### PR DESCRIPTION
stackit beta key-pair 

> delete
> describe
> update

stackit beta network-area

> describe
> delete
> update
> network-range

>       delete
>       describe

> route 
>       delete
>       describe
>       update

stackit beta network-interface

> describe
> delete
> update

stackit beta network

> describe
> delete
> update

stackit beta public-ip

> associate
> disassociate
> describe
> delete
> update

stackit beta security-group

> describe
> delete
> update

> rule
>       delete
>       describe

stackit beta server

> console
> deallocate
> delete
> describe
> log
> reboot
> rescue
> resize
> start
> stop
> unrescue
> update

> public-ip

>        attach
>        detach

> service-account

>        attach
>        detach

> volume

>        attach
>        detach
>        describe
>        update

stackit beta volume

> delete
> describe
> resize
> update

> performance-class

>        describe

stackit dns zone

> clone

stackit load-balancer 

> observability-credentials 
>        update
