### PR TITLE
fix(ci): mark the workflow as successful on coverage report error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,14 +58,15 @@ jobs:
     name: "Code coverage report"
     if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
     runs-on: ubuntu-latest
-    continue-on-error: true  # Add this line to prevent pipeline failures in forks
     needs: main
     permissions:
       contents: read
       actions: read  # to download code coverage results from "main" job
       pull-requests: write # write permission needed to comment on PR
     steps:
-      - uses: fgrosse/go-coverage-report@v1.2.0
+      - name: Check new code coverage
+        uses: fgrosse/go-coverage-report@v1.2.0
+        continue-on-error: true  # Add this line to prevent pipeline failures in forks
         with:
           coverage-artifact-name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
           coverage-file-name: ${{ env.CODE_COVERAGE_FILE_NAME }}


### PR DESCRIPTION
## Description

relates to #802

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
