### PR TITLE
Fix: Exit less if an interrupt character is typed

### DIFF
--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -189,7 +189,8 @@ func (p *Printer) PagerDisplay(content string) error {
 	// -S: disables line wrapping
 	// -w: highlight the first line after moving one full page down
 	// -R: interprets ANSI color and style sequences
-	pagerCmd := exec.Command("less", "-F", "-S", "-w", "-R")
+	// -K: exits if an interrupt character is typed
+	pagerCmd := exec.Command("less", "-F", "-S", "-w", "-R", "-K")
 
 	pager, pagerExists := os.LookupEnv("PAGER")
 	if pagerExists && pager != "nil" && pager != "" {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
