### PR TITLE
feat(ci): close stale PRs automatically

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,31 @@
+name: "Stale"
+on:
+  schedule:
+    # every night at 01:30
+    - cron: "30 1 * * *"
+  # run this workflow if the workflow definition gets changed within a PR
+  pull_request:
+    branches: ["main"]
+    paths: [".github/workflows/stale.yaml"]
+
+env:
+  DAYS_BEFORE_PR_STALE: 7
+  DAYS_BEFORE_PR_CLOSE: 7
+
+jobs:
+  stale:
+    name: "Stale"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: "Mark old PRs as stale"
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.CLI_RELEASE }}
+          stale-pr-message: "This PR was marked as stale after ${{ env.DAYS_BEFORE_PR_STALE }} days of inactivity and will be closed after another ${{ env.DAYS_BEFORE_PR_CLOSE }} days of further inactivity. If this PR should be kept open, just add a comment, remove the stale label or push new commits to it."
+          close-pr-message: "This PR was closed automatically because it has been stalled for ${{ env.DAYS_BEFORE_PR_CLOSE }} days with no activity. Feel free to re-open it at any time."
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_STALE }}
+          days-before-pr-close: ${{ env.DAYS_BEFORE_PR_CLOSE }}
+          # never mark issues as stale or close them
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,6 +12,10 @@ env:
   DAYS_BEFORE_PR_STALE: 7
   DAYS_BEFORE_PR_CLOSE: 7
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: "Stale"
@@ -21,7 +25,7 @@ jobs:
       - name: "Mark old PRs as stale"
         uses: actions/stale@v9
         with:
-          repo-token: ${{ secrets.CLI_RELEASE }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: "This PR was marked as stale after ${{ env.DAYS_BEFORE_PR_STALE }} days of inactivity and will be closed after another ${{ env.DAYS_BEFORE_PR_CLOSE }} days of further inactivity. If this PR should be kept open, just add a comment, remove the stale label or push new commits to it."
           close-pr-message: "This PR was closed automatically because it has been stalled for ${{ env.DAYS_BEFORE_PR_CLOSE }} days with no activity. Feel free to re-open it at any time."
           days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_STALE }}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-207

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
