### PR TITLE
Allow workaround if no browser can be opened

### DIFF
--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -232,7 +232,7 @@ func AuthorizeUser(p *print.Printer, isReauthentication bool) error {
 		}
 	})
 
-	p.Debug(print.DebugLevel, "opening browser for authentication")
+	p.Debug(print.DebugLevel, "opening browser for authentication: %s", authorizationURL)
 	p.Debug(print.DebugLevel, "using authentication server on %s", idpWellKnownConfig.Issuer)
 	p.Debug(print.DebugLevel, "using client ID %s for authentication ", idpClientID)
 


### PR DESCRIPTION
In debug mode, print out full authorizationURL to provide workaround when no window-server is available (hence no browser can be opened), as is the case when stackit-cli is run on headless systems.

The workaround is to call
``stackit --verbosity debug auth login``
Copy the link from the debug output and paste it to an available browser.