### PR TITLE
feat: prettify json output using stackit curl

### DIFF
--- a/internal/cmd/curl/curl_test.go
+++ b/internal/cmd/curl/curl_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -426,6 +428,22 @@ func TestOutputResponse(t *testing.T) {
 				resp:  &http.Response{Body: http.NoBody},
 			},
 			wantErr: false,
+		},
+		{
+			name: "expired jwt curl",
+			args: args{
+				model: fixtureInputModel(),
+				resp:  &http.Response{Body: io.NopCloser(strings.NewReader("Jwt is expired"))},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mssing jwt curl",
+			args: args{
+				model: fixtureInputModel(),
+				resp:  &http.Response{Body: io.NopCloser(strings.NewReader("Jwt is missing"))},
+			},
+			wantErr: true,
 		},
 	}
 	p := print.NewPrinter()


### PR DESCRIPTION
## Description

When using the `stackit curl` command, it's more readable to prettify the JSON response, especially on systems without tools like `jq` or `yq` for easy content extraction. Additionally, I've introduced an error message for expired JWT tokens.

Test it out:
```sh
./bin/stackit curl "https://iaas.api.eu01.stackit.cloud/v1beta1/networks/public-ip-ranges"
./bin/stackit curl "https://iaas.api.eu01.stackit.cloud/v1beta1/networks/public-ip-ranges" | jq
./bin/stackit curl "https://iaas.api.eu01.stackit.cloud/v1beta1/networks/public-ip-ranges" | yq eval '.items[].cidr'
```

Error messages stackit curl:
Old:
![Screenshot 2025-04-29 at 11 54 39](https://github.com/user-attachments/assets/93323d98-f2fb-4bd7-aac4-daf566081edd)

New:
![Screenshot 2025-04-29 at 11 54 28](https://github.com/user-attachments/assets/45c000e3-4afe-428a-8312-62ce55aecd71)

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 




