### PR TITLE
Extend output of IaaS commands

### DIFF
--- a/internal/cmd/beta/network/list/list.go
+++ b/internal/cmd/beta/network/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -151,7 +152,7 @@ func outputResult(p *print.Printer, outputFormat string, networks []iaas.Network
 		return nil
 	default:
 		table := tables.NewTable()
-		table.SetHeader("ID", "NAME", "STATUS", "PUBLIC IP", "ROUTED")
+		table.SetHeader("ID", "NAME", "STATUS", "PUBLIC IP", "PREFIXES", "ROUTED")
 
 		for _, network := range networks {
 			publicIp := ""
@@ -163,8 +164,12 @@ func outputResult(p *print.Printer, outputFormat string, networks []iaas.Network
 			if network.Routed != nil {
 				routed = *network.Routed
 			}
+			prefixes := ""
+			if network.Prefixes != nil && len(*network.Prefixes) > 0 {
+				prefixes = strings.Join(*network.Prefixes, ", ")
+			}
 
-			table.AddRow(*network.NetworkId, *network.Name, *network.State, publicIp, routed)
+			table.AddRow(*network.NetworkId, *network.Name, *network.State, publicIp, prefixes, routed)
 			table.AddSeparator()
 		}
 

--- a/internal/cmd/beta/security-group/describe/describe.go
+++ b/internal/cmd/beta/security-group/describe/describe.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/goccy/go-yaml"
-	"github.com/spf13/cobra"
+	"strings"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -14,8 +14,10 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
-	"strings"
 )
 
 type inputModel struct {

--- a/internal/cmd/beta/security-group/describe/describe.go
+++ b/internal/cmd/beta/security-group/describe/describe.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -17,6 +15,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"strings"
 )
 
 type inputModel struct {
@@ -114,7 +113,11 @@ func outputResult(p *print.Printer, model *inputModel, resp *iaas.SecurityGroup)
 
 		return nil
 	default:
+		var content []tables.Table
+
 		table := tables.NewTable()
+		table.SetTitle("SECURITY GROUP")
+
 		if id := resp.Id; id != nil {
 			table.AddRow("ID", *id)
 		}
@@ -130,8 +133,13 @@ func outputResult(p *print.Printer, model *inputModel, resp *iaas.SecurityGroup)
 			table.AddSeparator()
 		}
 
+		if stateful := resp.Stateful; stateful != nil {
+			table.AddRow("STATEFUL", *stateful)
+			table.AddSeparator()
+		}
+
 		if resp.Labels != nil && len(*resp.Labels) > 0 {
-			labels := []string{}
+			var labels []string
 			for key, value := range *resp.Labels {
 				labels = append(labels, fmt.Sprintf("%s: %s", key, value))
 			}
@@ -139,7 +147,66 @@ func outputResult(p *print.Printer, model *inputModel, resp *iaas.SecurityGroup)
 			table.AddSeparator()
 		}
 
-		if err := table.Display(p); err != nil {
+		if resp.CreatedAt != nil {
+			table.AddRow("CREATED AT", utils.ConvertTimePToDateTimeString(resp.CreatedAt))
+			table.AddSeparator()
+		}
+
+		if resp.UpdatedAt != nil {
+			table.AddRow("UPDATED AT", utils.ConvertTimePToDateTimeString(resp.UpdatedAt))
+			table.AddSeparator()
+		}
+
+		content = append(content, table)
+
+		if resp.Rules != nil && len(*resp.Rules) > 0 {
+			rulesTable := tables.NewTable()
+			rulesTable.SetTitle("RULES")
+			rulesTable.SetHeader(
+				"ID",
+				"DESCRIPTION",
+				"PROTOCOL",
+				"DIRECTION",
+				"ETHER TYPE",
+				"PORT RANGE",
+				"IP RANGE",
+				"ICMP PARAMETERS",
+				"REMOTE SECURITY GROUP ID",
+			)
+
+			for _, rule := range *resp.Rules {
+				var portRange string
+				if rule.PortRange != nil {
+					portRange = fmt.Sprintf("%s-%s", utils.PtrString(rule.PortRange.Min), utils.PtrString(rule.PortRange.Max))
+				}
+
+				var protocol string
+				if rule.Protocol != nil {
+					protocol = utils.PtrString(rule.Protocol.Name)
+				}
+
+				var icmpParameter string
+				if rule.IcmpParameters != nil {
+					icmpParameter = fmt.Sprintf("type: %s, code: %s", utils.PtrString(rule.IcmpParameters.Type), utils.PtrString(rule.IcmpParameters.Code))
+				}
+
+				rulesTable.AddRow(
+					utils.PtrString(rule.Id),
+					utils.PtrString(rule.Description),
+					protocol,
+					utils.PtrString(rule.Direction),
+					utils.PtrString(rule.Ethertype),
+					portRange,
+					utils.PtrString(rule.IpRange),
+					icmpParameter,
+					utils.PtrString(rule.RemoteSecurityGroupId),
+				)
+			}
+
+			content = append(content, rulesTable)
+		}
+
+		if err := tables.DisplayTables(p, content); err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}
 

--- a/internal/cmd/beta/security-group/list/list.go
+++ b/internal/cmd/beta/security-group/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
@@ -137,9 +138,25 @@ func outputResult(p *print.Printer, outputFormat string, items []iaas.SecurityGr
 		return nil
 	default:
 		table := tables.NewTable()
-		table.SetHeader("ID", "NAME", "STATEFUL")
+		table.SetHeader("ID", "NAME", "STATEFUL", "DESCRIPTION", "LABELS")
 		for _, item := range items {
-			table.AddRow(utils.PtrString(item.Id), utils.PtrString(item.Name), utils.PtrString(item.Stateful))
+
+			labelsString := ""
+			if item.Labels != nil {
+				var labels []string
+				for key, value := range *item.Labels {
+					labels = append(labels, fmt.Sprintf("%s: %s", key, value))
+				}
+				labelsString = strings.Join(labels, ", ")
+			}
+
+			table.AddRow(
+				utils.PtrString(item.Id),
+				utils.PtrString(item.Name),
+				utils.PtrString(item.Stateful),
+				utils.PtrString(item.Description),
+				labelsString,
+			)
 		}
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/beta/security-group/list/list.go
+++ b/internal/cmd/beta/security-group/list/list.go
@@ -140,8 +140,7 @@ func outputResult(p *print.Printer, outputFormat string, items []iaas.SecurityGr
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATEFUL", "DESCRIPTION", "LABELS")
 		for _, item := range items {
-
-			labelsString := ""
+			var labelsString string
 			if item.Labels != nil {
 				var labels []string
 				for key, value := range *item.Labels {

--- a/internal/cmd/beta/security-group/rule/list/list.go
+++ b/internal/cmd/beta/security-group/rule/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -166,7 +167,7 @@ func outputResult(p *print.Printer, outputFormat string, securityGroupRules []ia
 		return nil
 	default:
 		table := tables.NewTable()
-		table.SetHeader("ID", "ETHER TYPE", "DIRECTION", "PROTOCOL")
+		table.SetHeader("ID", "ETHER TYPE", "DIRECTION", "PROTOCOL", "REMOTE SECURITY GROUP ID")
 
 		for _, securityGroupRule := range securityGroupRules {
 			etherType := ""
@@ -181,7 +182,13 @@ func outputResult(p *print.Printer, outputFormat string, securityGroupRules []ia
 				}
 			}
 
-			table.AddRow(*securityGroupRule.Id, etherType, *securityGroupRule.Direction, protocolName)
+			table.AddRow(
+				utils.PtrString(securityGroupRule.Id),
+				etherType,
+				utils.PtrString(securityGroupRule.Direction),
+				protocolName,
+				utils.PtrString(securityGroupRule.RemoteSecurityGroupId),
+			)
 			table.AddSeparator()
 		}
 

--- a/internal/cmd/beta/security-group/rule/list/list.go
+++ b/internal/cmd/beta/security-group/rule/list/list.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -17,9 +15,11 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
 const (

--- a/internal/cmd/beta/server/describe/describe.go
+++ b/internal/cmd/beta/server/describe/describe.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -207,12 +206,6 @@ func outputResult(p *print.Printer, model *inputModel, server *iaas.Server) erro
 			content = append(content, nicsTable)
 		}
 
-		server.MaintenanceWindow = &iaas.ServerMaintenance{
-			Details:  utils.Ptr("Details about maintenance"),
-			EndsAt:   utils.Ptr(time.Now()),
-			StartsAt: utils.Ptr(time.Now()),
-			Status:   utils.Ptr("PLANNED"),
-		}
 		if server.MaintenanceWindow != nil {
 			maintenanceWindow := tables.NewTable()
 			maintenanceWindow.SetTitle("Maintenance Window")

--- a/internal/cmd/beta/server/describe/describe.go
+++ b/internal/cmd/beta/server/describe/describe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -190,20 +191,28 @@ func outputResult(p *print.Printer, model *inputModel, server *iaas.Server) erro
 		if server.Nics != nil && len(*server.Nics) > 0 {
 			nicsTable := tables.NewTable()
 			nicsTable.SetTitle("Attached Network Interfaces")
-			nicsTable.SetHeader("ID", "NETWORK ID", "NETWORK NAME", "PUBLIC IP")
+			nicsTable.SetHeader("ID", "NETWORK ID", "NETWORK NAME", "IPv4", "PUBLIC IP")
 
 			for _, nic := range *server.Nics {
-				publicIp := ""
-				if nic.PublicIp != nil {
-					publicIp = *nic.PublicIp
-				}
-				nicsTable.AddRow(*nic.NicId, *nic.NetworkId, *nic.NetworkName, publicIp)
+				nicsTable.AddRow(
+					utils.PtrString(nic.NicId),
+					utils.PtrString(nic.NetworkId),
+					utils.PtrString(nic.NetworkName),
+					utils.PtrString(nic.Ipv4),
+					utils.PtrString(nic.PublicIp),
+				)
 				nicsTable.AddSeparator()
 			}
 
 			content = append(content, nicsTable)
 		}
 
+		server.MaintenanceWindow = &iaas.ServerMaintenance{
+			Details:  utils.Ptr("Details about maintenance"),
+			EndsAt:   utils.Ptr(time.Now()),
+			StartsAt: utils.Ptr(time.Now()),
+			Status:   utils.Ptr("PLANNED"),
+		}
 		if server.MaintenanceWindow != nil {
 			maintenanceWindow := tables.NewTable()
 			maintenanceWindow.SetTitle("Maintenance Window")

--- a/internal/cmd/beta/server/describe/describe.go
+++ b/internal/cmd/beta/server/describe/describe.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"github.com/goccy/go-yaml"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -17,6 +14,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -138,8 +136,10 @@ func outputResult(p *print.Printer, model *inputModel, server *iaas.Server) erro
 		table.AddSeparator()
 		table.AddRow("AVAILABILITY ZONE", *server.AvailabilityZone)
 		table.AddSeparator()
-		table.AddRow("BOOT VOLUME", *server.BootVolume.Id)
-		table.AddSeparator()
+		if server.BootVolume != nil && server.BootVolume.Id != nil {
+			table.AddRow("BOOT VOLUME", *server.BootVolume.Id)
+			table.AddSeparator()
+		}
 		table.AddRow("POWER STATUS", *server.PowerStatus)
 		table.AddSeparator()
 
@@ -201,6 +201,36 @@ func outputResult(p *print.Printer, model *inputModel, server *iaas.Server) erro
 			}
 
 			content = append(content, nicsTable)
+		}
+
+		if server.MaintenanceWindow != nil {
+			maintenanceWindow := tables.NewTable()
+			maintenanceWindow.SetTitle("Maintenance Window")
+
+			if server.MaintenanceWindow.Status != nil {
+				maintenanceWindow.AddRow("STATUS", *server.MaintenanceWindow.Status)
+				maintenanceWindow.AddSeparator()
+			}
+			if server.MaintenanceWindow.Details != nil {
+				maintenanceWindow.AddRow("DETAILS", *server.MaintenanceWindow.Details)
+				maintenanceWindow.AddSeparator()
+			}
+			if server.MaintenanceWindow.StartsAt != nil {
+				maintenanceWindow.AddRow(
+					"STARTS AT",
+					utils.ConvertTimePToDateTimeString(server.MaintenanceWindow.StartsAt),
+				)
+				maintenanceWindow.AddSeparator()
+			}
+			if server.MaintenanceWindow.EndsAt != nil {
+				maintenanceWindow.AddRow(
+					"ENDS AT",
+					utils.ConvertTimePToDateTimeString(server.MaintenanceWindow.EndsAt),
+				)
+				maintenanceWindow.AddSeparator()
+			}
+
+			content = append(content, maintenanceWindow)
 		}
 
 		err := tables.DisplayTables(p, content)

--- a/internal/cmd/beta/server/describe/describe.go
+++ b/internal/cmd/beta/server/describe/describe.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/goccy/go-yaml"
+	"strings"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -13,10 +14,10 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
-	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
 const (

--- a/internal/cmd/beta/server/list/list.go
+++ b/internal/cmd/beta/server/list/list.go
@@ -166,7 +166,7 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 		return nil
 	default:
 		table := tables.NewTable()
-		table.SetHeader("ID", "Name", "Status", "Machine Types", "Availability Zones", "Nic IPv4", "Public IPs")
+		table.SetHeader("ID", "Name", "Status", "Machine Type", "Availability Zones", "Nic IPv4", "Public IPs")
 
 		for i := range servers {
 			server := servers[i]
@@ -177,7 +177,7 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 				for i, nic := range *server.Nics {
 					if nic.Ipv4 != nil || nic.PublicIp != nil {
 						nicIPv4 += utils.PtrString(nic.Ipv4)
-						publicIPs = utils.PtrString(nic.PublicIp)
+						publicIPs += utils.PtrString(nic.PublicIp)
 
 						if i != len(*server.Nics)-1 {
 							publicIPs += "\n"

--- a/internal/cmd/beta/server/list/list.go
+++ b/internal/cmd/beta/server/list/list.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,9 +14,11 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
 const (

--- a/internal/cmd/beta/server/list/list_test.go
+++ b/internal/cmd/beta/server/list/list_test.go
@@ -53,6 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 func fixtureRequest(mods ...func(request *iaas.ApiListServersRequest)) iaas.ApiListServersRequest {
 	request := testClient.ListServers(testCtx, testProjectId)
 	request = request.LabelSelector(testLabelSelector)
+	request = request.Details(true)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -87,5 +87,5 @@ func ConvertTimePToDateTimeString(t *time.Time) string {
 	if t == nil {
 		return ""
 	}
-	return (*t).Format(time.DateTime)
+	return t.Format(time.DateTime)
 }

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -78,4 +79,13 @@ func ValidateURLDomain(value string) error {
 		return fmt.Errorf(`only urls belonging to domain %s are allowed`, allowedUrlDomain)
 	}
 	return nil
+}
+
+// ConvertTimePToDateTimeString converts a time.Time pointer to a string represented as "2006-01-02 15:04:05"
+// This function will return an empty string if the input is nil
+func ConvertTimePToDateTimeString(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return (*t).Format(time.DateTime)
 }


### PR DESCRIPTION
- `beta network list`
  - add value: prefixes
- `beta security-group describe`
  - add values
    - stateful
    - createdAt
    - updatedAt
  - add "Rules" table with values:
    - ID
    - description
    - protocol
    - direction
    - etherType
    - portRange
    - ipRange
    - icmpParameters
    - remoteSecurityGroupId
- `beta security-group list`
  - add values:
    - description
    - labels
- `beta security-group rule list`
  - add value: remoteSecurityGroupId
- `beta server describe`
  - add "Maintenance Window" table with values:
    - status
    - details
    - startsAt
    - endsAt
- `beta server list`
  - add values:
    - machineType
    - nicIPv4
    - publicIPs