### PR TITLE
add GetAuthEmail() function, to get the email of the authenticated user or service account - fix: project list command does not work with service account  - it uses the GetAuthEmail() function to get correct email

### DIFF
--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -167,7 +167,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient resourceMana
 	}
 
 	if model.ParentId == nil && model.ProjectIdLike == nil && model.Member == nil {
-		email, err := auth.GetAuthField(auth.USER_EMAIL)
+		email, err := auth.GetAuthEmail()
 		if err != nil {
 			return req, fmt.Errorf("get email of authenticated user: %w", err)
 		}

--- a/internal/cmd/project/list/list_test.go
+++ b/internal/cmd/project/list/list_test.go
@@ -259,7 +259,12 @@ func TestParseInput(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	keyring.MockInit()
-	err := auth.SetAuthField(auth.USER_EMAIL, "test@test.com")
+	err := auth.SetAuthFlow(auth.AUTH_FLOW_USER_TOKEN)
+	if err != nil {
+		t.Fatalf("Failed to set auth flow: %v", err)
+	}
+
+	err = auth.SetAuthField(auth.USER_EMAIL, "test@test.com")
 	if err != nil {
 		t.Fatalf("Failed to set auth user email: %v", err)
 	}

--- a/internal/pkg/auth/storage.go
+++ b/internal/pkg/auth/storage.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"os"
 	"path/filepath"
 
@@ -23,7 +22,6 @@ type AuthFlow string
 
 const (
 	keyringService     = "stackit-cli"
-	textFileFolderName = "stackit"
 	textFileName       = "cli-auth-storage.txt"
 	envAccessTokenName = "STACKIT_ACCESS_TOKEN"
 )
@@ -340,6 +338,29 @@ func GetProfileEmail(profile string) string {
 		}
 	}
 	return email
+}
+
+// GetAuthEmail returns the email of the authenticated account.
+// If the environment variable STACKIT_ACCESS_TOKEN is set, the email of this token will be returned.
+func GetAuthEmail() (string, error) {
+	// If STACKIT_ACCESS_TOKEN is set, get the mail from the token
+	if accessToken := os.Getenv(envAccessTokenName); accessToken != "" {
+		email, err := getEmailFromToken(accessToken)
+		if err != nil {
+			return "", fmt.Errorf("error getting email from token: %w", err)
+		}
+		return email, nil
+	}
+
+	profile, err := config.GetProfile()
+	if err != nil {
+		return "", fmt.Errorf("error getting profile: %w", err)
+	}
+	email := GetProfileEmail(profile)
+	if email == "" {
+		return "", fmt.Errorf("error getting profile email. email is empty")
+	}
+	return email, nil
 }
 
 func LoginUser(email, accessToken, refreshToken, sessionExpiresAtUnix string) error {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-177

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
