### PR TITLE
Draft: fix(project): limit flag not set

### DIFF
--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -173,7 +173,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient resourceMana
 		}
 		req = req.Member(email)
 	}
-	req = req.Limit(float32(model.PageSize))
+
+	req = req.Limit(float32(*model.Limit))
 	req = req.Offset(float32(offset))
 	return req, nil
 }


### PR DESCRIPTION
## Description

Fixes a small issue which does not set the limit correct

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
