### PR TITLE
fix(goreleaser): Remove conflicts configuration for homebrew_casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,8 +117,6 @@ signs:
 homebrew_casks:
   - name: stackit
     directory: Casks
-    conflicts:
-      - formula: stackit
     repository:
       owner: stackitcloud
       name: homebrew-tap


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

Remove `conflicts` configuration for homebrew_casks, because it is deprecated and it's just a no-op. (See [goreleaser docs](https://goreleaser.com/deprecations/#homebrew_casksconflictsformula))

relates to https://github.com/stackitcloud/homebrew-tap/issues/5

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
