### PR TITLE
fix: add completions to linux archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,9 +49,9 @@ builds:
           output: true
         # Completion files
         - cmd: mkdir -p dist/completions
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion zsh > ./dist/completions/stackit.zsh'
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion bash > ./dist/completions/stackit.bash'
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion fish > ./dist/completions/stackit.fish'
+        - cmd: sh -c 'go run main.go completion zsh > ./dist/completions/stackit.zsh'
+        - cmd: sh -c 'go run main.go completion bash > ./dist/completions/stackit.bash'
+        - cmd: sh -c 'go run main.go completion fish > ./dist/completions/stackit.fish'
 
 archives:
   - id: windows-archives

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,25 +48,22 @@ builds:
         - cmd: spctl -a -t open --context context:primary-signature -v dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg
           output: true
         # Completion files
-        - cmd: mkdir -p dist/macos-builds_{{.Target}}/completions
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion zsh > ./dist/macos-builds_{{.Target}}/completions/stackit.zsh'
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion bash > ./dist/macos-builds_{{.Target}}/completions/stackit.bash'
-        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion fish > ./dist/macos-builds_{{.Target}}/completions/stackit.fish'
+        - cmd: mkdir -p dist/completions
+        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion zsh > ./dist/completions/stackit.zsh'
+        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion bash > ./dist/completions/stackit.bash'
+        - cmd: sh -c './dist/macos-builds_{{.Target}}/{{.Name}} completion fish > ./dist/completions/stackit.fish'
 
 archives:
+  - id: windows-archives
+    ids:
+      - windows-builds
+    formats: [ 'zip' ]
   - ids:
       - linux-builds
-      - windows-builds
-    formats: [ 'tar.gz' ]
-    format_overrides:
-      - goos: windows
-        formats: [ 'zip' ]
-  - id: macos-archives
-    ids:
       - macos-builds
     formats: [ 'tar.gz' ]
     files:
-      - src: ./dist/macos-builds_{{.Target}}/completions/*
+      - src: ./dist/completions/*
         dst: completions
       - LICENSE.md
       - README.md


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to https://github.com/stackitcloud/homebrew-tap/issues/8

The completions files weren't part of the linux archives, which results in an error when installing the STACKIT CLI via homebrew on linux

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
