### PR TITLE
chore(observability): remove argus alias and warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,6 @@ This CLI is in a BETA state. More services and functionality will be supported s
 Your feedback is appreciated! 
 Feel free to open [GitHub issues](https://github.com/stackitcloud/stackit-cli) to provide feature requests and bug reports.
 
-<a name="warning-new-stackit-idp"></a>
-
-> [!WARNING]
-> On August 26 2024, The STACKIT Argus service was renamed to STACKIT Observability.
->
-> This means that there is a new command group `observability`, which offers the same functionality as the deprecated `argus` command.
->
-> Please make sure to **update your STACKIT CLI to the latest version after August 26 2024** to ensure that you start using `observability` command.
-
 ## Installation
 
 Please refer to our [installation guide](./INSTALLATION.md) for instructions on how to install and get started using the STACKIT CLI.

--- a/internal/cmd/observability/observability.go
+++ b/internal/cmd/observability/observability.go
@@ -15,12 +15,11 @@ import (
 
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "observability",
-		Aliases: []string{"argus"},
-		Short:   "Provides functionality for Observability",
-		Long:    "Provides functionality for Observability.",
-		Args:    args.NoArgs,
-		Run:     utils.CmdHelp,
+		Use:   "observability",
+		Short: "Provides functionality for Observability",
+		Long:  "Provides functionality for Observability.",
+		Args:  args.NoArgs,
+		Run:   utils.CmdHelp,
 	}
 	addSubcommands(cmd, p)
 	return cmd


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-50

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs`
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
