### PR TITLE
fix(iaas): prevent nil pointer dereference on empty volume name

### DIFF
--- a/internal/cmd/affinity-groups/delete/delete.go
+++ b/internal/cmd/affinity-groups/delete/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -93,7 +93,7 @@ func buildRequest(ctx context.Context, model inputModel, apiClient *iaas.APIClie
 func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/image/delete/delete.go
+++ b/internal/cmd/image/delete/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -57,8 +57,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get image name: %v", err)
 				imageName = model.ImageId
-			} else if imageName == "" {
-				imageName = model.ImageId
 			}
 
 			if !model.AssumeYes {
@@ -87,7 +85,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/image/update/update.go
+++ b/internal/cmd/image/update/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -135,8 +135,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.WarningLevel, "cannot retrieve image name: %v", err)
 				imageLabel = model.Id
-			} else if imageLabel == "" {
-				imageLabel = model.Id
 			}
 
 			if !model.AssumeYes {
@@ -194,7 +192,7 @@ func configureFlags(cmd *cobra.Command) {
 func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/network-area/delete/delete.go
+++ b/internal/cmd/network-area/delete/delete.go
@@ -63,8 +63,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 				networkAreaLabel = model.AreaId
-			} else if networkAreaLabel == "" {
-				networkAreaLabel = model.AreaId
 			}
 
 			if !model.AssumeYes {

--- a/internal/cmd/network-area/describe/describe.go
+++ b/internal/cmd/network-area/describe/describe.go
@@ -3,6 +3,7 @@ package describe
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -79,7 +80,9 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 			if model.ShowAttachedProjects {
 				projects, err = iaasUtils.ListAttachedProjects(ctx, apiClient, *model.OrganizationId, model.AreaId)
-				if err != nil {
+				if err != nil && errors.Is(err, iaasUtils.ErrItemsNil) {
+					projects = []string{}
+				} else if err != nil {
 					return fmt.Errorf("get attached projects: %w", err)
 				}
 			}

--- a/internal/cmd/network-area/network-range/delete/delete.go
+++ b/internal/cmd/network-area/network-range/delete/delete.go
@@ -61,8 +61,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 				networkAreaLabel = *model.NetworkAreaId
-			} else if networkAreaLabel == "" {
-				networkAreaLabel = *model.NetworkAreaId
 			}
 			networkRangeLabel, err := iaasUtils.GetNetworkRangePrefix(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId, model.NetworkRangeId)
 			if err != nil {

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -81,8 +81,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
 					networkAreaLabel = *model.NetworkAreaId
-				} else if networkAreaLabel == "" {
-					networkAreaLabel = *model.NetworkAreaId
 				}
 				params.Printer.Info("No network ranges found for SNA %q\n", networkAreaLabel)
 				return nil
@@ -114,7 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
 	if limit != nil && *limit < 1 {
-		return nil, &errors.FlagValidationError{
+		return nil, &cliErr.FlagValidationError{
 			Flag:    limitFlag,
 			Details: "must be greater than 0",
 		}

--- a/internal/cmd/network-area/route/create/create.go
+++ b/internal/cmd/network-area/route/create/create.go
@@ -74,8 +74,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 				networkAreaLabel = *model.NetworkAreaId
-			} else if networkAreaLabel == "" {
-				networkAreaLabel = *model.NetworkAreaId
 			}
 
 			if !model.AssumeYes {

--- a/internal/cmd/network-area/route/delete/delete.go
+++ b/internal/cmd/network-area/route/delete/delete.go
@@ -61,8 +61,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 				networkAreaLabel = *model.NetworkAreaId
-			} else if networkAreaLabel == "" {
-				networkAreaLabel = *model.NetworkAreaId
 			}
 
 			if !model.AssumeYes {

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -80,8 +80,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 					networkAreaLabel = *model.NetworkAreaId
-				} else if networkAreaLabel == "" {
-					networkAreaLabel = *model.NetworkAreaId
 				}
 				params.Printer.Info("No static routes found for STACKIT Network Area %q\n", networkAreaLabel)
 				return nil
@@ -113,7 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
 	if limit != nil && *limit < 1 {
-		return nil, &errors.FlagValidationError{
+		return nil, &cliErr.FlagValidationError{
 			Flag:    limitFlag,
 			Details: "must be greater than 0",
 		}

--- a/internal/cmd/network-area/route/update/update.go
+++ b/internal/cmd/network-area/route/update/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -70,8 +70,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
 				networkAreaLabel = *model.NetworkAreaId
-			} else if networkAreaLabel == "" {
-				networkAreaLabel = *model.NetworkAreaId
 			}
 
 			// Call API
@@ -104,7 +102,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	labels := flags.FlagToStringToStringPointer(p, cmd, labelFlag)
 
 	if labels == nil {
-		return nil, &errors.EmptyUpdateError{}
+		return nil, &cliErr.EmptyUpdateError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/volume/attach/attach.go
+++ b/internal/cmd/server/volume/attach/attach.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -69,8 +69,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
 				volumeLabel = model.VolumeId
-			} else if volumeLabel == "" {
-				volumeLabel = model.VolumeId
 			}
 
 			serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, *model.ServerId)
@@ -115,7 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	volumeId := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/volume/describe/describe.go
+++ b/internal/cmd/server/volume/describe/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -69,8 +69,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
 				volumeLabel = model.VolumeId
-			} else if volumeLabel == "" {
-				volumeLabel = model.VolumeId
 			}
 
 			serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, *model.ServerId)
@@ -106,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	volumeId := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/volume/detach/detach.go
+++ b/internal/cmd/server/volume/detach/detach.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -59,8 +59,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
 				volumeLabel = model.VolumeId
-			} else if volumeLabel == "" {
-				volumeLabel = model.VolumeId
 			}
 
 			serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, *model.ServerId)
@@ -105,7 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	volumeId := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/volume/list/list.go
+++ b/internal/cmd/server/volume/list/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -83,6 +83,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				volumeLabel, err := iaasUtils.GetVolumeName(ctx, apiClient, model.ProjectId, *volumes[i].VolumeId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
+					volumeLabel = ""
 				}
 				volumeNames = append(volumeNames, volumeLabel)
 			}
@@ -104,7 +105,7 @@ func configureFlags(cmd *cobra.Command) {
 func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/volume/update/update.go
+++ b/internal/cmd/server/volume/update/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -65,8 +65,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
 				volumeLabel = model.VolumeId
-			} else if volumeLabel == "" {
-				volumeLabel = model.VolumeId
 			}
 
 			serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, *model.ServerId)
@@ -111,7 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	volumeId := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/cmd/volume/delete/delete.go
+++ b/internal/cmd/volume/delete/delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -57,12 +57,10 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			volumeLabel := model.VolumeId
-			volumeName, err := iaasUtils.GetVolumeName(ctx, apiClient, model.ProjectId, model.VolumeId)
+			volumeLabel, err := iaasUtils.GetVolumeName(ctx, apiClient, model.ProjectId, model.VolumeId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get volume name: %v", err)
-			} else if volumeName != "" {
-				volumeLabel = volumeName
+				volumeLabel = model.VolumeId
 			}
 
 			if !model.AssumeYes {
@@ -107,7 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
+		return nil, &cliErr.ProjectIdError{}
 	}
 
 	model := inputModel{

--- a/internal/pkg/services/iaas/utils/utils.go
+++ b/internal/pkg/services/iaas/utils/utils.go
@@ -2,9 +2,16 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+var (
+	ErrResponseNil = errors.New("response is nil")
+	ErrNameNil     = errors.New("name is nil")
+	ErrItemsNil    = errors.New("items is nil")
 )
 
 type IaaSClient interface {
@@ -34,6 +41,10 @@ func GetSecurityGroupName(ctx context.Context, apiClient IaaSClient, projectId, 
 	resp, err := apiClient.GetSecurityGroupExecute(ctx, projectId, securityGroupId)
 	if err != nil {
 		return "", fmt.Errorf("get security group: %w", err)
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }
@@ -62,6 +73,10 @@ func GetVolumeName(ctx context.Context, apiClient IaaSClient, projectId, volumeI
 	resp, err := apiClient.GetVolumeExecute(ctx, projectId, volumeId)
 	if err != nil {
 		return "", fmt.Errorf("get volume: %w", err)
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }
@@ -70,6 +85,10 @@ func GetNetworkName(ctx context.Context, apiClient IaaSClient, projectId, networ
 	resp, err := apiClient.GetNetworkExecute(ctx, projectId, networkId)
 	if err != nil {
 		return "", fmt.Errorf("get network: %w", err)
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }
@@ -78,6 +97,10 @@ func GetNetworkAreaName(ctx context.Context, apiClient IaaSClient, organizationI
 	resp, err := apiClient.GetNetworkAreaExecute(ctx, organizationId, areaId)
 	if err != nil {
 		return "", fmt.Errorf("get network area: %w", err)
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }
@@ -86,6 +109,10 @@ func ListAttachedProjects(ctx context.Context, apiClient IaaSClient, organizatio
 	resp, err := apiClient.ListNetworkAreaProjectsExecute(ctx, organizationId, areaId)
 	if err != nil {
 		return nil, fmt.Errorf("list network area attached projects: %w", err)
+	} else if resp == nil {
+		return nil, ErrResponseNil
+	} else if resp.Items == nil {
+		return nil, ErrItemsNil
 	}
 	return *resp.Items, nil
 }
@@ -124,9 +151,10 @@ func GetImageName(ctx context.Context, apiClient IaaSClient, projectId, imageId 
 	resp, err := apiClient.GetImageExecute(ctx, projectId, imageId)
 	if err != nil {
 		return "", fmt.Errorf("get image: %w", err)
-	}
-	if resp.Name == nil {
-		return "", nil
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }
@@ -135,9 +163,10 @@ func GetAffinityGroupName(ctx context.Context, apiClient IaaSClient, projectId, 
 	resp, err := apiClient.GetAffinityGroupExecute(ctx, projectId, affinityGroupId)
 	if err != nil {
 		return "", fmt.Errorf("get affinity group: %w", err)
-	}
-	if resp.Name == nil {
-		return "", nil
+	} else if resp == nil {
+		return "", ErrResponseNil
+	} else if resp.Name == nil {
+		return "", ErrNameNil
 	}
 	return *resp.Name, nil
 }

--- a/internal/pkg/services/iaas/utils/utils_test.go
+++ b/internal/pkg/services/iaas/utils/utils_test.go
@@ -186,6 +186,26 @@ func TestGetSecurityGroupName(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "response is nil",
+			args: args{
+				getInstanceResp:  nil,
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "name in response is nil",
+			args: args{
+				getInstanceResp: &iaas.SecurityGroup{
+					Name: nil,
+				},
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -330,6 +350,26 @@ func TestGetVolumeName(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "response is nil",
+			args: args{
+				getInstanceResp:  nil,
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "name in response is nil",
+			args: args{
+				getInstanceResp: &iaas.Volume{
+					Name: nil,
+				},
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -376,6 +416,26 @@ func TestGetNetworkName(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "response is nil",
+			args: args{
+				getInstanceResp:  nil,
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "name in response is nil",
+			args: args{
+				getInstanceResp: &iaas.Network{
+					Name: nil,
+				},
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -421,6 +481,27 @@ func TestGetNetworkAreaName(t *testing.T) {
 				getInstanceFails: true,
 			},
 			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "response is nil",
+			args: args{
+				getInstanceResp:  nil,
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "name in response is nil",
+			args: args{
+				getInstanceResp: &iaas.NetworkArea{
+					Name: nil,
+				},
+				getInstanceFails: false,
+			},
+			wantErr: true,
+			want:    "",
 		},
 	}
 	for _, tt := range tests {
@@ -701,10 +782,18 @@ func TestGetImageName(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:      "nil name",
+			name:      "response is nil",
 			imageErr:  false,
-			imageResp: &iaas.Image{},
+			imageResp: nil,
 			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "name in response is nil",
+			imageErr:  false,
+			imageResp: &iaas.Image{Name: nil},
+			want:      "",
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -745,10 +834,22 @@ func TestGetAffinityGroupName(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:         "nil affinity group name",
-			affinityErr:  false,
-			affinityResp: &iaas.AffinityGroup{},
-			want:         "",
+			name:        "response is nil",
+			affinityErr: false,
+			affinityResp: &iaas.AffinityGroup{
+				Name: nil,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:        "affinity group name in response is nil",
+			affinityErr: false,
+			affinityResp: &iaas.AffinityGroup{
+				Name: nil,
+			},
+			want:    "",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-208

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
