### PR TITLE
fix: release pipeline increase max-tries in download of mirror

### DIFF
--- a/scripts/publish-apt-packages.sh
+++ b/scripts/publish-apt-packages.sh
@@ -27,7 +27,7 @@ aptly mirror create -config "${APTLY_CONFIG_FILE_PATH}" -keyring="${CUSTOM_KEYRI
 
 # Update the mirror to the latest state
 printf "\n>>> Updating mirror \n"
-aptly mirror update -keyring="${CUSTOM_KEYRING_FILE}" current
+aptly mirror update -keyring="${CUSTOM_KEYRING_FILE}" -max-tries=5 current
 
 # Create a snapshot of the mirror
 printf "\n>>> Creating snapshop from mirror \n"


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
