### PR TITLE
feat(ske): respect KUBECONFIG environment variable (#875)

### DIFF
--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -284,8 +284,12 @@ func WriteConfigFile(configPath, data string) error {
 	return nil
 }
 
-// GetDefaultKubeconfigPath returns the default location for the kubeconfig file.
+// GetDefaultKubeconfigPath returns the default location for the kubeconfig file or the value of KUBECONFIG if set.
 func GetDefaultKubeconfigPath() (string, error) {
+	if kubeconfigEnv := os.Getenv("KUBECONFIG"); kubeconfigEnv != "" {
+		return kubeconfigEnv, nil
+	}
+
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get user home directory: %w", err)

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -698,3 +698,42 @@ func TestGetDefaultKubeconfigPath(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDefaultKubeconfigPathWithEnvVar(t *testing.T) {
+	tests := []struct {
+		description      string
+		kubeconfigEnvVar string
+		expected         string
+		userHome         string
+	}{
+		{
+			description:      "base",
+			kubeconfigEnvVar: "~/.kube/custom/config",
+			expected:         "~/.kube/custom/config",
+			userHome:         "/home/test-user",
+		},
+		{
+			description:      "return user home when environment var is empty",
+			kubeconfigEnvVar: "",
+			expected:         "/home/test-user/.kube/config",
+			userHome:         "/home/test-user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			// Setup environment variables
+			os.Setenv("KUBECONFIG", tt.kubeconfigEnvVar)
+			os.Setenv("HOME", tt.userHome)
+
+			output, err := GetDefaultKubeconfigPath()
+
+			if err != nil {
+				t.Errorf("failed on valid input")
+			}
+			if output != tt.expected {
+				t.Errorf("expected output to be %s, got %s", tt.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

relates to #875

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
