### PR TITLE
fix: add missing security group ID output to `security-group create` command

### DIFF
--- a/internal/cmd/security-group/create/create.go
+++ b/internal/cmd/security-group/create/create.go
@@ -156,7 +156,7 @@ func outputResult(p *print.Printer, outputFormat, name string, resp iaas.Securit
 
 		return nil
 	default:
-		p.Outputf("Created security group %q\n", name)
+		p.Outputf("Created security group %q.\nSecurity Group ID %s\n", name, utils.PtrString(resp.Id))
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #845 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
