### PR TITLE
fix(auth): print token to stdout on get-access-token cmd

### DIFF
--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -42,7 +42,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				return &cliErr.AccessTokenExpiredError{}
 			}
 
-			p.Info("%s\n", accessToken)
+			p.Outputf("%s\n", accessToken)
 			return nil
 		},
 	}


### PR DESCRIPTION
relates to STACKITCLI-175 / #653