### PR TITLE
fix: server yaml output of userdata field displayed as bytearray instead of base64

### DIFF
--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -30,6 +30,26 @@ type inputModel struct {
 	ServerId string
 }
 
+// convertServerForYAML creates a map with UserData as base64 string for YAML output
+func convertServerForYAML(server *iaas.Server) map[string]interface{} {
+	if server == nil {
+		return nil
+	}
+
+	// Marshal to JSON first to get the correct format for UserData
+	jsonData, err := json.Marshal(server)
+	if err != nil {
+		return nil
+	}
+
+	var serverMap map[string]interface{}
+	if err := json.Unmarshal(jsonData, &serverMap); err != nil {
+		return nil
+	}
+
+	return serverMap
+}
+
 func NewCmd(params *params.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("describe %s", serverIdArg),
@@ -118,7 +138,7 @@ func outputResult(p *print.Printer, outputFormat string, server *iaas.Server) er
 
 		return nil
 	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(server, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		details, err := yaml.MarshalWithOptions(convertServerForYAML(server), yaml.IndentSequence(true), yaml.UseJSONMarshaler())
 		if err != nil {
 			return fmt.Errorf("marshal server: %w", err)
 		}


### PR DESCRIPTION
## Description

Jira: https://jira.schwarz/browse/STACKITCLI-219

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
