### PR TITLE
fix panic in auth.TokenExpired

### DIFF
--- a/internal/pkg/auth/user_token_flow.go
+++ b/internal/pkg/auth/user_token_flow.go
@@ -118,6 +118,8 @@ func TokenExpired(token string) (bool, error) {
 	expirationTimestampNumeric, err := tokenParsed.Claims.GetExpirationTime()
 	if err != nil {
 		return false, fmt.Errorf("get expiration timestamp from access token: %w", err)
+	} else if expirationTimestampNumeric == nil {
+		return false, nil
 	}
 	expirationTimestamp := expirationTimestampNumeric.Time
 	now := time.Now()

--- a/internal/pkg/auth/user_token_flow_test.go
+++ b/internal/pkg/auth/user_token_flow_test.go
@@ -381,3 +381,40 @@ func createTokens(accessTokenExpiresAt, refreshTokenExpiresAt time.Time) (access
 
 	return accessToken, refreshToken, nil
 }
+
+func TestTokenExpired(t *testing.T) {
+	tests := []struct {
+		desc     string
+		token    string
+		expected bool
+	}{
+		{
+			desc:     "token without exp",
+			token:    `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+			expected: false,
+		},
+		{
+			desc:     "exp 0",
+			token:    `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjB9.rIhVGrtR0B0gUYPZDnB6LZ_w7zckH_9qFZBWG4rCkRY`,
+			expected: true,
+		},
+		{
+			desc:     "exp 9007199254740991",
+			token:    `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIyNTc2MDkwNzExMTExMTExfQ.aStshPjoSKTIcBeESbLJWvbMVuw-XWInXcf1P7tiWaE`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual, err := TokenExpired(tt.token)
+			if err != nil {
+				t.Fatalf("TokenExpired() error = %v", err)
+			}
+
+			if actual != tt.expected {
+				t.Errorf("TokenExpired() = %v, want %v", actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a panic, if CLI is authenticated with an invalid Service Account Token.

`stackit auth activate-service-account` accept any JWT token with an email claim. 

However, `stackit auth get-access-token` panics, because the command checks for an expire date, which is not present.

The underlaying JWT library does not return an error, if the exp claim is not present.

JWT RFC explained that exp is an manatory field. However in any case, an application should never panic.

Ref: https://github.com/golang-jwt/jwt/blob/048854f1b0ac96c0a843d52fc09d7878b853683f/map_claims.go#L48

```
stackit auth activate-service-account --service-account-token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkdW1teS11c2VyIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJqd2RAZXhhbXBsZS5jb20iLCJpYXQiOjE2MDAwMDAwMDB9.dC8oFSpuKo7y1r3zHqPqGXnHTsFf2w0tFt6Iwb3kUpw 
You have been successfully authenticated to the STACKIT CLI!
Service account email: jwd@example.com

stackit auth get-access-token
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102ea1328]

goroutine 1 [running]:
github.com/stackitcloud/stackit-cli/internal/pkg/auth.TokenExpired({0x140004ddc80, 0xbd})
        /Users/runner/work/stackit-cli/stackit-cli/internal/pkg/auth/user_token_flow.go:122 +0x138
github.com/stackitcloud/stackit-cli/internal/cmd/auth/get-access-token.NewCmd.func1(0x14000017800?, {0x10549ec40?, 0x4?, 0x103d8a888?})
        /Users/runner/work/stackit-cli/stackit-cli/internal/cmd/auth/get-access-token/get_access_token.go:37 +0x40
github.com/spf13/cobra.(*Command).execute(0x140001e3b08, {0x10549ec40, 0x0, 0x0})
        /Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x140001e2c08)
        /Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/stackitcloud/stackit-cli/internal/cmd.Execute({0x1040ab348, 0x6}, {0x1040ab6e0, 0x14})
        /Users/runner/work/stackit-cli/stackit-cli/internal/cmd/root.go:208 +0x98
main.main()
        /Users/runner/work/stackit-cli/stackit-cli/main.go:18 +0x40
```

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
