### PR TITLE
chore(flags): add unit test for string to string flag parsing

### DIFF
--- a/internal/pkg/flags/flag_to_value_test.go
+++ b/internal/pkg/flags/flag_to_value_test.go
@@ -1,0 +1,73 @@
+package flags
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+)
+
+func TestFlagToStringToStringPointer(t *testing.T) {
+	const flagName = "labels"
+
+	tests := []struct {
+		name      string
+		flagValue *string
+		want      *map[string]string
+	}{
+		{
+			name:      "flag unset",
+			flagValue: nil,
+			want:      nil,
+		},
+		{
+			name:      "flag set with single value",
+			flagValue: utils.Ptr("foo=bar"),
+			want: &map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name:      "flag set with multiple values",
+			flagValue: utils.Ptr("foo=bar,label1=value1,label2=value2"),
+			want: &map[string]string{
+				"foo":    "bar",
+				"label1": "value1",
+				"label2": "value2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := print.NewPrinter()
+			// create a new, simple test command with a string-to-string flag
+			cmd := func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "greet",
+					Short: "A simple greeting command",
+					Long:  "A simple greeting command",
+					Run: func(_ *cobra.Command, _ []string) {
+						fmt.Println("Hello world")
+					},
+				}
+				cmd.Flags().StringToString(flagName, nil, "Labels are key-value string pairs.")
+				return cmd
+			}()
+
+			// set the flag value if a value use given, else consider the flag unset
+			if tt.flagValue != nil {
+				err := cmd.Flags().Set(flagName, *tt.flagValue)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			if got := FlagToStringToStringPointer(p, cmd, flagName); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FlagToStringToStringPointer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
