### PR TITLE
fix: remove access_token prefix from YAML output in get-access-token

### DIFF
--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -61,13 +60,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 				return nil
 			case print.YAMLOutputFormat:
-				details, err := yaml.MarshalWithOptions(map[string]string{
-					"access_token": accessToken,
-				}, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-				if err != nil {
-					return fmt.Errorf("marshal image list: %w", err)
-				}
-				params.Printer.Outputln(string(details))
+				params.Printer.Outputln(accessToken)
 
 				return nil
 			default:


### PR DESCRIPTION
## Description

relates to https://jira.schwarz/browse/STACKITCLI-236

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
