### PR TITLE
feat(auth): support output format in stackit auth get-access-token command

### DIFF
--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -62,7 +62,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 				return nil
 			case print.YAMLOutputFormat:
-				params.Printer.Outputf(`access_token: %q`, accessToken)
 				details, err := yaml.MarshalWithOptions(map[string]string{
 					"access_token": accessToken,
 				}, yaml.IndentSequence(true), yaml.UseJSONMarshaler())

--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -45,8 +45,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Try to get a valid access token, refreshing if necessary
-
-			// Try to get a valid access token, refreshing if necessary
 			accessToken, err := auth.RefreshAccessToken(params.Printer)
 			if err != nil {
 				return err

--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -1,13 +1,23 @@
 package getaccesstoken
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 )
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+}
 
 func NewCmd(params *params.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,7 +30,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				`Print a short-lived access token`,
 				"$ stackit auth get-access-token"),
 		),
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			model, err := parseInput(params.Printer, cmd)
+			if err != nil {
+				return err
+			}
+
 			userSessionExpired, err := auth.UserSessionExpired()
 			if err != nil {
 				return err
@@ -30,14 +45,60 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Try to get a valid access token, refreshing if necessary
+
+			// Try to get a valid access token, refreshing if necessary
 			accessToken, err := auth.RefreshAccessToken(params.Printer)
 			if err != nil {
 				return err
 			}
 
-			params.Printer.Outputf("%s\n", accessToken)
-			return nil
+			switch model.OutputFormat {
+			case print.JSONOutputFormat:
+				details, err := json.MarshalIndent(map[string]string{
+					"access_token": accessToken,
+				}, "", "  ")
+				if err != nil {
+					return fmt.Errorf("marshal image list: %w", err)
+				}
+				params.Printer.Outputln(string(details))
+
+				return nil
+			case print.YAMLOutputFormat:
+				params.Printer.Outputf(`access_token: %q`, accessToken)
+				details, err := yaml.MarshalWithOptions(map[string]string{
+					"access_token": accessToken,
+				}, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+				if err != nil {
+					return fmt.Errorf("marshal image list: %w", err)
+				}
+				params.Printer.Outputln(string(details))
+
+				return nil
+			default:
+				params.Printer.Outputln(accessToken)
+
+				return nil
+			}
 		},
 	}
 	return cmd
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #888 

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
