### PR TITLE
chore(cli): Move stackit cli to GA

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,7 +124,7 @@ homebrew_casks:
       name: CLI Release Bot
       email: noreply@stackit.de
     homepage: "https://github.com/stackitcloud/stackit-cli"
-    description: "A command-line interface to manage STACKIT resources.\nThis CLI is in a beta state. More services and functionality will be supported soon."
+    description: "A command-line interface to manage STACKIT resources."
     license: "Apache-2.0"
     # If set to auto, the release will not be uploaded to the homebrew tap repo
     # if the tag has a prerelease indicator (e.g. v0.0.1-alpha1)
@@ -144,12 +144,12 @@ snapcrafts:
     # centre graphical frontends
     title: STACKIT CLI
     summary: A command-line interface to manage STACKIT resources.
-    description: "A command-line interface to manage STACKIT resources.\nThis CLI is in a beta state. More services and functionality will be supported soon."
+    description: "A command-line interface to manage STACKIT resources."
     license: Apache-2.0
     confinement: classic
     # Grade "devel" will only release to `edge` and `beta` channels
     # Grade "stable" will also release to the `candidate` and `stable` channels
-    grade: devel
+    grade: stable
     # Whether to publish the Snap to the store
     publish: true
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -67,7 +67,7 @@ $ stackit config profile import -c @default.json --name myProfile
 The STACKIT CLI is available as a [Snap](https://snapcraft.io/stackit), and can be installed via:
 
 ```shell
-sudo snap install stackit --beta --classic
+sudo snap install stackit --classic
 ```
 
 or via the [Snap Store](https://snapcraft.io/snap-store) for desktop.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <br>
 </div>
 
-# STACKIT CLI (BETA)
+# STACKIT CLI
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/stackitcloud/stackit-cli)](https://goreportcard.com/report/github.com/stackitcloud/stackit-cli) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/stackitcloud/stackit-cli) [![GitHub License](https://img.shields.io/github/license/stackitcloud/stackit-cli)](https://www.apache.org/licenses/LICENSE-2.0)
 
@@ -19,7 +19,6 @@ The STACKIT CLI allows you to manage your STACKIT services and resources as well
 - DNS zones and record-sets
 - Databases such as PostgreSQL Flex, MongoDB Flex and SQLServer Flex
 
-This CLI is in a BETA state. More services and functionality will be supported soon.
 Your feedback is appreciated! 
 Feel free to open [GitHub issues](https://github.com/stackitcloud/stackit-cli) to provide feature requests and bug reports.
 

--- a/docs/stackit.md
+++ b/docs/stackit.md
@@ -5,8 +5,7 @@ Manage STACKIT resources using the command line
 ### Synopsis
 
 Manage STACKIT resources using the command line.
-This CLI is in a BETA state.
-More services and functionality will be supported soon. Your feedback is appreciated!
+Your feedback is appreciated!
 
 ```
 stackit [flags]

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -54,7 +54,7 @@ func NewRootCmd(version, date string, p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "stackit",
 		Short:             "Manage STACKIT resources using the command line",
-		Long:              "Manage STACKIT resources using the command line.\nThis CLI is in a BETA state.\nMore services and functionality will be supported soon. Your feedback is appreciated!",
+		Long:              "Manage STACKIT resources using the command line.\nYour feedback is appreciated!",
 		Args:              args.NoArgs,
 		SilenceErrors:     true, // Error is beautified in a custom way before being printed
 		SilenceUsage:      true,
@@ -97,7 +97,7 @@ func NewRootCmd(version, date string, p *print.Printer) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if flags.FlagToBoolValue(p, cmd, "version") {
-				p.Outputf("STACKIT CLI (beta)\n")
+				p.Outputf("STACKIT CLI\n")
 
 				parsedDate, err := time.Parse(time.RFC3339, date)
 				if err != nil {

--- a/internal/pkg/auth/templates/login-successful.html
+++ b/internal/pkg/auth/templates/login-successful.html
@@ -6,7 +6,7 @@
     <base href="/" />
     <meta
       name="description"
-      content="A command-line interface to manage STACKIT resources. This CLI is in a BETA state. More services and functionality will be supported soon."
+      content="A command-line interface to manage STACKIT resources."
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta property="og:title" content="STACKIT" />


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
