### PR TITLE
fix: s3 publish endpoint could not be parsed

### DIFF
--- a/.aptly.conf
+++ b/.aptly.conf
@@ -25,7 +25,7 @@
       "region": "eu01",
       "bucket": "distribution",
       "acl":"public-read",
-      "endpoint": "object.storage.eu01.onstackit.cloud"
+      "endpoint": "https://object.storage.eu01.onstackit.cloud"
     }
   },
   "SwiftPublishEndpoints": {},


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
