### PR TITLE
docs: add missing envs in auth guide

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -92,7 +92,12 @@ The expected format of the service account key is a **json** with the following 
 > - setting the environment variable `STACKIT_PRIVATE_KEY_PATH`
 > - setting `STACKIT_PRIVATE_KEY_PATH` in the credentials file (see above)
 
-4. The CLI will search for the keys and, if valid, will use them to get access and refresh tokens which will be used to authenticate all the requests.
+4. Alternative, if you want to pass the keys directly without storing a file on disk:
+
+   - setting the environment variable `STACKIT_SERVICE_ACCOUNT_KEY` with the content of the service account key
+   - optional: setting the environment variable `STACKIT_PRIVATE_KEY` with the content of the private key
+
+5. The CLI will search for the keys and, if valid, will use them to get access and refresh tokens which will be used to authenticate all the requests.
 
 ### Token flow
 


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #955

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
