### PR TITLE
chore(sqlserverflex): show how to get flavors in create instance example

### DIFF
--- a/docs/stackit_beta_sqlserverflex_instance_create.md
+++ b/docs/stackit_beta_sqlserverflex_instance_create.md
@@ -16,7 +16,8 @@ stackit beta sqlserverflex instance create [flags]
   Create a SQLServer Flex instance with name "my-instance" and specify flavor by CPU and RAM. Other parameters are set to default values
   $ stackit beta sqlserverflex instance create --name my-instance --cpu 1 --ram 4
 
-  Create a SQLServer Flex instance with name "my-instance" and specify flavor by ID. Other parameters are set to default values
+  Create a SQLServer Flex instance with name "my-instance" and specify flavor by ID. Other parameters are set to default values.
+  The flavor ID can be retrieved by running "$ stackit beta sqlserverflex options --flavors"
   $ stackit beta sqlserverflex instance create --name my-instance --flavor-id xxx
 
   Create a SQLServer Flex instance with name "my-instance", specify flavor by CPU and RAM, set storage size to 20 GB, and restrict access to a specific range of IP addresses. Other parameters are set to default values

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -76,7 +76,8 @@ func NewCmd(p *print.Printer) *cobra.Command {
 				`Create a SQLServer Flex instance with name "my-instance" and specify flavor by CPU and RAM. Other parameters are set to default values`,
 				`$ stackit beta sqlserverflex instance create --name my-instance --cpu 1 --ram 4`),
 			examples.NewExample(
-				`Create a SQLServer Flex instance with name "my-instance" and specify flavor by ID. Other parameters are set to default values`,
+				`Create a SQLServer Flex instance with name "my-instance" and specify flavor by ID. Other parameters are set to default values.
+  The flavor ID can be retrieved by running "$ stackit beta sqlserverflex options --flavors"`,
 				`$ stackit beta sqlserverflex instance create --name my-instance --flavor-id xxx`),
 			examples.NewExample(
 				`Create a SQLServer Flex instance with name "my-instance", specify flavor by CPU and RAM, set storage size to 20 GB, and restrict access to a specific range of IP addresses. Other parameters are set to default values`,


### PR DESCRIPTION

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs`
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
