### PR TITLE
fix: output (yaml) userdata in proper base64 encoding for server describe and list commands

### DIFF
--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	sdkutils "github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
@@ -118,7 +119,11 @@ func outputResult(p *print.Printer, outputFormat string, server *iaas.Server) er
 
 		return nil
 	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(server, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		converted, err := sdkutils.ConvertForYAML(server)
+		if err != nil {
+			return fmt.Errorf("convert server for YAML: %w", err)
+		}
+		details, err := yaml.MarshalWithOptions(converted, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
 		if err != nil {
 			return fmt.Errorf("marshal server: %w", err)
 		}

--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -119,7 +119,7 @@ func outputResult(p *print.Printer, outputFormat string, server *iaas.Server) er
 
 		return nil
 	case print.YAMLOutputFormat:
-		converted, err := sdkutils.ConvertForYAML(server)
+		converted, err := sdkutils.ConvertByteArraysToBase64(server)
 		if err != nil {
 			return fmt.Errorf("convert server for YAML: %w", err)
 		}

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	sdkutils "github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
@@ -158,7 +159,17 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 
 		return nil
 	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(servers, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		// Convert each server to map with base64 encoded byte arrays
+		convertedServers := make([]map[string]interface{}, len(servers))
+		for i, server := range servers {
+			converted, err := sdkutils.ConvertForYAML(server)
+			if err != nil {
+				return fmt.Errorf("convert server for YAML: %w", err)
+			}
+			convertedServers[i] = converted
+		}
+
+		details, err := yaml.MarshalWithOptions(convertedServers, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
 		if err != nil {
 			return fmt.Errorf("marshal server: %w", err)
 		}

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -162,7 +162,7 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 		// Convert each server to map with base64 encoded byte arrays
 		convertedServers := make([]map[string]interface{}, len(servers))
 		for i, server := range servers {
-			converted, err := sdkutils.ConvertForYAML(server)
+			converted, err := sdkutils.ConvertByteArraysToBase64(server)
 			if err != nil {
 				return fmt.Errorf("convert server for YAML: %w", err)
 			}


### PR DESCRIPTION
## Description

Jira: https://jira.schwarz/secure/RapidBoard.jspa?rapidView=41274&view=detail&selectedIssue=STACKITCLI-219

Convertion Function "ConvertByteArraysToBase64" got added in go-sdk utils that handles proper convertion of byteArrays to base64 strings. It's used for the server list and server describe commands.

Checkout the GO-SDK with branch bf/userdata-base64-fix and replace SDK with local path:
replace github.com/stackitcloud/stackit-sdk-go => /Users/bfuertsch/work/StackIT/stackit-sdk-go
To access the convertion function

Testing Instructions well documented in the jira ticket for server describe command (same applies for list command):
https://jira.schwarz/browse/STACKITCLI-219

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
