### PR TITLE
fix(image): Uefi flag cannot be set to false

### DIFF
--- a/docs/stackit_image_create.md
+++ b/docs/stackit_image_create.md
@@ -42,7 +42,7 @@ stackit image create [flags]
       --rescue-bus string        Sets the device bus when the image is used as a rescue image.
       --rescue-device string     Sets the device when the image is used as a rescue image.
       --secure-boot              Enables Secure Boot.
-      --uefi                     Enables UEFI boot.
+      --uefi                     Enables UEFI boot. (default true)
       --video-model string       Sets Graphic device model.
       --virtio-scsi              Enables the use of VirtIO SCSI to provide block device access. By default instances use VirtIO Block.
 ```

--- a/internal/cmd/image/create/create.go
+++ b/internal/cmd/image/create/create.go
@@ -62,7 +62,7 @@ type imageConfig struct {
 	RescueBus              *string
 	RescueDevice           *string
 	SecureBoot             *bool
-	Uefi                   *bool
+	Uefi                   bool
 	VideoModel             *string
 	VirtioScsi             *bool
 }
@@ -270,7 +270,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(rescueBusFlag, "", "Sets the device bus when the image is used as a rescue image.")
 	cmd.Flags().String(rescueDeviceFlag, "", "Sets the device when the image is used as a rescue image.")
 	cmd.Flags().Bool(secureBootFlag, false, "Enables Secure Boot.")
-	cmd.Flags().Bool(uefiFlag, false, "Enables UEFI boot.")
+	cmd.Flags().Bool(uefiFlag, true, "Enables UEFI boot.")
 	cmd.Flags().String(videoModelFlag, "", "Sets Graphic device model.")
 	cmd.Flags().Bool(virtioScsiFlag, false, "Enables the use of VirtIO SCSI to provide block device access. By default instances use VirtIO Block.")
 
@@ -311,7 +311,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 			RescueBus:              flags.FlagToStringPointer(p, cmd, rescueBusFlag),
 			RescueDevice:           flags.FlagToStringPointer(p, cmd, rescueDeviceFlag),
 			SecureBoot:             flags.FlagToBoolPointer(p, cmd, secureBootFlag),
-			Uefi:                   flags.FlagToBoolPointer(p, cmd, uefiFlag),
+			Uefi:                   flags.FlagToBoolValue(p, cmd, uefiFlag),
 			VideoModel:             flags.FlagToStringPointer(p, cmd, videoModelFlag),
 			VirtioScsi:             flags.FlagToBoolPointer(p, cmd, virtioScsiFlag),
 		},
@@ -367,7 +367,7 @@ func createPayload(_ context.Context, model *inputModel) iaas.CreateImagePayload
 			RescueBus:              iaas.NewNullableString(model.Config.RescueBus),
 			RescueDevice:           iaas.NewNullableString(model.Config.RescueDevice),
 			SecureBoot:             model.Config.SecureBoot,
-			Uefi:                   model.Config.Uefi,
+			Uefi:                   utils.Ptr(model.Config.Uefi),
 			VideoModel:             iaas.NewNullableString(model.Config.VideoModel),
 			VirtioScsi:             model.Config.VirtioScsi,
 		}

--- a/internal/cmd/image/create/create_test.go
+++ b/internal/cmd/image/create/create_test.go
@@ -105,7 +105,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			RescueBus:              &testRescueBus,
 			RescueDevice:           &testRescueDevice,
 			SecureBoot:             &testSecureBoot,
-			Uefi:                   &testUefi,
+			Uefi:                   testUefi,
 			VideoModel:             &testVideoModel,
 			VirtioScsi:             &testVirtioScsi,
 		},
@@ -247,6 +247,16 @@ func TestParseInput(t *testing.T) {
 			isValid: false,
 		},
 		{
+			description: "uefi flag is set to false",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[uefiFlag] = strconv.FormatBool(false)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.Config.Uefi = false
+			}),
+		},
+		{
 			description: "no rescue device and no bus is valid",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, rescueBusFlag)
@@ -347,7 +357,7 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "uefi flag",
 			model: fixtureInputModel(func(model *inputModel) {
-				model.Config.Uefi = utils.Ptr(false)
+				model.Config.Uefi = false
 			}),
 			expectedRequest: fixtureRequest(func(request *iaas.ApiCreateImageRequest) {
 				*request = request.CreateImagePayload(fixtureCreatePayload(func(payload *iaas.CreateImagePayload) {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #694 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
