### PR TITLE
Adjust CLI regarding ske API changes

### DIFF
--- a/internal/cmd/ske/cluster/create/create_test.go
+++ b/internal/cmd/ske/cluster/create/create_test.go
@@ -3,6 +3,7 @@ package create
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -60,8 +61,8 @@ var testPayload = &ske.CreateOrUpdateClusterPayload{
 			MachineImageVersion: utils.Ptr(true),
 		},
 		TimeWindow: &ske.TimeWindow{
-			End:   utils.Ptr("0000-01-01T05:00:00+02:00"),
-			Start: utils.Ptr("0000-01-01T03:00:00+02:00"),
+			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.UTC)),
+			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.UTC)),
 		},
 	},
 }

--- a/internal/cmd/ske/cluster/create/create_test.go
+++ b/internal/cmd/ske/cluster/create/create_test.go
@@ -61,8 +61,8 @@ var testPayload = &ske.CreateOrUpdateClusterPayload{
 			MachineImageVersion: utils.Ptr(true),
 		},
 		TimeWindow: &ske.TimeWindow{
-			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.UTC)),
-			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.UTC)),
+			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.FixedZone("test-zone", 2*60*60))),
+			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.FixedZone("test-zone", 2*60*60))),
 		},
 	},
 }

--- a/internal/cmd/ske/cluster/update/update_test.go
+++ b/internal/cmd/ske/cluster/update/update_test.go
@@ -61,8 +61,8 @@ var testPayload = ske.CreateOrUpdateClusterPayload{
 			MachineImageVersion: utils.Ptr(true),
 		},
 		TimeWindow: &ske.TimeWindow{
-			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.UTC)),
-			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.UTC)),
+			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.FixedZone("test-zone", 2*60*60))),
+			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.FixedZone("test-zone", 2*60*60))),
 		},
 	},
 }

--- a/internal/cmd/ske/cluster/update/update_test.go
+++ b/internal/cmd/ske/cluster/update/update_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -60,8 +61,8 @@ var testPayload = ske.CreateOrUpdateClusterPayload{
 			MachineImageVersion: utils.Ptr(true),
 		},
 		TimeWindow: &ske.TimeWindow{
-			End:   utils.Ptr("0000-01-01T05:00:00+02:00"),
-			Start: utils.Ptr("0000-01-01T03:00:00+02:00"),
+			End:   utils.Ptr(time.Date(0000, 01, 01, 5, 0, 0, 0, time.UTC)),
+			Start: utils.Ptr(time.Date(0000, 01, 01, 3, 0, 0, 0, time.UTC)),
 		},
 	},
 }

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -238,7 +239,7 @@ func buildKubernetesVersionsTable(resp *ske.ProviderOptions) (tables.Table, erro
 		}
 		expirationDate := ""
 		if v.ExpirationDate != nil {
-			expirationDate = *v.ExpirationDate
+			expirationDate = v.ExpirationDate.Format(time.RFC3339)
 		}
 		table.AddRow(*v.Version, *v.State, expirationDate, string(featureGate))
 	}
@@ -265,7 +266,7 @@ func buildMachineImagesTable(resp *ske.ProviderOptions) tables.Table {
 
 			expirationDate := "-"
 			if version.ExpirationDate != nil {
-				expirationDate = *version.ExpirationDate
+				expirationDate = version.ExpirationDate.Format(time.RFC3339)
 			}
 			table.AddRow(*image.Name, *version.Version, *version.State, expirationDate, criNamesString)
 		}

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -32,7 +32,6 @@ const (
 )
 
 type SKEClient interface {
-	GetServiceStatusExecute(ctx context.Context, projectId string) (*ske.ProjectResponse, error)
 	ListClustersExecute(ctx context.Context, projectId string) (*ske.ListClustersResponse, error)
 	ListProviderOptionsExecute(ctx context.Context) (*ske.ProviderOptions, error)
 }

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
 )
 
@@ -65,23 +64,10 @@ users:
 )
 
 type skeClientMocked struct {
-	serviceDisabled          bool
-	getServiceStatusFails    bool
-	getServiceStatusResp     *ske.ProjectResponse
 	listClustersFails        bool
 	listClustersResp         *ske.ListClustersResponse
 	listProviderOptionsFails bool
 	listProviderOptionsResp  *ske.ProviderOptions
-}
-
-func (m *skeClientMocked) GetServiceStatusExecute(_ context.Context, _ string) (*ske.ProjectResponse, error) {
-	if m.getServiceStatusFails {
-		return nil, fmt.Errorf("could not get service status")
-	}
-	if m.serviceDisabled {
-		return nil, &oapierror.GenericOpenAPIError{StatusCode: 404}
-	}
-	return m.getServiceStatusResp, nil
 }
 
 func (m *skeClientMocked) ListClustersExecute(_ context.Context, _ string) (*ske.ListClustersResponse, error) {


### PR DESCRIPTION
GetServiceStatusExecute was deprecated on 2024-04-16 and was now removed.
ExpiredDate was changed to time instead of string