### PR TITLE
Onboard Intake (1/3): introduce intake runner command

### DIFF
--- a/docs/stackit.md
+++ b/docs/stackit.md
@@ -35,6 +35,7 @@ stackit [flags]
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
 * [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
 * [stackit image](./stackit_image.md)	 - Manage server images
+* [stackit intake](./stackit_intake.md)	 - Provides functionality for STACKIT Intake
 * [stackit key-pair](./stackit_key-pair.md)	 - Provides functionality for SSH key pairs
 * [stackit load-balancer](./stackit_load-balancer.md)	 - Provides functionality for Load Balancer
 * [stackit logme](./stackit_logme.md)	 - Provides functionality for LogMe

--- a/docs/stackit_intake.md
+++ b/docs/stackit_intake.md
@@ -1,0 +1,41 @@
+## stackit intake
+
+Provides functionality for STACKIT Intake
+
+### Synopsis
+
+Provides functionality for STACKIT Intake.
+
+```
+stackit intake [flags]
+```
+
+### Examples
+
+```
+  
+  $ stackit intake
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit intake"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/docs/stackit_intake_runner.md
+++ b/docs/stackit_intake_runner.md
@@ -1,0 +1,38 @@
+## stackit intake runner
+
+Provides functionality for Intake Runners
+
+### Synopsis
+
+Provides functionality for Intake Runners.
+
+```
+stackit intake runner [flags]
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit intake runner"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake](./stackit_intake.md)	 - Provides functionality for STACKIT Intake
+* [stackit intake runner create](./stackit_intake_runner_create.md)	 - Creates a new Intake Runner
+* [stackit intake runner delete](./stackit_intake_runner_delete.md)	 - Deletes an Intake Runner
+* [stackit intake runner describe](./stackit_intake_runner_describe.md)	 - Shows details of an Intake Runner
+* [stackit intake runner list](./stackit_intake_runner_list.md)	 - Lists all Intake Runners
+* [stackit intake runner update](./stackit_intake_runner_update.md)	 - Updates an Intake Runner
+

--- a/docs/stackit_intake_runner_create.md
+++ b/docs/stackit_intake_runner_create.md
@@ -1,0 +1,48 @@
+## stackit intake runner create
+
+Creates a new Intake Runner
+
+### Synopsis
+
+Creates a new Intake Runner.
+
+```
+stackit intake runner create [flags]
+```
+
+### Examples
+
+```
+  Create a new Intake Runner with a display name and message capacity limits
+  $ stackit intake runner create --display-name my-runner --max-message-size-kib 1000 --max-messages-per-hour 5000
+
+  Create a new Intake Runner with a description and labels
+  $ stackit intake runner create --display-name my-runner --max-message-size-kib 1000 --max-messages-per-hour 5000 --description "Main runner for production" --labels="env=prod,team=billing"
+```
+
+### Options
+
+```
+      --description string          Description
+      --display-name string         Display name
+  -h, --help                        Help for "stackit intake runner create"
+      --labels stringToString       Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2" (default [])
+      --max-message-size-kib int    Maximum message size in KiB
+      --max-messages-per-hour int   Maximum number of messages per hour
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/docs/stackit_intake_runner_delete.md
+++ b/docs/stackit_intake_runner_delete.md
@@ -1,0 +1,40 @@
+## stackit intake runner delete
+
+Deletes an Intake Runner
+
+### Synopsis
+
+Deletes an Intake Runner.
+
+```
+stackit intake runner delete RUNNER_ID [flags]
+```
+
+### Examples
+
+```
+  Delete an Intake Runner with ID "xxx"
+  $ stackit intake runner delete xxx
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit intake runner delete"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/docs/stackit_intake_runner_describe.md
+++ b/docs/stackit_intake_runner_describe.md
@@ -1,0 +1,43 @@
+## stackit intake runner describe
+
+Shows details of an Intake Runner
+
+### Synopsis
+
+Shows details of an Intake Runner.
+
+```
+stackit intake runner describe RUNNER_ID [flags]
+```
+
+### Examples
+
+```
+  Get details of an Intake Runner with ID "xxx"
+  $ stackit intake runner describe xxx
+
+  Get details of an Intake Runner with ID "xxx" in JSON format
+  $ stackit intake runner describe xxx --output-format json
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit intake runner describe"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/docs/stackit_intake_runner_list.md
+++ b/docs/stackit_intake_runner_list.md
@@ -1,0 +1,47 @@
+## stackit intake runner list
+
+Lists all Intake Runners
+
+### Synopsis
+
+Lists all Intake Runners for the current project.
+
+```
+stackit intake runner list [flags]
+```
+
+### Examples
+
+```
+  List all Intake Runners
+  $ stackit intake runner list
+
+  List all Intake Runners in JSON format
+  $ stackit intake runner list --output-format json
+
+  List up to 5 Intake Runners
+  $ stackit intake runner list --limit 5
+```
+
+### Options
+
+```
+  -h, --help        Help for "stackit intake runner list"
+      --limit int   Maximum number of entries to list
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/docs/stackit_intake_runner_update.md
+++ b/docs/stackit_intake_runner_update.md
@@ -1,0 +1,51 @@
+## stackit intake runner update
+
+Updates an Intake Runner
+
+### Synopsis
+
+Updates an Intake Runner. Only the specified fields are updated.
+
+```
+stackit intake runner update RUNNER_ID [flags]
+```
+
+### Examples
+
+```
+  Update the display name of an Intake Runner with ID "xxx"
+  $ stackit intake runner update xxx --display-name "new-runner-name"
+
+  Update the message capacity limits for an Intake Runner with ID "xxx"
+  $ stackit intake runner update xxx --max-message-size-kib 2000 --max-messages-per-hour 10000
+
+  Clear the labels of an Intake Runner with ID "xxx" by providing an empty value
+  $ stackit intake runner update xxx --labels ""
+```
+
+### Options
+
+```
+      --description string          Description
+      --display-name string         Display name
+  -h, --help                        Help for "stackit intake runner update"
+      --labels string               Labels in key=value format. To clear all labels, provide an empty string, e.g. --labels ""
+      --max-message-size-kib int    Maximum message size in KiB. Note: Overall message capacity cannot be decreased.
+      --max-messages-per-hour int   Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit intake runner](./stackit_intake_runner.md)	 - Provides functionality for Intake Runners
+

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.1
 	github.com/stackitcloud/stackit-sdk-go/services/git v0.7.1
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v0.29.2
+	github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.1
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.1
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.2.1
@@ -181,7 +182,6 @@ require (
 	github.com/sonatard/noctx v0.1.0 // indirect
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
-	github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,7 @@ require (
 	github.com/sonatard/noctx v0.1.0 // indirect
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
+	github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -577,6 +577,8 @@ github.com/stackitcloud/stackit-sdk-go/services/iaas v0.29.2 h1:BvrbqLi9u0943TTk
 github.com/stackitcloud/stackit-sdk-go/services/iaas v0.29.2/go.mod h1:b/jgJf7QHdRzU2fmZeJJtu5j0TAevDRghzcn5MyRmOI=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0 h1:IhswZoEHqkBW60wEmRaeoSrW68PGLQKrWVmMPMzwYrY=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0/go.mod h1:vRnT3zxWJ1k7wbAk8JmO0xFmPhmeos5HTIWdsVAAoKU=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.1 h1:qKAGtRfnB89vXom5mIwctMHFeznMQWXJd3cqQBURIK8=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.1/go.mod h1:jOArPjNRkwv4487+9ab3dRG+lM09leu5FiRohbQs9Z4=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.5.1 h1:OdJEs8eOfrzn9tCBDLxIyP8hX50zPfcXNYnRoQX+chs=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.5.1/go.mod h1:11uzaOPCF9SeDHXEGOPMlHDD3J5r2TnvCGUwW9Igq9c=
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.25.1 h1:hv5WrRU9rN6Jx4OwdOGJRyaQrfA9p1tzEoQK6/CDyoA=

--- a/go.sum
+++ b/go.sum
@@ -575,6 +575,8 @@ github.com/stackitcloud/stackit-sdk-go/services/git v0.7.1 h1:hkFixFnBcQzU4BSIZF
 github.com/stackitcloud/stackit-sdk-go/services/git v0.7.1/go.mod h1:Ng1EzrRndG3iGXGH90AZJz//wfK+2YOyDwTnTLwX3a4=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v0.29.2 h1:BvrbqLi9u0943TTkflPDLGbXgqgVzv7oy8tZHD3q3lg=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v0.29.2/go.mod h1:b/jgJf7QHdRzU2fmZeJJtu5j0TAevDRghzcn5MyRmOI=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0 h1:IhswZoEHqkBW60wEmRaeoSrW68PGLQKrWVmMPMzwYrY=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.1.0/go.mod h1:vRnT3zxWJ1k7wbAk8JmO0xFmPhmeos5HTIWdsVAAoKU=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.5.1 h1:OdJEs8eOfrzn9tCBDLxIyP8hX50zPfcXNYnRoQX+chs=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.5.1/go.mod h1:11uzaOPCF9SeDHXEGOPMlHDD3J5r2TnvCGUwW9Igq9c=
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.25.1 h1:hv5WrRU9rN6Jx4OwdOGJRyaQrfA9p1tzEoQK6/CDyoA=

--- a/internal/cmd/intake/common/util.go
+++ b/internal/cmd/intake/common/util.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseLabels parses the labels flag value into a map.
+// An empty string clears the labels, returning a pointer to an empty map.
+func ParseLabels(labelsVal string) (map[string]string, error) {
+	if labelsVal == "" {
+		// User wants to clear labels
+		return map[string]string{}, nil
+	}
+
+	// User provided labels, parse them
+	parsedLabels := make(map[string]string)
+	pairs := strings.Split(labelsVal, ",")
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 || kv[0] == "" {
+			return nil, fmt.Errorf("invalid label format, expected key=value: %q", pair)
+		}
+		parsedLabels[kv[0]] = kv[1]
+	}
+	return parsedLabels, nil
+}

--- a/internal/cmd/intake/intake.go
+++ b/internal/cmd/intake/intake.go
@@ -1,0 +1,31 @@
+package intake
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+)
+
+// NewCmd creates the 'stackit intake' command
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "intake",
+		Short: "Provides functionality for STACKIT Intake",
+		Long:  "Provides functionality for STACKIT Intake.",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				``,
+				"$ stackit intake"),
+		),
+		Run: utils.CmdHelp,
+	}
+
+	// Sub-commands
+	cmd.AddCommand(runner.NewCmd(params))
+
+	return cmd
+}

--- a/internal/cmd/intake/runner/create/create.go
+++ b/internal/cmd/intake/runner/create/create.go
@@ -1,0 +1,175 @@
+package create
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
+)
+
+const (
+	displayNameFlag        = "display-name"
+	maxMessageSizeKiBFlag  = "max-message-size-kib"
+	maxMessagesPerHourFlag = "max-messages-per-hour"
+	descriptionFlag        = "description"
+	labelsFlag             = "labels"
+)
+
+// inputModel struct holds all the input parameters for the command
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	DisplayName        *string
+	MaxMessageSizeKiB  *int64
+	MaxMessagesPerHour *int64
+	Description        *string
+	Labels             *map[string]string
+}
+
+func NewCreateCmd(p *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates a new Intake Runner",
+		Long:  "Creates a new Intake Runner.",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`Create a new Intake Runner with a display name and message capacity limits`,
+				`$ stackit intake runner create --display-name my-runner --max-message-size-kib 1000 --max-messages-per-hour 5000`),
+			examples.NewExample(
+				`Create a new Intake Runner with a description and labels`,
+				`$ stackit intake runner create --display-name my-runner --max-message-size-kib 1000 --max-messages-per-hour 5000 --description "Main runner for production" --labels="env=prod,team=billing"`),
+		),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p.Printer, cmd)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p.Printer)
+			if err != nil {
+				return err
+			}
+
+			projectLabel, err := projectname.GetProjectName(ctx, p.Printer, p.CliVersion, cmd)
+			if err != nil {
+				p.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to create an Intake Runner for project %q?", projectLabel)
+				err = p.Printer.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("create Intake Runner: %w", err)
+			}
+			runnerId := *resp.Id
+
+			return outputResult(p.Printer, model.OutputFormat, projectLabel, runnerId, resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().String(displayNameFlag, "", "Display name")
+	cmd.Flags().Int64(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB")
+	cmd.Flags().Int64(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour")
+	cmd.Flags().String(descriptionFlag, "", "Description")
+	cmd.Flags().StringToString(labelsFlag, nil, "Labels in key=value format, separated by commas. Example: --labels \"key1=value1,key2=value2\"")
+
+	err := flags.MarkFlagsRequired(cmd, displayNameFlag, maxMessageSizeKiBFlag, maxMessagesPerHourFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &cliErr.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel:    globalFlags,
+		DisplayName:        flags.FlagToStringPointer(p, cmd, displayNameFlag),
+		MaxMessageSizeKiB:  flags.FlagToInt64Pointer(p, cmd, maxMessageSizeKiBFlag),
+		MaxMessagesPerHour: flags.FlagToInt64Pointer(p, cmd, maxMessagesPerHourFlag),
+		Description:        flags.FlagToStringPointer(p, cmd, descriptionFlag),
+		Labels:             flags.FlagToStringToStringPointer(p, cmd, labelsFlag),
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiCreateIntakeRunnerRequest {
+	// Start building the request by calling the base method with path parameters
+	req := apiClient.CreateIntakeRunner(ctx, model.ProjectId, model.Region)
+
+	// Create the payload struct with data from the input model
+	payload := intake.CreateIntakeRunnerPayload{
+		DisplayName:        model.DisplayName,
+		MaxMessageSizeKiB:  model.MaxMessageSizeKiB,
+		MaxMessagesPerHour: model.MaxMessagesPerHour,
+		Description:        model.Description,
+		Labels:             model.Labels,
+	}
+	// Attach the payload to the request builder
+	req = req.CreateIntakeRunnerPayload(payload)
+
+	return req
+}
+
+func outputResult(p *print.Printer, outputFormat, projectLabel, runnerId string, resp *intake.IntakeRunnerResponse) error {
+	switch outputFormat {
+	case print.JSONOutputFormat:
+		details, err := json.MarshalIndent(resp, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal instance: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	case print.YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		if err != nil {
+			return fmt.Errorf("marshal instance: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	default:
+		p.Outputf("Created Intake Runner for project %q. Runner ID: %s\n", projectLabel, runnerId)
+		return nil
+	}
+}

--- a/internal/cmd/intake/runner/create/create_test.go
+++ b/internal/cmd/intake/runner/create/create_test.go
@@ -1,0 +1,297 @@
+package create
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+// Define a unique key for the context to avoid collisions
+type testCtxKey struct{}
+
+var (
+	// testCtx dummy context for testing purposes
+	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	// testClient mock API client
+	testClient    = &intake.APIClient{}
+	testProjectId = uuid.NewString()
+	testRegion    = "eu01"
+
+	// Define test values for flags
+	testDisplayName        = "testrunner"
+	testMaxMessageSizeKiB  = int64(1024)
+	testMaxMessagesPerHour = int64(10000)
+	testDescription        = "This is a test runner"
+	testLabels             = map[string]string{"env": "test", "team": "dev"}
+	testLabelsString       = "env=test,team=dev"
+)
+
+// fixtureFlagValues generates a map of flag values for tests
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
+		displayNameFlag:           testDisplayName,
+		maxMessageSizeKiBFlag:     "1024",
+		maxMessagesPerHourFlag:    "10000",
+		descriptionFlag:           testDescription,
+		labelsFlag:                testLabelsString,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+// fixtureInputModel generates an input model for tests
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		DisplayName:        utils.Ptr(testDisplayName),
+		MaxMessageSizeKiB:  utils.Ptr(testMaxMessageSizeKiB),
+		MaxMessagesPerHour: utils.Ptr(testMaxMessagesPerHour),
+		Description:        utils.Ptr(testDescription),
+		Labels:             utils.Ptr(testLabels),
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+// fixtureCreatePayload generates a CreateIntakeRunnerPayload for tests
+func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeRunnerPayload)) intake.CreateIntakeRunnerPayload {
+	payload := intake.CreateIntakeRunnerPayload{
+		DisplayName:        utils.Ptr(testDisplayName),
+		MaxMessageSizeKiB:  utils.Ptr(testMaxMessageSizeKiB),
+		MaxMessagesPerHour: utils.Ptr(testMaxMessagesPerHour),
+		Description:        utils.Ptr(testDescription),
+		Labels:             utils.Ptr(testLabels),
+	}
+	for _, mod := range mods {
+		mod(&payload)
+	}
+	return payload
+}
+
+// fixtureRequest generates an API request for tests
+func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeRunnerRequest)) intake.ApiCreateIntakeRunnerRequest {
+	request := testClient.CreateIntakeRunner(testCtx, testProjectId, testRegion)
+	request = request.CreateIntakeRunnerPayload(fixtureCreatePayload())
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "project id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, globalflags.ProjectIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "project id invalid",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "display name missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, displayNameFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "max message size missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, maxMessageSizeKiBFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "max messages per hour missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, maxMessagesPerHourFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "required fields only",
+			flagValues: map[string]string{
+				globalflags.ProjectIdFlag: testProjectId,
+				globalflags.RegionFlag:    testRegion,
+				displayNameFlag:           testDisplayName,
+				maxMessageSizeKiBFlag:     "1024",
+				maxMessagesPerHourFlag:    "10000",
+			},
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.Description = nil
+				model.Labels = nil
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			p := print.NewPrinter()
+			cmd := NewCreateCmd(&params.CmdParams{Printer: p})
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(p, cmd)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing flags: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest intake.ApiCreateIntakeRunnerRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+		{
+			description: "no optionals",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.Description = nil
+				model.Labels = nil
+			}),
+			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRunnerRequest) {
+				*request = (*request).CreateIntakeRunnerPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeRunnerPayload) {
+					payload.Description = nil
+					payload.Labels = nil
+				}))
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestOutputResult(t *testing.T) {
+	type args struct {
+		outputFormat string
+		projectLabel string
+		runnerId     string
+		resp         *intake.IntakeRunnerResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "default output",
+			args:    args{outputFormat: "default", projectLabel: "my-project", runnerId: "runner-id-123", resp: &intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "json output",
+			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")}},
+			wantErr: false,
+		},
+		{
+			name:    "yaml output",
+			args:    args{outputFormat: print.YAMLOutputFormat, resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")}},
+			wantErr: false,
+		},
+		{
+			name:    "nil response",
+			args:    args{outputFormat: print.JSONOutputFormat, resp: nil},
+			wantErr: false,
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewCreateCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.runnerId, tt.args.resp); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/intake/runner/delete/delete.go
+++ b/internal/cmd/intake/runner/delete/delete.go
@@ -1,0 +1,105 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+const (
+	runnerIdArg = "RUNNER_ID"
+)
+
+// inputModel struct holds all the input parameters for the command
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	RunnerId string
+}
+
+// NewDeleteCmd creates a new cobra command for deleting an Intake Runner
+func NewDeleteCmd(p *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("delete %s", runnerIdArg),
+		Short: "Deletes an Intake Runner",
+		Long:  "Deletes an Intake Runner.",
+		Args:  args.SingleArg(runnerIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Delete an Intake Runner with ID "xxx"`,
+				`$ stackit intake runner delete xxx`),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p.Printer)
+			if err != nil {
+				return err
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to delete Intake Runner %q?", model.RunnerId)
+				err = p.Printer.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			if err = req.Execute(); err != nil {
+				return fmt.Errorf("delete Intake Runner: %w", err)
+			}
+
+			p.Printer.Info("Deletion request for Intake Runner %q sent successfully.\n", model.RunnerId)
+			return nil
+		},
+	}
+	return cmd
+}
+
+// parseInput parses the command arguments and flags into a standardized model
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	runnerId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &cliErr.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		RunnerId:        runnerId,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+// buildRequest creates the API request to delete an Intake Runner
+func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeRunnerRequest {
+	req := apiClient.DeleteIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	return req
+}

--- a/internal/cmd/intake/runner/delete/delete_test.go
+++ b/internal/cmd/intake/runner/delete/delete_test.go
@@ -1,0 +1,200 @@
+package delete
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+// Define a unique key for the context to avoid collisions
+type testCtxKey struct{}
+
+var (
+	// testCtx is a dummy context for testing purposes
+	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	// testClient is a mock API client
+	testClient    = &intake.APIClient{}
+	testProjectId = uuid.NewString()
+	testRunnerId  = uuid.NewString()
+	testRegion    = "eu01"
+)
+
+// fixtureArgValues generates a slice of arguments for tests
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testRunnerId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
+
+// fixtureFlagValues generates a map of flag values for tests
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+// fixtureInputModel generates an input model for tests
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		RunnerId: testRunnerId,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+// fixtureRequest generates an API request for tests
+func fixtureRequest(mods ...func(request *intake.ApiDeleteIntakeRunnerRequest)) intake.ApiDeleteIntakeRunnerRequest {
+	request := testClient.DeleteIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			argValues:     fixtureArgValues(),
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "project id missing",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, globalflags.ProjectIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "runner id invalid",
+			argValues:   []string{"invalid-uuid"},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			p := print.NewPrinter()
+			cmd := NewDeleteCmd(&params.CmdParams{Printer: p})
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(p, cmd, tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing input: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest intake.ApiDeleteIntakeRunnerRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/cmd/intake/runner/describe/describe.go
+++ b/internal/cmd/intake/runner/describe/describe.go
@@ -1,0 +1,142 @@
+package describe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+)
+
+const (
+	runnerIdArg = "RUNNER_ID"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	RunnerId string
+}
+
+func NewDescribeCmd(p *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("describe %s", runnerIdArg),
+		Short: "Shows details of an Intake Runner",
+		Long:  "Shows details of an Intake Runner.",
+		Args:  args.SingleArg(runnerIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Get details of an Intake Runner with ID "xxx"`,
+				`$ stackit intake runner describe xxx`),
+			examples.NewExample(
+				`Get details of an Intake Runner with ID "xxx" in JSON format`,
+				`$ stackit intake runner describe xxx --output-format json`),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p.Printer)
+			if err != nil {
+				return err
+			}
+
+			// Call API to get a single runner
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("get Intake Runner: %w", err)
+			}
+
+			return outputResult(p.Printer, model.OutputFormat, resp)
+		},
+	}
+	return cmd
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	runnerId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &cliErr.ProjectIdError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		RunnerId:        runnerId,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+// buildRequest creates the API request to get a single Intake Runner
+func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiGetIntakeRunnerRequest {
+	req := apiClient.GetIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	return req
+}
+
+// outputResult formats the API response and prints it to the console
+func outputResult(p *print.Printer, outputFormat string, runner *intake.IntakeRunnerResponse) error {
+	if runner == nil {
+		return fmt.Errorf("received nil runner, could not display details")
+	}
+
+	switch outputFormat {
+	case print.JSONOutputFormat:
+		details, err := json.MarshalIndent(runner, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal Intake Runner: %w", err)
+		}
+		p.Outputln(string(details))
+		return nil
+
+	case print.YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(runner, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		if err != nil {
+			return fmt.Errorf("marshal Intake Runner: %w", err)
+		}
+		p.Outputln(string(details))
+		return nil
+
+	default:
+		table := tables.NewTable()
+		table.SetHeader("Attribute", "Value")
+		table.AddRow("ID", runner.GetId())
+		table.AddRow("Name", runner.GetDisplayName())
+		table.AddRow("Description", runner.GetDescription())
+		table.AddRow("Max Message Size (KiB)", runner.GetMaxMessageSizeKiB())
+		table.AddRow("Max Messages/Hour", runner.GetMaxMessagesPerHour())
+		table.AddRow("Ingestion URI", runner.GetUri())
+
+		err := table.Display(p)
+		if err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+		return nil
+	}
+}

--- a/internal/cmd/intake/runner/describe/describe_test.go
+++ b/internal/cmd/intake/runner/describe/describe_test.go
@@ -1,0 +1,235 @@
+package describe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+type testCtxKey struct{}
+
+var (
+	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient    = &intake.APIClient{}
+	testProjectId = uuid.NewString()
+	testRunnerId  = uuid.NewString()
+	testRegion    = "eu01"
+)
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testRunnerId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		RunnerId: testRunnerId,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *intake.ApiGetIntakeRunnerRequest)) intake.ApiGetIntakeRunnerRequest {
+	request := testClient.GetIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			argValues:     fixtureArgValues(),
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no arg values",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "no flag values",
+			argValues:   fixtureArgValues(),
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "project id missing",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, globalflags.ProjectIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "runner id invalid",
+			argValues:   []string{"invalid-uuid"},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			p := print.NewPrinter()
+			cmd := NewDescribeCmd(&params.CmdParams{Printer: p})
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(p, cmd, tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing input: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest intake.ApiGetIntakeRunnerRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestOutputResult(t *testing.T) {
+	type args struct {
+		outputFormat string
+		runner       *intake.IntakeRunnerResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "default output",
+			args:    args{outputFormat: "default", runner: &intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "json output",
+			args:    args{outputFormat: print.JSONOutputFormat, runner: &intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "yaml output",
+			args:    args{outputFormat: print.YAMLOutputFormat, runner: &intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "nil runner",
+			args:    args{runner: nil},
+			wantErr: true,
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewDescribeCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.runner); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/intake/runner/list/list.go
+++ b/internal/cmd/intake/runner/list/list.go
@@ -1,0 +1,175 @@
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+const (
+	limitFlag = "limit"
+)
+
+// inputModel struct holds all the input parameters for the command
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	Limit *int64
+}
+
+// NewListCmd creates a new cobra command for listing Intake Runners
+func NewListCmd(p *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all Intake Runners",
+		Long:  "Lists all Intake Runners for the current project.",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`List all Intake Runners`,
+				`$ stackit intake runner list`),
+			examples.NewExample(
+				`List all Intake Runners in JSON format`,
+				`$ stackit intake runner list --output-format json`),
+			examples.NewExample(
+				`List up to 5 Intake Runners`,
+				`$ stackit intake runner list --limit 5`),
+		),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p.Printer, cmd)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p.Printer)
+			if err != nil {
+				return err
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("list Intake Runners: %w", err)
+			}
+			runners := resp.GetIntakeRunners()
+			if len(runners) == 0 {
+				projectLabel, err := projectname.GetProjectName(ctx, p.Printer, p.CliVersion, cmd)
+				if err != nil {
+					p.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+					projectLabel = model.ProjectId
+				}
+				p.Printer.Info("No Intake Runners found for project %q\n", projectLabel)
+				return nil
+			}
+
+			// Truncate output
+			if model.Limit != nil && len(runners) > int(*model.Limit) {
+				runners = runners[:*model.Limit]
+			}
+
+			return outputResult(p.Printer, model.OutputFormat, runners)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+// configureFlags adds the --limit flag to the command
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Int64(limitFlag, 0, "Maximum number of entries to list")
+}
+
+// parseInput parses the command flags into a standardized model
+func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &errors.ProjectIdError{}
+	}
+
+	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
+	if limit != nil && *limit < 1 {
+		return nil, &errors.FlagValidationError{
+			Flag:    limitFlag,
+			Details: "must be greater than 0",
+		}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		Limit:           limit,
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+// buildRequest creates the API request to list Intake Runners
+func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiListIntakeRunnersRequest {
+	req := apiClient.ListIntakeRunners(ctx, model.ProjectId, model.Region)
+	// Note: we do support API pagination, but for consistency with other services, we fetch all items and apply
+	// client-side limit.
+	// A more advanced implementation could use the --limit flag to set the API's PageSize.
+	return req
+}
+
+// outputResult formats the API response and prints it to the console
+func outputResult(p *print.Printer, outputFormat string, runners []intake.IntakeRunnerResponse) error {
+	switch outputFormat {
+	case print.JSONOutputFormat:
+		details, err := json.MarshalIndent(runners, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal Intake Runner list: %w", err)
+		}
+		p.Outputln(string(details))
+		return nil
+
+	case print.YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(runners, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		if err != nil {
+			return fmt.Errorf("marshal Intake Runner list: %w", err)
+		}
+		p.Outputln(string(details))
+		return nil
+
+	default:
+		table := tables.NewTable()
+
+		table.SetHeader("ID", "NAME")
+		for i := range runners {
+			runner := runners[i]
+			table.AddRow(
+				runner.GetId(),
+				runner.GetDisplayName(),
+			)
+		}
+		err := table.Display(p)
+		if err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+		return nil
+	}
+}

--- a/internal/cmd/intake/runner/list/list_test.go
+++ b/internal/cmd/intake/runner/list/list_test.go
@@ -1,0 +1,221 @@
+package list
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+type testCtxKey struct{}
+
+var (
+	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient    = &intake.APIClient{}
+	testProjectId = uuid.NewString()
+	testRegion    = "eu01"
+	testLimit     = int64(5)
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *intake.ApiListIntakeRunnersRequest)) intake.ApiListIntakeRunnersRequest {
+	request := testClient.ListIntakeRunners(testCtx, testProjectId, testRegion)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "with limit",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[limitFlag] = strconv.FormatInt(testLimit, 10)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.Limit = utils.Ptr(testLimit)
+			}),
+		},
+		{
+			description: "project id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, globalflags.ProjectIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "limit is zero",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[limitFlag] = "0"
+			}),
+			isValid: false,
+		},
+		{
+			description: "limit is negative",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[limitFlag] = "-1"
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			p := print.NewPrinter()
+			cmd := NewListCmd(&params.CmdParams{Printer: p})
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(p, cmd)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing flags: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest intake.ApiListIntakeRunnersRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestOutputResult(t *testing.T) {
+	type args struct {
+		outputFormat string
+		runners      []intake.IntakeRunnerResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "default output",
+			args:    args{outputFormat: "default", runners: []intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "json output",
+			args:    args{outputFormat: print.JSONOutputFormat, runners: []intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "empty slice",
+			args:    args{runners: []intake.IntakeRunnerResponse{}},
+			wantErr: false,
+		},
+		{
+			name:    "nil slice",
+			args:    args{runners: nil},
+			wantErr: false,
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewListCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.runners); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/intake/runner/runner.go
+++ b/internal/cmd/intake/runner/runner.go
@@ -1,0 +1,31 @@
+package runner
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner/create"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner/delete"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner/describe"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner/list"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/runner/update"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+)
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runner",
+		Short: "Provides functionality for Intake Runners",
+		Long:  "Provides functionality for Intake Runners.",
+		Args:  args.NoArgs,
+		Run:   utils.CmdHelp,
+	}
+	// Pass the params down to each action command
+	cmd.AddCommand(create.NewCreateCmd(params))
+	cmd.AddCommand(delete.NewDeleteCmd(params))
+	cmd.AddCommand(describe.NewDescribeCmd(params))
+	cmd.AddCommand(list.NewListCmd(params))
+	cmd.AddCommand(update.NewUpdateCmd(params))
+
+	return cmd
+}

--- a/internal/cmd/intake/runner/update/update.go
+++ b/internal/cmd/intake/runner/update/update.go
@@ -1,0 +1,172 @@
+package update
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake/common"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+const (
+	runnerIdArg = "RUNNER_ID"
+)
+
+const (
+	displayNameFlag        = "display-name"
+	maxMessageSizeKiBFlag  = "max-message-size-kib"
+	maxMessagesPerHourFlag = "max-messages-per-hour"
+	descriptionFlag        = "description"
+	labelsFlag             = "labels"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	RunnerId           string
+	DisplayName        *string
+	MaxMessageSizeKiB  *int64
+	MaxMessagesPerHour *int64
+	Description        *string
+	Labels             *map[string]string
+}
+
+func NewUpdateCmd(p *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("update %s", runnerIdArg),
+		Short: "Updates an Intake Runner",
+		Long:  "Updates an Intake Runner. Only the specified fields are updated.",
+		Args:  args.SingleArg(runnerIdArg, utils.ValidateUUID),
+		Example: examples.Build(
+			examples.NewExample(
+				`Update the display name of an Intake Runner with ID "xxx"`,
+				`$ stackit intake runner update xxx --display-name "new-runner-name"`),
+			examples.NewExample(
+				`Update the message capacity limits for an Intake Runner with ID "xxx"`,
+				`$ stackit intake runner update xxx --max-message-size-kib 2000 --max-messages-per-hour 10000`),
+			examples.NewExample(
+				`Clear the labels of an Intake Runner with ID "xxx" by providing an empty value`,
+				`$ stackit intake runner update xxx --labels ""`),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(p.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(p.Printer)
+			if err != nil {
+				return err
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			if err := req.Execute(); err != nil {
+				return fmt.Errorf("update Intake Runner: %w", err)
+			}
+
+			p.Printer.Info("Update request for Intake Runner %q sent successfully.\n", model.RunnerId)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().String(displayNameFlag, "", "Display name")
+	cmd.Flags().Int64(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB. Note: Overall message capacity cannot be decreased.")
+	cmd.Flags().Int64(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.")
+	cmd.Flags().String(descriptionFlag, "", "Description")
+	cmd.Flags().String(labelsFlag, "", "Labels in key=value format. To clear all labels, provide an empty string, e.g. --labels \"\"")
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
+	runnerId := inputArgs[0]
+
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.ProjectId == "" {
+		return nil, &cliErr.ProjectIdError{}
+	}
+
+	var labels *map[string]string
+	if cmd.Flags().Changed(labelsFlag) {
+		labelsVal, err := cmd.Flags().GetString(labelsFlag)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse --%s: %w", labelsFlag, err)
+		}
+		if labelsVal == "" {
+			// User wants to clear labels
+			labels = &map[string]string{}
+		} else {
+			// User provided labels, parse them
+			parsedLabels, err := common.ParseLabels(labelsVal)
+			if err != nil {
+				return nil, err
+			}
+
+			labels = &parsedLabels
+		}
+	}
+
+	model := inputModel{
+		GlobalFlagModel:    globalFlags,
+		RunnerId:           runnerId,
+		DisplayName:        flags.FlagToStringPointer(p, cmd, displayNameFlag),
+		MaxMessageSizeKiB:  flags.FlagToInt64Pointer(p, cmd, maxMessageSizeKiBFlag),
+		MaxMessagesPerHour: flags.FlagToInt64Pointer(p, cmd, maxMessagesPerHourFlag),
+		Description:        flags.FlagToStringPointer(p, cmd, descriptionFlag),
+		Labels:             labels,
+	}
+
+	if model.DisplayName == nil && model.MaxMessageSizeKiB == nil && model.MaxMessagesPerHour == nil && model.Description == nil && model.Labels == nil {
+		return nil, &cliErr.EmptyUpdateError{}
+	}
+
+	if p.IsVerbosityDebug() {
+		modelStr, err := print.BuildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
+
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiUpdateIntakeRunnerRequest {
+	req := apiClient.UpdateIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+
+	payload := intake.UpdateIntakeRunnerPayload{}
+	if model.DisplayName != nil {
+		payload.DisplayName = model.DisplayName
+	}
+	if model.MaxMessageSizeKiB != nil {
+		payload.MaxMessageSizeKiB = model.MaxMessageSizeKiB
+	}
+	if model.MaxMessagesPerHour != nil {
+		payload.MaxMessagesPerHour = model.MaxMessagesPerHour
+	}
+	if model.Description != nil {
+		payload.Description = model.Description
+	}
+	if model.Labels != nil {
+		payload.Labels = model.Labels
+	}
+
+	req = req.UpdateIntakeRunnerPayload(payload)
+	return req
+}

--- a/internal/cmd/intake/runner/update/update_test.go
+++ b/internal/cmd/intake/runner/update/update_test.go
@@ -1,0 +1,260 @@
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+type testCtxKey struct{}
+
+var (
+	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient    = &intake.APIClient{}
+	testProjectId = uuid.NewString()
+	testRunnerId  = uuid.NewString()
+	testRegion    = "eu01"
+)
+
+func fixtureArgValues(mods ...func(argValues []string)) []string {
+	argValues := []string{
+		testRunnerId,
+	}
+	for _, mod := range mods {
+		mod(argValues)
+	}
+	return argValues
+}
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
+		displayNameFlag:           "new-runner-name",
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			ProjectId: testProjectId,
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		RunnerId:    testRunnerId,
+		DisplayName: utils.Ptr("new-runner-name"),
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *intake.ApiUpdateIntakeRunnerRequest)) intake.ApiUpdateIntakeRunnerRequest {
+	request := testClient.UpdateIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	payload := intake.UpdateIntakeRunnerPayload{
+		DisplayName: utils.Ptr("new-runner-name"),
+	}
+	request = request.UpdateIntakeRunnerPayload(payload)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			argValues:     fixtureArgValues(),
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no update flags provided",
+			argValues:   fixtureArgValues(),
+			flagValues: map[string]string{
+				globalflags.ProjectIdFlag: testProjectId,
+				globalflags.RegionFlag:    testRegion,
+			},
+			isValid: false,
+		},
+		{
+			description: "update all fields",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[maxMessageSizeKiBFlag] = "2048"
+				flagValues[maxMessagesPerHourFlag] = "10000"
+				flagValues[descriptionFlag] = "new description"
+				flagValues[labelsFlag] = "env=prod,team=sre"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.MaxMessageSizeKiB = utils.Ptr(int64(2048))
+				model.MaxMessagesPerHour = utils.Ptr(int64(10000))
+				model.Description = utils.Ptr("new description")
+				model.Labels = utils.Ptr(map[string]string{"env": "prod", "team": "sre"})
+			}),
+		},
+		{
+			description: "clear labels",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[labelsFlag] = ""
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.Labels = utils.Ptr(map[string]string{})
+			}),
+		},
+		{
+			description: "no args",
+			argValues:   []string{},
+			flagValues:  fixtureFlagValues(),
+			isValid:     false,
+		},
+		{
+			description: "project id missing",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, globalflags.ProjectIdFlag)
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			p := print.NewPrinter()
+			cmd := NewUpdateCmd(&params.CmdParams{Printer: p})
+			err := globalflags.Configure(cmd.Flags())
+			if err != nil {
+				t.Fatalf("configure global flags: %v", err)
+			}
+
+			for flag, value := range tt.flagValues {
+				err := cmd.Flags().Set(flag, value)
+				if err != nil {
+					if !tt.isValid {
+						return
+					}
+					t.Fatalf("setting flag --%s=%s: %v", flag, value, err)
+				}
+			}
+
+			err = cmd.ValidateArgs(tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating args: %v", err)
+			}
+
+			err = cmd.ValidateRequiredFlags()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error validating flags: %v", err)
+			}
+
+			model, err := parseInput(p, cmd, tt.argValues)
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error parsing input: %v", err)
+			}
+
+			if !tt.isValid {
+				t.Fatalf("did not fail on invalid input")
+			}
+			diff := cmp.Diff(model, tt.expectedModel)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest intake.ApiUpdateIntakeRunnerRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+		{
+			description: "update description and labels",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.DisplayName = nil
+				model.Description = utils.Ptr("new-desc")
+				model.Labels = utils.Ptr(map[string]string{"key": "value"})
+			}),
+			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
+				payload := intake.UpdateIntakeRunnerPayload{
+					Description: utils.Ptr("new-desc"),
+					Labels:      utils.Ptr(map[string]string{"key": "value"}),
+				}
+				*request = (*request).UpdateIntakeRunnerPayload(payload)
+			}),
+		},
+		{
+			description: "update all fields",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.DisplayName = utils.Ptr("another-name")
+				model.MaxMessageSizeKiB = utils.Ptr(int64(4096))
+				model.MaxMessagesPerHour = utils.Ptr(int64(20000))
+				model.Description = utils.Ptr("final-desc")
+				model.Labels = utils.Ptr(map[string]string{"a": "b"})
+			}),
+			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
+				payload := intake.UpdateIntakeRunnerPayload{
+					DisplayName:        utils.Ptr("another-name"),
+					MaxMessageSizeKiB:  utils.Ptr(int64(4096)),
+					MaxMessagesPerHour: utils.Ptr(int64(20000)),
+					Description:        utils.Ptr("final-desc"),
+					Labels:             utils.Ptr(map[string]string{"a": "b"}),
+				}
+				*request = (*request).UpdateIntakeRunnerPayload(payload)
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/dns"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/git"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/image"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/intake"
 	keypair "github.com/stackitcloud/stackit-cli/internal/cmd/key-pair"
 	loadbalancer "github.com/stackitcloud/stackit-cli/internal/cmd/load-balancer"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/logme"
@@ -192,6 +193,7 @@ func addSubcommands(cmd *cobra.Command, params *params.CmdParams) {
 	cmd.AddCommand(quota.NewCmd(params))
 	cmd.AddCommand(affinityGroups.NewCmd(params))
 	cmd.AddCommand(git.NewCmd(params))
+	cmd.AddCommand(intake.NewCmd(params))
 }
 
 // traverseCommands calls f for c and all of its children.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -46,6 +46,7 @@ const (
 	IaaSCustomEndpointKey              = "iaas_custom_endpoint"
 	TokenCustomEndpointKey             = "token_custom_endpoint"
 	GitCustomEndpointKey               = "git_custom_endpoint"
+	IntakeCustomEndpointKey            = "intake_custom_endpoint"
 
 	ProjectNameKey     = "project_name"
 	DefaultProfileName = "default"
@@ -105,6 +106,7 @@ var ConfigKeys = []string{
 	IaaSCustomEndpointKey,
 	TokenCustomEndpointKey,
 	GitCustomEndpointKey,
+	IntakeCustomEndpointKey,
 }
 
 var defaultConfigFolderPath string
@@ -190,6 +192,7 @@ func setConfigDefaults() {
 	viper.SetDefault(IaaSCustomEndpointKey, "")
 	viper.SetDefault(TokenCustomEndpointKey, "")
 	viper.SetDefault(GitCustomEndpointKey, "")
+	viper.SetDefault(IntakeCustomEndpointKey, "")
 }
 
 func getConfigFilePath(configFolder string) string {

--- a/internal/pkg/services/intake/client/client.go
+++ b/internal/pkg/services/intake/client/client.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+)
+
+// ConfigureClient creates and configures a new Intake API client
+func ConfigureClient(p *print.Printer) (*intake.APIClient, error) {
+	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
+	if err != nil {
+		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
+		return nil, &errors.AuthError{}
+	}
+
+	region := viper.GetString(config.RegionKey)
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		sdkConfig.WithRegion(region),
+		authCfgOption,
+	}
+
+	customEndpoint := viper.GetString(config.IntakeCustomEndpointKey)
+
+	if customEndpoint != "" {
+		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
+	}
+
+	if p.IsVerbosityDebug() {
+		cfgOptions = append(cfgOptions,
+			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
+		)
+	}
+
+	apiClient, err := intake.NewAPIClient(cfgOptions...)
+	if err != nil {
+		p.Debug(print.ErrorLevel, "create new API client: %v", err)
+		return nil, &errors.AuthError{}
+	}
+
+	return apiClient, nil
+}


### PR DESCRIPTION
## Description

This PR onboards the new **STACKIT Intake** ([ticket](https://jira.schwarz/browse/STACKITINT-1349)) service into the CLI. 

Intake is composed of three components: 
* **Intake Runners**: dedicated, isolated runtime data ingestion environment
* **Intakes**: a specific data stream or topic **within an Intake Runner**
* **Intake Users**: provides secure access credentials for your applications to connect to your **Intake**

This PR contains the **Intake Runners part only to make a quicker and less overwhelming review**. The remaining code (2/3) can be submitted as part of this PR once the first batch has been reviewed/approved or we can open a different PR for it (as the maintainer please). 

The commands are designed to work as follows: 
```
$ stackit-cli intake runner create ... 
$ stackit-cli intake create ... 
$ stackit-cli intake user create... 
```

Most customers will use `intakes` hence why we decided to go with this command structure. The folder structure will look like the following due to the hierachy desired: 
```
$ ls stackit-cli/internal/cmd/intake
common    
instance    # command for intakes 
intake.go        
runner   
user  
```

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 

