### PR TITLE
fix(ske/login): use region from kubeconfig

### DIFF
--- a/internal/cmd/ske/kubeconfig/login/login.go
+++ b/internal/cmd/ske/kubeconfig/login/login.go
@@ -122,9 +122,9 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 type clusterConfig struct {
 	STACKITProjectID string `json:"stackitProjectID"`
 	ClusterName      string `json:"clusterName"`
+	Region           string `json:"region"`
 
 	cacheKey string
-	Region   string
 }
 
 func parseClusterConfig(p *print.Printer, cmd *cobra.Command) (*clusterConfig, error) {
@@ -157,8 +157,10 @@ func parseClusterConfig(p *print.Printer, cmd *cobra.Command) (*clusterConfig, e
 
 	config.cacheKey = fmt.Sprintf("ske-login-%x", sha256.Sum256([]byte(execCredential.Spec.Cluster.Server)))
 
-	globalFlags := globalflags.Parse(p, cmd)
-	config.Region = globalFlags.Region
+	// NOTE: Fallback if region is not set in the kubeconfig (this was the case in the past)
+	if config.Region == "" {
+		config.Region = globalflags.Parse(p, cmd).Region
+	}
 
 	return config, nil
 }


### PR DESCRIPTION
## Description

This fixes retrieval of new kubeconfigs via the SKE login plugin when using the CLI in a "cross" region setup: CLI configured for `eu01` but login kubeconfig for a cluster in `eu02`.
Instead of using the CLIs `region` flag, it will now use the region as included in the login kubeconfig (`.clusters.cluster.extensions.extension.region`). The `region` field will be included in all newly retrieved login kubeconfigs at the beginning of next week. But I've kept the current behavior as a fallback in case the field is missing, so this PR doesn't depend on the updated SKE-API.

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
