### PR TITLE
feat(ci): add check for goreleaser configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,15 @@ jobs:
       
       - name: Test
         run: make test
+
+  config:
+    name: Check GoReleaser config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,10 +45,10 @@ builds:
           '
 
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz' ]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
 
 release:
   # If set to auto, the GitHub release will be marked as "Pre-release"
@@ -66,7 +66,7 @@ changelog:
 nfpms:
   - id: linux-packages
     # IDs of the builds for which to create packages for
-    builds:
+    ids:
       - linux-builds
     package_name: stackit
     vendor: STACKIT
@@ -114,7 +114,7 @@ brews:
 
 snapcrafts:
   # IDs of the builds for which to create packages for
-  - builds:
+  - ids:
       - linux-builds
     # The name of the snap
     name: stackit


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

will help to detect deprecated options

basically the same as https://github.com/stackitcloud/terraform-provider-stackit/pull/863

updated the following deprecated goreleaser options:
- https://goreleaser.com/deprecations/#archivesformat
- https://goreleaser.com/deprecations/#archivesformat_overridesformat
- https://goreleaser.com/deprecations/#nfpmsbuilds
- https://goreleaser.com/deprecations/#snapsbuilds

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
