### PR TITLE
feat(cli): set custom user-agent header for STACKIT API calls

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -53,7 +53,7 @@ Please remember to run `make generate-docs` after your changes to keep the comma
 
 Below is a typical structure of a CLI command:
 
-https://github.com/stackitcloud/stackit-cli/blob/6f762bd56407ed232080efabc4d2bf87f260b71d/.github/docs/contribution-guide/cmd.go#L23-L156
+https://github.com/stackitcloud/stackit-cli/blob/85ce44cd18d11169f2548d8657031b5fc6f94740/.github/docs/contribution-guide/cmd.go#L23-L156
 
 Please remember to always add unit tests for `parseInput`, `buildRequest` (in `bar_test.go`), and any other util functions used.
 
@@ -83,7 +83,7 @@ If you want to add a command that uses a STACKIT service `foo` that was not yet 
     1.  This is done in `internal/pkg/services/foo/client/client.go`
     2.  Below is an example of a typical `client.go` file structure:
 
-https://github.com/stackitcloud/stackit-cli/blob/6f762bd56407ed232080efabc4d2bf87f260b71d/.github/docs/contribution-guide/client.go#L12-L35
+https://github.com/stackitcloud/stackit-cli/blob/85ce44cd18d11169f2548d8657031b5fc6f94740/.github/docs/contribution-guide/client.go#L12-L35
 
 ### Local development
 

--- a/internal/cmd/affinity-groups/create/create.go
+++ b/internal/cmd/affinity-groups/create/create.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/affinity-groups/delete/delete.go
+++ b/internal/cmd/affinity-groups/delete/delete.go
@@ -47,12 +47,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/affinity-groups/describe/describe.go
+++ b/internal/cmd/affinity-groups/describe/describe.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/affinity-groups/list/list.go
+++ b/internal/cmd/affinity-groups/list/list.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/create/create.go
+++ b/internal/cmd/beta/alb/create/create.go
@@ -54,12 +54,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/delete/delete.go
+++ b/internal/cmd/beta/alb/delete/delete.go
@@ -45,12 +45,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/describe/describe.go
+++ b/internal/cmd/beta/alb/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/list/list.go
+++ b/internal/cmd/beta/alb/list/list.go
@@ -55,12 +55,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/observability-credentials/add/add.go
+++ b/internal/cmd/beta/alb/observability-credentials/add/add.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/observability-credentials/delete/delete.go
+++ b/internal/cmd/beta/alb/observability-credentials/delete/delete.go
@@ -44,7 +44,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/observability-credentials/describe/describe.go
+++ b/internal/cmd/beta/alb/observability-credentials/describe/describe.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/observability-credentials/list/list.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/observability-credentials/update/update.go
+++ b/internal/cmd/beta/alb/observability-credentials/update/update.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			model := parseInput(params.Printer, cmd, args)
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/plans/plans.go
+++ b/internal/cmd/beta/alb/plans/plans.go
@@ -44,12 +44,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/pool/update/update.go
+++ b/internal/cmd/beta/alb/pool/update/update.go
@@ -54,12 +54,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/alb/quotas/quotas.go
+++ b/internal/cmd/beta/alb/quotas/quotas.go
@@ -43,7 +43,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/alb/update/update.go
+++ b/internal/cmd/beta/alb/update/update.go
@@ -55,12 +55,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/sqlserverflex/database/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/database/create/create.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/database/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/database/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/database/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/database/describe/describe.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/database/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return fmt.Errorf("get SQLServer Flex databases: %w", err)
 			}
 			if resp.Databases == nil || len(*resp.Databases) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -93,12 +93,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/instance/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return fmt.Errorf("get SQLServer Flex instances: %w", err)
 			}
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/beta/sqlserverflex/instance/update/update.go
+++ b/internal/cmd/beta/sqlserverflex/instance/update/update.go
@@ -84,7 +84,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/options/options.go
+++ b/internal/cmd/beta/sqlserverflex/options/options.go
@@ -116,7 +116,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/user/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/user/delete/delete.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/user/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/user/describe/describe.go
@@ -61,7 +61,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/user/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
+++ b/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/config/list/list_test.go
+++ b/internal/cmd/config/list/list_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 )
 

--- a/internal/cmd/config/profile/create/create.go
+++ b/internal/cmd/config/profile/create/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"

--- a/internal/cmd/config/profile/create/create_test.go
+++ b/internal/cmd/config/profile/create/create_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 

--- a/internal/cmd/config/profile/delete/delete.go
+++ b/internal/cmd/config/profile/delete/delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"

--- a/internal/cmd/config/profile/delete/delete_test.go
+++ b/internal/cmd/config/profile/delete/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 

--- a/internal/cmd/config/profile/export/export_test.go
+++ b/internal/cmd/config/profile/export/export_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 

--- a/internal/cmd/config/profile/list/list.go
+++ b/internal/cmd/config/profile/list/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
+
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"

--- a/internal/cmd/config/profile/set/set_test.go
+++ b/internal/cmd/config/profile/set/set_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 

--- a/internal/cmd/config/set/set_test.go
+++ b/internal/cmd/config/set/set_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"

--- a/internal/cmd/config/unset/unset_test.go
+++ b/internal/cmd/config/unset/unset_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/google/go-cmp/cmp"

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/record-set/delete/delete.go
+++ b/internal/cmd/dns/record-set/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/record-set/list/list.go
+++ b/internal/cmd/dns/record-set/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/record-set/update/update.go
+++ b/internal/cmd/dns/record-set/update/update.go
@@ -62,7 +62,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/record-set/update/update_test.go
+++ b/internal/cmd/dns/record-set/update/update_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"

--- a/internal/cmd/dns/zone/clone/clone.go
+++ b/internal/cmd/dns/zone/clone/clone.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -78,12 +78,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/dns/zone/delete/delete.go
+++ b/internal/cmd/dns/zone/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -89,7 +89,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			if len(zones) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/dns/zone/update/update.go
+++ b/internal/cmd/dns/zone/update/update.go
@@ -70,7 +70,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/image/create/create.go
+++ b/internal/cmd/image/create/create.go
@@ -106,7 +106,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/image/delete/delete.go
+++ b/internal/cmd/image/delete/delete.go
@@ -42,12 +42,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/image/describe/describe.go
+++ b/internal/cmd/image/describe/describe.go
@@ -44,7 +44,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/image/list/list.go
+++ b/internal/cmd/image/list/list.go
@@ -60,12 +60,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/image/update/update.go
+++ b/internal/cmd/image/update/update.go
@@ -120,12 +120,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/key-pair/create/create.go
+++ b/internal/cmd/key-pair/create/create.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/key-pair/delete/delete.go
+++ b/internal/cmd/key-pair/delete/delete.go
@@ -44,7 +44,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/key-pair/describe/describe.go
+++ b/internal/cmd/key-pair/describe/describe.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -66,7 +66,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/key-pair/update/update.go
+++ b/internal/cmd/key-pair/update/update.go
@@ -47,7 +47,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			model := parseInput(params.Printer, cmd, args)
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/create/create.go
+++ b/internal/cmd/load-balancer/create/create.go
@@ -66,12 +66,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/delete/delete.go
+++ b/internal/cmd/load-balancer/delete/delete.go
@@ -45,7 +45,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/describe/describe.go
+++ b/internal/cmd/load-balancer/describe/describe.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/generate-payload/generate_payload.go
+++ b/internal/cmd/load-balancer/generate-payload/generate_payload.go
@@ -142,7 +142,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/list/list.go
+++ b/internal/cmd/load-balancer/list/list.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.LoadBalancers == nil || (resp.LoadBalancers != nil && len(*resp.LoadBalancers) == 0) {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/observability-credentials/add/add.go
+++ b/internal/cmd/load-balancer/observability-credentials/add/add.go
@@ -57,12 +57,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
+++ b/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
@@ -41,12 +41,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/observability-credentials/delete/delete.go
+++ b/internal/cmd/load-balancer/observability-credentials/delete/delete.go
@@ -46,12 +46,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/observability-credentials/describe/describe.go
+++ b/internal/cmd/load-balancer/observability-credentials/describe/describe.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -67,12 +67,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/observability-credentials/update/update.go
+++ b/internal/cmd/load-balancer/observability-credentials/update/update.go
@@ -68,12 +68,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/load-balancer/quota/quota.go
+++ b/internal/cmd/load-balancer/quota/quota.go
@@ -41,7 +41,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/target-pool/add-target/add_target.go
+++ b/internal/cmd/load-balancer/target-pool/add-target/add_target.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/target-pool/describe/describe.go
+++ b/internal/cmd/load-balancer/target-pool/describe/describe.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/target-pool/remove-target/remove_target.go
+++ b/internal/cmd/load-balancer/target-pool/remove-target/remove_target.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/load-balancer/update/update.go
+++ b/internal/cmd/load-balancer/update/update.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/credentials/create/create.go
+++ b/internal/cmd/logme/credentials/create/create.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/credentials/delete/delete.go
+++ b/internal/cmd/logme/credentials/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/credentials/describe/describe.go
+++ b/internal/cmd/logme/credentials/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/credentials/list/list.go
+++ b/internal/cmd/logme/credentials/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/instance/create/create.go
+++ b/internal/cmd/logme/instance/create/create.go
@@ -81,12 +81,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/logme/instance/delete/delete.go
+++ b/internal/cmd/logme/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/instance/describe/describe.go
+++ b/internal/cmd/logme/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/logme/instance/update/update.go
+++ b/internal/cmd/logme/instance/update/update.go
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/logme/plans/plans.go
+++ b/internal/cmd/logme/plans/plans.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Offerings
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/credentials/delete/delete.go
+++ b/internal/cmd/mariadb/credentials/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -81,12 +81,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/mariadb/instance/delete/delete.go
+++ b/internal/cmd/mariadb/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -76,7 +76,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Offerings
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/backup/list/list.go
+++ b/internal/cmd/mongodbflex/backup/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/backup/restore/restore.go
+++ b/internal/cmd/mongodbflex/backup/restore/restore.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/backup/schedule/schedule.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
+++ b/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
@@ -76,7 +76,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -83,12 +83,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/mongodbflex/instance/delete/delete.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return fmt.Errorf("get MongoDB Flex instances: %w", err)
 			}
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -67,7 +67,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/delete/delete.go
+++ b/internal/cmd/mongodbflex/user/delete/delete.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/create/create.go
+++ b/internal/cmd/network-area/create/create.go
@@ -78,13 +78,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			var orgLabel string
-			rmApiClient, err := rmClient.ConfigureClient(params.Printer)
+			rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
 			if err == nil {
 				orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
 				if err != nil {

--- a/internal/cmd/network-area/delete/delete.go
+++ b/internal/cmd/network-area/delete/delete.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/describe/describe.go
+++ b/internal/cmd/network-area/describe/describe.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
-	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 	rmUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -67,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -81,7 +82,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
 				var orgLabel string
-				rmApiClient, err := rmClient.ConfigureClient(params.Printer)
+				rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
 				if err == nil {
 					orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
 					if err != nil {

--- a/internal/cmd/network-area/network-range/create/create.go
+++ b/internal/cmd/network-area/network-range/create/create.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/network-range/delete/delete.go
+++ b/internal/cmd/network-area/network-range/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/network-range/describe/describe.go
+++ b/internal/cmd/network-area/network-range/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/route/create/create.go
+++ b/internal/cmd/network-area/route/create/create.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/route/delete/delete.go
+++ b/internal/cmd/network-area/route/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/route/describe/describe.go
+++ b/internal/cmd/network-area/route/describe/describe.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -62,7 +62,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/route/update/update.go
+++ b/internal/cmd/network-area/route/update/update.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-area/update/update.go
+++ b/internal/cmd/network-area/update/update.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -13,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
-	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 	rmUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
@@ -66,13 +67,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			var orgLabel string
-			rmApiClient, err := rmClient.ConfigureClient(params.Printer)
+			rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
 			if err == nil {
 				orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
 				if err != nil {

--- a/internal/cmd/network-interface/create/create.go
+++ b/internal/cmd/network-interface/create/create.go
@@ -74,12 +74,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/network-interface/delete/delete.go
+++ b/internal/cmd/network-interface/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-interface/describe/describe.go
+++ b/internal/cmd/network-interface/describe/describe.go
@@ -61,7 +61,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-interface/list/list.go
+++ b/internal/cmd/network-interface/list/list.go
@@ -66,7 +66,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network-interface/update/update.go
+++ b/internal/cmd/network-interface/update/update.go
@@ -76,7 +76,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network/create/create.go
+++ b/internal/cmd/network/create/create.go
@@ -96,12 +96,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/network/delete/delete.go
+++ b/internal/cmd/network/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network/describe/describe.go
+++ b/internal/cmd/network/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/network/list/list.go
+++ b/internal/cmd/network/list/list.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/network/update/update.go
+++ b/internal/cmd/network/update/update.go
@@ -79,7 +79,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/bucket/create/create.go
+++ b/internal/cmd/object-storage/bucket/create/create.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/bucket/delete/delete.go
+++ b/internal/cmd/object-storage/bucket/delete/delete.go
@@ -46,7 +46,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/bucket/describe/describe.go
+++ b/internal/cmd/object-storage/bucket/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/bucket/list/list.go
+++ b/internal/cmd/object-storage/bucket/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return fmt.Errorf("get Object Storage buckets: %w", err)
 			}
 			if resp.Buckets == nil || len(*resp.Buckets) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/object-storage/credentials-group/create/create.go
+++ b/internal/cmd/object-storage/credentials-group/create/create.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/credentials-group/delete/delete.go
+++ b/internal/cmd/object-storage/credentials-group/delete/delete.go
@@ -46,7 +46,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/credentials/create/create.go
+++ b/internal/cmd/object-storage/credentials/create/create.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/credentials/delete/delete.go
+++ b/internal/cmd/object-storage/credentials/delete/delete.go
@@ -47,7 +47,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/credentials/list/list.go
+++ b/internal/cmd/object-storage/credentials/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/object-storage/disable/disable.go
+++ b/internal/cmd/object-storage/disable/disable.go
@@ -40,12 +40,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/object-storage/enable/enable.go
+++ b/internal/cmd/object-storage/enable/enable.go
@@ -40,12 +40,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/observability/credentials/create/create.go
+++ b/internal/cmd/observability/credentials/create/create.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/credentials/delete/delete.go
+++ b/internal/cmd/observability/credentials/delete/delete.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/credentials/list/list.go
+++ b/internal/cmd/observability/credentials/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/grafana/describe/describe.go
+++ b/internal/cmd/observability/grafana/describe/describe.go
@@ -61,7 +61,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/grafana/public-read-access/disable/disable.go
+++ b/internal/cmd/observability/grafana/public-read-access/disable/disable.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/grafana/public-read-access/enable/enable.go
+++ b/internal/cmd/observability/grafana/public-read-access/enable/enable.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/grafana/single-sign-on/disable/disable.go
+++ b/internal/cmd/observability/grafana/single-sign-on/disable/disable.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/grafana/single-sign-on/enable/enable.go
+++ b/internal/cmd/observability/grafana/single-sign-on/enable/enable.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/instance/create/create.go
+++ b/internal/cmd/observability/instance/create/create.go
@@ -61,12 +61,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/observability/instance/delete/delete.go
+++ b/internal/cmd/observability/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/instance/describe/describe.go
+++ b/internal/cmd/observability/instance/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/instance/list/list.go
+++ b/internal/cmd/observability/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/observability/instance/update/update.go
+++ b/internal/cmd/observability/instance/update/update.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/plans/plans.go
+++ b/internal/cmd/observability/plans/plans.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Plans
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/observability/scrape-config/create/create.go
+++ b/internal/cmd/observability/scrape-config/create/create.go
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/scrape-config/delete/delete.go
+++ b/internal/cmd/observability/scrape-config/delete/delete.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/scrape-config/describe/describe.go
+++ b/internal/cmd/observability/scrape-config/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/scrape-config/generate-payload/generate_payload.go
+++ b/internal/cmd/observability/scrape-config/generate-payload/generate_payload.go
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/scrape-config/list/list.go
+++ b/internal/cmd/observability/scrape-config/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/observability/scrape-config/update/update.go
+++ b/internal/cmd/observability/scrape-config/update/update.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/credentials/delete/delete.go
+++ b/internal/cmd/opensearch/credentials/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/instance/create/create.go
+++ b/internal/cmd/opensearch/instance/create/create.go
@@ -83,12 +83,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/opensearch/instance/delete/delete.go
+++ b/internal/cmd/opensearch/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/opensearch/instance/update/update.go
+++ b/internal/cmd/opensearch/instance/update/update.go
@@ -79,7 +79,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Offerings
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/organization/member/add/add.go
+++ b/internal/cmd/organization/member/add/add.go
@@ -66,7 +66,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -62,7 +62,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/backup/describe/describe.go
+++ b/internal/cmd/postgresflex/backup/describe/describe.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/backup/list/list.go
+++ b/internal/cmd/postgresflex/backup/list/list.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/backup/update-schedule/update_schedule.go
+++ b/internal/cmd/postgresflex/backup/update-schedule/update_schedule.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/instance/clone/clone.go
+++ b/internal/cmd/postgresflex/instance/clone/clone.go
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/instance/create/create.go
+++ b/internal/cmd/postgresflex/instance/create/create.go
@@ -84,12 +84,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/postgresflex/instance/delete/delete.go
+++ b/internal/cmd/postgresflex/instance/delete/delete.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/instance/describe/describe.go
+++ b/internal/cmd/postgresflex/instance/describe/describe.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return fmt.Errorf("get PostgreSQL Flex instances: %w", err)
 			}
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/postgresflex/instance/update/update.go
+++ b/internal/cmd/postgresflex/instance/update/update.go
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/options/options.go
+++ b/internal/cmd/postgresflex/options/options.go
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/delete/delete.go
+++ b/internal/cmd/postgresflex/user/delete/delete.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/describe/describe.go
+++ b/internal/cmd/postgresflex/user/describe/describe.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/list/list.go
+++ b/internal/cmd/postgresflex/user/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/reset-password/reset_password.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -73,7 +73,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/project/delete/delete.go
+++ b/internal/cmd/project/delete/delete.go
@@ -43,12 +43,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/project/member/add/add.go
+++ b/internal/cmd/project/member/add/add.go
@@ -59,12 +59,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			members := *resp.Members
 			if len(members) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/project/member/remove/remove.go
+++ b/internal/cmd/project/member/remove/remove.go
@@ -62,12 +62,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -71,7 +71,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			roles := *resp.Roles
 			if len(roles) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/project/update/update.go
+++ b/internal/cmd/project/update/update.go
@@ -62,12 +62,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/public-ip/associate/associate.go
+++ b/internal/cmd/public-ip/associate/associate.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/public-ip/create/create.go
+++ b/internal/cmd/public-ip/create/create.go
@@ -59,12 +59,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/public-ip/delete/delete.go
+++ b/internal/cmd/public-ip/delete/delete.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/public-ip/describe/describe.go
+++ b/internal/cmd/public-ip/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/public-ip/disassociate/disassociate.go
+++ b/internal/cmd/public-ip/disassociate/disassociate.go
@@ -47,7 +47,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/public-ip/update/update.go
+++ b/internal/cmd/public-ip/update/update.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/quota/list/list.go
+++ b/internal/cmd/quota/list/list.go
@@ -44,12 +44,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/rabbitmq/credentials/create/create.go
+++ b/internal/cmd/rabbitmq/credentials/create/create.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/credentials/delete/delete.go
+++ b/internal/cmd/rabbitmq/credentials/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/credentials/describe/describe.go
+++ b/internal/cmd/rabbitmq/credentials/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/credentials/list/list.go
+++ b/internal/cmd/rabbitmq/credentials/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/instance/create/create.go
+++ b/internal/cmd/rabbitmq/instance/create/create.go
@@ -83,12 +83,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/rabbitmq/instance/delete/delete.go
+++ b/internal/cmd/rabbitmq/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/instance/describe/describe.go
+++ b/internal/cmd/rabbitmq/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/instance/list/list.go
+++ b/internal/cmd/rabbitmq/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/rabbitmq/instance/update/update.go
+++ b/internal/cmd/rabbitmq/instance/update/update.go
@@ -79,7 +79,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rabbitmq/plans/plans.go
+++ b/internal/cmd/rabbitmq/plans/plans.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Offerings
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/redis/credentials/create/create.go
+++ b/internal/cmd/redis/credentials/create/create.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/credentials/delete/delete.go
+++ b/internal/cmd/redis/credentials/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/credentials/describe/describe.go
+++ b/internal/cmd/redis/credentials/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/credentials/list/list.go
+++ b/internal/cmd/redis/credentials/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/instance/create/create.go
+++ b/internal/cmd/redis/instance/create/create.go
@@ -81,12 +81,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/redis/instance/delete/delete.go
+++ b/internal/cmd/redis/instance/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/instance/describe/describe.go
+++ b/internal/cmd/redis/instance/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/instance/list/list.go
+++ b/internal/cmd/redis/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			instances := *resp.Instances
 			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/redis/instance/update/update.go
+++ b/internal/cmd/redis/instance/update/update.go
@@ -76,7 +76,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/redis/plans/plans.go
+++ b/internal/cmd/redis/plans/plans.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			plans := *resp.Offerings
 			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -56,12 +56,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/secrets-manager/instance/delete/delete.go
+++ b/internal/cmd/secrets-manager/instance/delete/delete.go
@@ -45,7 +45,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/instance/describe/describe.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Instances == nil || len(*resp.Instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/secrets-manager/instance/update/update.go
+++ b/internal/cmd/secrets-manager/instance/update/update.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -61,7 +61,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/user/delete/delete.go
+++ b/internal/cmd/secrets-manager/user/delete/delete.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/user/describe/describe.go
+++ b/internal/cmd/secrets-manager/user/describe/describe.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/secrets-manager/user/update/update.go
+++ b/internal/cmd/secrets-manager/user/update/update.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/security-group/create/create.go
+++ b/internal/cmd/security-group/create/create.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/security-group/delete/delete.go
+++ b/internal/cmd/security-group/delete/delete.go
@@ -42,12 +42,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/security-group/describe/describe.go
+++ b/internal/cmd/security-group/describe/describe.go
@@ -45,7 +45,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -49,12 +49,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/security-group/rule/create/create.go
+++ b/internal/cmd/security-group/rule/create/create.go
@@ -85,12 +85,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/security-group/rule/delete/delete.go
+++ b/internal/cmd/security-group/rule/delete/delete.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/security-group/rule/describe/describe.go
+++ b/internal/cmd/security-group/rule/describe/describe.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/security-group/rule/list/list.go
+++ b/internal/cmd/security-group/rule/list/list.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -82,7 +82,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 					securityGroupLabel = *model.SecurityGroupId
 				}
 
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/security-group/update/update.go
+++ b/internal/cmd/security-group/update/update.go
@@ -53,12 +53,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/server/backup/create/create.go
+++ b/internal/cmd/server/backup/create/create.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -13,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -63,14 +64,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/delete/delete.go
+++ b/internal/cmd/server/backup/delete/delete.go
@@ -48,7 +48,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/describe/describe.go
+++ b/internal/cmd/server/backup/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/disable/disable.go
+++ b/internal/cmd/server/backup/disable/disable.go
@@ -48,14 +48,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/enable/enable.go
+++ b/internal/cmd/server/backup/enable/enable.go
@@ -48,14 +48,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/list/list.go
+++ b/internal/cmd/server/backup/list/list.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
@@ -55,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -70,7 +71,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if len(backups) == 0 {
 				serverLabel := model.ServerId
 				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 					if err != nil {
 						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/restore/restore.go
+++ b/internal/cmd/server/backup/restore/restore.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/schedule/create/create.go
+++ b/internal/cmd/server/backup/schedule/create/create.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -13,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -71,14 +72,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/schedule/delete/delete.go
+++ b/internal/cmd/server/backup/schedule/delete/delete.go
@@ -49,14 +49,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/schedule/describe/describe.go
+++ b/internal/cmd/server/backup/schedule/describe/describe.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/schedule/list/list.go
+++ b/internal/cmd/server/backup/schedule/list/list.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
@@ -55,14 +56,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/backup/schedule/update/update.go
+++ b/internal/cmd/server/backup/schedule/update/update.go
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/volume-backup/delete/delete.go
+++ b/internal/cmd/server/backup/volume-backup/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/backup/volume-backup/restore/restore.go
+++ b/internal/cmd/server/backup/volume-backup/restore/restore.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/command/create/create.go
+++ b/internal/cmd/server/command/create/create.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/runcommand/client"
 	runcommandUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/runcommand/utils"
@@ -59,14 +60,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/command/describe/describe.go
+++ b/internal/cmd/server/command/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/command/list/list.go
+++ b/internal/cmd/server/command/list/list.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/runcommand/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
@@ -55,14 +56,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/command/template/describe/describe.go
+++ b/internal/cmd/server/command/template/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/command/template/list/list.go
+++ b/internal/cmd/server/command/template/list/list.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/console/console.go
+++ b/internal/cmd/server/console/console.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -118,12 +118,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/server/deallocate/deallocate.go
+++ b/internal/cmd/server/deallocate/deallocate.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/delete/delete.go
+++ b/internal/cmd/server/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/server/log/log.go
+++ b/internal/cmd/server/log/log.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/machine-type/describe/describe.go
+++ b/internal/cmd/server/machine-type/describe/describe.go
@@ -54,7 +54,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/machine-type/list/list.go
+++ b/internal/cmd/server/machine-type/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/server/network-interface/attach/attach.go
+++ b/internal/cmd/server/network-interface/attach/attach.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/network-interface/detach/detach.go
+++ b/internal/cmd/server/network-interface/detach/detach.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/network-interface/list/list.go
+++ b/internal/cmd/server/network-interface/list/list.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/os-update/create/create.go
+++ b/internal/cmd/server/os-update/create/create.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -13,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -58,14 +59,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/describe/describe.go
+++ b/internal/cmd/server/os-update/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/os-update/disable/disable.go
+++ b/internal/cmd/server/os-update/disable/disable.go
@@ -47,14 +47,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/enable/enable.go
+++ b/internal/cmd/server/os-update/enable/enable.go
@@ -48,14 +48,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/list/list.go
+++ b/internal/cmd/server/os-update/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -72,7 +72,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if len(updates) == 0 {
 				serverLabel := model.ServerId
 				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 					if err != nil {
 						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/schedule/create/create.go
+++ b/internal/cmd/server/os-update/schedule/create/create.go
@@ -67,14 +67,14 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			serverLabel := model.ServerId
 			// Get server name
-			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/schedule/delete/delete.go
+++ b/internal/cmd/server/os-update/schedule/delete/delete.go
@@ -47,7 +47,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/os-update/schedule/describe/describe.go
+++ b/internal/cmd/server/os-update/schedule/describe/describe.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/os-update/schedule/list/list.go
+++ b/internal/cmd/server/os-update/schedule/list/list.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
@@ -55,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -70,7 +71,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if len(schedules) == 0 {
 				serverLabel := model.ServerId
 				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer); err == nil {
+				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
 					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.ServerId)
 					if err != nil {
 						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)

--- a/internal/cmd/server/os-update/schedule/update/update.go
+++ b/internal/cmd/server/os-update/schedule/update/update.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/public-ip/attach/attach.go
+++ b/internal/cmd/server/public-ip/attach/attach.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/public-ip/detach/detach.go
+++ b/internal/cmd/server/public-ip/detach/detach.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/reboot/reboot.go
+++ b/internal/cmd/server/reboot/reboot.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/rescue/rescue.go
+++ b/internal/cmd/server/rescue/rescue.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/resize/resize.go
+++ b/internal/cmd/server/resize/resize.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/service-account/list/list.go
+++ b/internal/cmd/server/service-account/list/list.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/start/start.go
+++ b/internal/cmd/server/start/start.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/stop/stop.go
+++ b/internal/cmd/server/stop/stop.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/unrescue/unrescue.go
+++ b/internal/cmd/server/unrescue/unrescue.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/update/update.go
+++ b/internal/cmd/server/update/update.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/volume/attach/attach.go
+++ b/internal/cmd/server/volume/attach/attach.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/volume/describe/describe.go
+++ b/internal/cmd/server/volume/describe/describe.go
@@ -60,7 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/volume/detach/detach.go
+++ b/internal/cmd/server/volume/detach/detach.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/volume/list/list.go
+++ b/internal/cmd/server/volume/list/list.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/server/volume/update/update.go
+++ b/internal/cmd/server/volume/update/update.go
@@ -56,7 +56,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -49,12 +49,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -44,7 +44,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -42,7 +42,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/key/delete/delete.go
+++ b/internal/cmd/service-account/key/delete/delete.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/key/describe/describe.go
+++ b/internal/cmd/service-account/key/describe/describe.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -57,7 +57,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/key/update/update.go
+++ b/internal/cmd/service-account/key/update/update.go
@@ -67,7 +67,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			serviceAccounts := *resp.Items
 			if len(serviceAccounts) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -59,7 +59,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -62,7 +62,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/service-account/token/revoke/revoke.go
+++ b/internal/cmd/service-account/token/revoke/revoke.go
@@ -53,7 +53,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -71,12 +71,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId
@@ -91,7 +91,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure ServiceEnable API client
-			serviceEnablementApiClient, err := serviceEnablementClient.ConfigureClient(params.Printer)
+			serviceEnablementApiClient, err := serviceEnablementClient.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -46,7 +46,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/generate-payload/generate_payload.go
+++ b/internal/cmd/ske/cluster/generate-payload/generate_payload.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -58,13 +58,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			// Configure ServiceEnable API client
-			serviceEnablementApiClient, err := serviceEnablementClient.ConfigureClient(params.Printer)
+			serviceEnablementApiClient, err := serviceEnablementClient.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 			clusters := *resp.Items
 			if len(clusters) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/ske/cluster/update/update.go
+++ b/internal/cmd/ske/cluster/update/update.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/credentials/complete-rotation/complete_rotation.go
+++ b/internal/cmd/ske/credentials/complete-rotation/complete_rotation.go
@@ -63,7 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/credentials/start-rotation/start_rotation.go
+++ b/internal/cmd/ske/credentials/start-rotation/start_rotation.go
@@ -66,7 +66,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -42,7 +42,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -43,12 +43,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -43,12 +43,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -84,7 +84,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/kubeconfig/login/login.go
+++ b/internal/cmd/ske/kubeconfig/login/login.go
@@ -75,7 +75,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -66,7 +66,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/volume/create/create.go
+++ b/internal/cmd/volume/create/create.go
@@ -78,12 +78,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId

--- a/internal/cmd/volume/delete/delete.go
+++ b/internal/cmd/volume/delete/delete.go
@@ -52,7 +52,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/volume/describe/describe.go
+++ b/internal/cmd/volume/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/volume/list/list.go
+++ b/internal/cmd/volume/list/list.go
@@ -64,7 +64,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/volume/performance-class/describe/describe.go
+++ b/internal/cmd/volume/performance-class/describe/describe.go
@@ -55,7 +55,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/volume/performance-class/list/list.go
+++ b/internal/cmd/volume/performance-class/list/list.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, cmd)
+				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 					projectLabel = model.ProjectId

--- a/internal/cmd/volume/resize/resize.go
+++ b/internal/cmd/volume/resize/resize.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/volume/update/update.go
+++ b/internal/cmd/volume/update/update.go
@@ -65,7 +65,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/projectname/project_name.go
+++ b/internal/pkg/projectname/project_name.go
@@ -19,7 +19,7 @@ import (
 // Returns the project name associated to the project ID set in config
 //
 // Uses the one stored in config if it's valid, otherwise gets it from the API
-func GetProjectName(ctx context.Context, p *print.Printer, cmd *cobra.Command) (string, error) {
+func GetProjectName(ctx context.Context, p *print.Printer, cliVersion string, cmd *cobra.Command) (string, error) {
 	// If we can use the project name from config, return it
 	if useProjectNameFromConfig(p, cmd) {
 		return viper.GetString(config.ProjectNameKey), nil
@@ -30,7 +30,7 @@ func GetProjectName(ctx context.Context, p *print.Printer, cmd *cobra.Command) (
 		return "", fmt.Errorf("found empty project ID and name")
 	}
 
-	apiClient, err := client.ConfigureClient(p)
+	apiClient, err := client.ConfigureClient(p, cliVersion)
 	if err != nil {
 		return "", fmt.Errorf("configure resource manager client: %w", err)
 	}

--- a/internal/pkg/projectname/project_name_test.go
+++ b/internal/pkg/projectname/project_name_test.go
@@ -42,7 +42,7 @@ func TestGetProjectName(t *testing.T) {
 			p := print.NewPrinter()
 			cmd := &cobra.Command{}
 
-			projectName, err := GetProjectName(context.Background(), p, cmd)
+			projectName, err := GetProjectName(context.Background(), p, "0.0.0-dummy", cmd)
 			if err != nil {
 				if tt.isValid {
 					t.Fatalf("unexpected error: %v", err)

--- a/internal/pkg/services/alb/client/client.go
+++ b/internal/pkg/services/alb/client/client.go
@@ -5,29 +5,27 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
 
-func ConfigureClient(p *print.Printer) (*alb.APIClient, error) {
-	var err error
-	var apiClient *alb.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*alb.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.IaaSCustomEndpointKey)
 	if customEndpoint != "" {
 		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		cfgOptions = append(cfgOptions, authCfgOption)
 	}
 
 	if p.IsVerbosityDebug() {
@@ -36,7 +34,7 @@ func ConfigureClient(p *print.Printer) (*alb.APIClient, error) {
 		)
 	}
 
-	apiClient, err = alb.NewAPIClient(cfgOptions...)
+	apiClient, err := alb.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/authorization/client/client.go
+++ b/internal/pkg/services/authorization/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
 )
 
-func ConfigureClient(p *print.Printer) (*authorization.APIClient, error) {
-	var err error
-	var apiClient *authorization.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*authorization.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.AuthorizationCustomEndpointKey)
 
@@ -35,7 +35,7 @@ func ConfigureClient(p *print.Printer) (*authorization.APIClient, error) {
 		)
 	}
 
-	apiClient, err = authorization.NewAPIClient(cfgOptions...)
+	apiClient, err := authorization.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/dns/client/client.go
+++ b/internal/pkg/services/dns/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -11,17 +13,16 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-func ConfigureClient(p *print.Printer) (*dns.APIClient, error) {
-	var err error
-	var apiClient *dns.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*dns.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.DNSCustomEndpointKey)
 
@@ -35,7 +36,7 @@ func ConfigureClient(p *print.Printer) (*dns.APIClient, error) {
 		)
 	}
 
-	apiClient, err = dns.NewAPIClient(cfgOptions...)
+	apiClient, err := dns.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/iaas/client/client.go
+++ b/internal/pkg/services/iaas/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
-func ConfigureClient(p *print.Printer) (*iaas.APIClient, error) {
-	var err error
-	var apiClient *iaas.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*iaas.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.IaaSCustomEndpointKey)
 	if customEndpoint != "" {
@@ -37,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*iaas.APIClient, error) {
 		)
 	}
 
-	apiClient, err = iaas.NewAPIClient(cfgOptions...)
+	apiClient, err := iaas.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/load-balancer/client/client.go
+++ b/internal/pkg/services/load-balancer/client/client.go
@@ -5,29 +5,27 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 )
 
-func ConfigureClient(p *print.Printer) (*loadbalancer.APIClient, error) {
-	var err error
-	var apiClient *loadbalancer.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*loadbalancer.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.LoadBalancerCustomEndpointKey)
 	if customEndpoint != "" {
 		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		cfgOptions = append(cfgOptions, authCfgOption)
 	}
 
 	if p.IsVerbosityDebug() {
@@ -36,7 +34,7 @@ func ConfigureClient(p *print.Printer) (*loadbalancer.APIClient, error) {
 		)
 	}
 
-	apiClient, err = loadbalancer.NewAPIClient(cfgOptions...)
+	apiClient, err := loadbalancer.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/logme/client/client.go
+++ b/internal/pkg/services/logme/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/logme"
 )
 
-func ConfigureClient(p *print.Printer) (*logme.APIClient, error) {
-	var err error
-	var apiClient *logme.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*logme.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.LogMeCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*logme.APIClient, error) {
 		)
 	}
 
-	apiClient, err = logme.NewAPIClient(cfgOptions...)
+	apiClient, err := logme.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/mariadb/client/client.go
+++ b/internal/pkg/services/mariadb/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
 )
 
-func ConfigureClient(p *print.Printer) (*mariadb.APIClient, error) {
-	var err error
-	var apiClient *mariadb.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*mariadb.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.MariaDBCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*mariadb.APIClient, error) {
 		)
 	}
 
-	apiClient, err = mariadb.NewAPIClient(cfgOptions...)
+	apiClient, err := mariadb.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/mongodbflex/client/client.go
+++ b/internal/pkg/services/mongodbflex/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
-func ConfigureClient(p *print.Printer) (*mongodbflex.APIClient, error) {
-	var err error
-	var apiClient *mongodbflex.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*mongodbflex.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.MongoDBFlexCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*mongodbflex.APIClient, error) {
 		)
 	}
 
-	apiClient, err = mongodbflex.NewAPIClient(cfgOptions...)
+	apiClient, err := mongodbflex.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/object-storage/client/client.go
+++ b/internal/pkg/services/object-storage/client/client.go
@@ -5,24 +5,26 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-func ConfigureClient(p *print.Printer) (*objectstorage.APIClient, error) {
-	var err error
-	var apiClient *objectstorage.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*objectstorage.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ObjectStorageCustomEndpointKey)
 
@@ -36,7 +38,7 @@ func ConfigureClient(p *print.Printer) (*objectstorage.APIClient, error) {
 		)
 	}
 
-	apiClient, err = objectstorage.NewAPIClient(cfgOptions...)
+	apiClient, err := objectstorage.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/observability/client/client.go
+++ b/internal/pkg/services/observability/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/observability"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 )
 
-func ConfigureClient(p *print.Printer) (*observability.APIClient, error) {
-	var err error
-	var apiClient *observability.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*observability.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ObservabilityCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*observability.APIClient, error) {
 		)
 	}
 
-	apiClient, err = observability.NewAPIClient(cfgOptions...)
+	apiClient, err := observability.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/opensearch/client/client.go
+++ b/internal/pkg/services/opensearch/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/opensearch"
 )
 
-func ConfigureClient(p *print.Printer) (*opensearch.APIClient, error) {
-	var err error
-	var apiClient *opensearch.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*opensearch.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.OpenSearchCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*opensearch.APIClient, error) {
 		)
 	}
 
-	apiClient, err = opensearch.NewAPIClient(cfgOptions...)
+	apiClient, err := opensearch.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/postgresflex/client/client.go
+++ b/internal/pkg/services/postgresflex/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
 )
 
-func ConfigureClient(p *print.Printer) (*postgresflex.APIClient, error) {
-	var err error
-	var apiClient *postgresflex.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*postgresflex.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.PostgresFlexCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*postgresflex.APIClient, error) {
 		)
 	}
 
-	apiClient, err = postgresflex.NewAPIClient(cfgOptions...)
+	apiClient, err := postgresflex.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/rabbitmq/client/client.go
+++ b/internal/pkg/services/rabbitmq/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
 )
 
-func ConfigureClient(p *print.Printer) (*rabbitmq.APIClient, error) {
-	var err error
-	var apiClient *rabbitmq.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*rabbitmq.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.RabbitMQCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*rabbitmq.APIClient, error) {
 		)
 	}
 
-	apiClient, err = rabbitmq.NewAPIClient(cfgOptions...)
+	apiClient, err := rabbitmq.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/redis/client/client.go
+++ b/internal/pkg/services/redis/client/client.go
@@ -5,24 +5,25 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/redis"
 )
 
-func ConfigureClient(p *print.Printer) (*redis.APIClient, error) {
-	var err error
-	var apiClient *redis.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*redis.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
 	region := viper.GetString(config.RegionKey)
-	cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.RedisCustomEndpointKey)
 
@@ -36,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*redis.APIClient, error) {
 		)
 	}
 
-	apiClient, err = redis.NewAPIClient(cfgOptions...)
+	apiClient, err := redis.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/resourcemanager/client/client.go
+++ b/internal/pkg/services/resourcemanager/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 )
 
-func ConfigureClient(p *print.Printer) (*resourcemanager.APIClient, error) {
-	var err error
-	var apiClient *resourcemanager.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*resourcemanager.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ResourceManagerEndpointKey)
 
@@ -35,7 +35,7 @@ func ConfigureClient(p *print.Printer) (*resourcemanager.APIClient, error) {
 		)
 	}
 
-	apiClient, err = resourcemanager.NewAPIClient(cfgOptions...)
+	apiClient, err := resourcemanager.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/runcommand/client/client.go
+++ b/internal/pkg/services/runcommand/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
 )
 
-func ConfigureClient(p *print.Printer) (*runcommand.APIClient, error) {
-	var err error
-	var apiClient *runcommand.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*runcommand.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.RunCommandCustomEndpointKey)
 	if customEndpoint != "" {
@@ -36,7 +36,7 @@ func ConfigureClient(p *print.Printer) (*runcommand.APIClient, error) {
 		)
 	}
 
-	apiClient, err = runcommand.NewAPIClient(cfgOptions...)
+	apiClient, err := runcommand.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/serverbackup/client/client.go
+++ b/internal/pkg/services/serverbackup/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 )
 
-func ConfigureClient(p *print.Printer) (*serverbackup.APIClient, error) {
-	var err error
-	var apiClient *serverbackup.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*serverbackup.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ServerBackupCustomEndpointKey)
 	if customEndpoint != "" {
@@ -37,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*serverbackup.APIClient, error) {
 		)
 	}
 
-	apiClient, err = serverbackup.NewAPIClient(cfgOptions...)
+	apiClient, err := serverbackup.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/serverosupdate/client/client.go
+++ b/internal/pkg/services/serverosupdate/client/client.go
@@ -5,22 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 )
 
-func ConfigureClient(p *print.Printer) (*serverupdate.APIClient, error) {
-	var apiClient *serverupdate.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*serverupdate.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ServerOsUpdateCustomEndpointKey)
 	if customEndpoint != "" {
@@ -35,7 +36,7 @@ func ConfigureClient(p *print.Printer) (*serverupdate.APIClient, error) {
 		)
 	}
 
-	apiClient, err = serverupdate.NewAPIClient(cfgOptions...)
+	apiClient, err := serverupdate.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/service-account/client/client.go
+++ b/internal/pkg/services/service-account/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 )
 
-func ConfigureClient(p *print.Printer) (*serviceaccount.APIClient, error) {
-	var err error
-	var apiClient *serviceaccount.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*serviceaccount.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ServiceAccountCustomEndpointKey)
 
@@ -35,7 +35,7 @@ func ConfigureClient(p *print.Printer) (*serviceaccount.APIClient, error) {
 		)
 	}
 
-	apiClient, err = serviceaccount.NewAPIClient(cfgOptions...)
+	apiClient, err := serviceaccount.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/service-enablement/client/client.go
+++ b/internal/pkg/services/service-enablement/client/client.go
@@ -6,22 +6,22 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
 )
 
-func ConfigureClient(p *print.Printer) (*serviceenablement.APIClient, error) {
-	var err error
-	var apiClient *serviceenablement.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*serviceenablement.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.ServiceEnablementCustomEndpointKey)
 	if customEndpoint != "" {
@@ -37,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*serviceenablement.APIClient, error) {
 		)
 	}
 
-	apiClient, err = serviceenablement.NewAPIClient(cfgOptions...)
+	apiClient, err := serviceenablement.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/ske/client/client.go
+++ b/internal/pkg/services/ske/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
 )
 
-func ConfigureClient(p *print.Printer) (*ske.APIClient, error) {
-	var err error
-	var apiClient *ske.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*ske.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.SKECustomEndpointKey)
 	if customEndpoint != "" {
@@ -37,7 +37,7 @@ func ConfigureClient(p *print.Printer) (*ske.APIClient, error) {
 		)
 	}
 
-	apiClient, err = ske.NewAPIClient(cfgOptions...)
+	apiClient, err := ske.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/services/sqlserverflex/client/client.go
+++ b/internal/pkg/services/sqlserverflex/client/client.go
@@ -5,23 +5,23 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
 )
 
-func ConfigureClient(p *print.Printer) (*sqlserverflex.APIClient, error) {
-	var err error
-	var apiClient *sqlserverflex.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
+func ConfigureClient(p *print.Printer, cliVersion string) (*sqlserverflex.APIClient, error) {
 	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
 		return nil, &errors.AuthError{}
 	}
-	cfgOptions = append(cfgOptions, authCfgOption)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
 
 	customEndpoint := viper.GetString(config.SQLServerFlexCustomEndpointKey)
 
@@ -35,7 +35,7 @@ func ConfigureClient(p *print.Printer) (*sqlserverflex.APIClient, error) {
 		)
 	}
 
-	apiClient, err = sqlserverflex.NewAPIClient(cfgOptions...)
+	apiClient, err := sqlserverflex.NewAPIClient(cfgOptions...)
 	if err != nil {
 		p.Debug(print.ErrorLevel, "create new API client: %v", err)
 		return nil, &errors.AuthError{}

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
+	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 )
 
 // Ptr Returns the pointer to any type T
@@ -123,4 +124,8 @@ func Base64Encode(message []byte) string {
 	b := make([]byte, base64.StdEncoding.EncodedLen(len(message)))
 	base64.StdEncoding.Encode(b, message)
 	return string(b)
+}
+
+func UserAgentConfigOption(cliVersion string) sdkConfig.ConfigurationOption {
+	return sdkConfig.WithUserAgent(fmt.Sprintf("stackit-cli/%s", cliVersion))
 }

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"reflect"
 	"testing"
+
+	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 
 	"github.com/spf13/viper"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
@@ -104,6 +107,44 @@ func TestValidateURLDomain(t *testing.T) {
 			}
 			if !tt.isValid && err == nil {
 				t.Errorf("expected URL to be invalid, got no error")
+			}
+		})
+	}
+}
+
+func TestUserAgentConfigOption(t *testing.T) {
+	type args struct {
+		providerVersion string
+	}
+	tests := []struct {
+		name string
+		args args
+		want sdkConfig.ConfigurationOption
+	}{
+		{
+			name: "TestUserAgentConfigOption",
+			args: args{
+				providerVersion: "1.0.0",
+			},
+			want: sdkConfig.WithUserAgent("stackit-cli/1.0.0"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientConfigActual := sdkConfig.Configuration{}
+			err := tt.want(&clientConfigActual)
+			if err != nil {
+				t.Errorf("error configuring client: %v", err)
+			}
+
+			clientConfigExpected := sdkConfig.Configuration{}
+			err = UserAgentConfigOption(tt.args.providerVersion)(&clientConfigExpected)
+			if err != nil {
+				t.Errorf("error configuring client: %v", err)
+			}
+
+			if !reflect.DeepEqual(clientConfigActual, clientConfigExpected) {
+				t.Errorf("UserAgentConfigOption() = %v, want %v", clientConfigActual, clientConfigExpected)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-180

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
