### PR TITLE
feat: add project validation (only for service SKE yet) 

### DIFF
--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -70,7 +70,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -71,7 +71,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -46,7 +46,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -45,7 +45,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -50,7 +50,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -10,13 +10,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
 )
 
@@ -49,6 +49,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Validate project ID (exists and user has access)
+			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			if err != nil {
+				return err
+			}
+
 			// Configure API client
 			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
@@ -72,9 +79,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	clusterName := inputArgs[0]
 
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -51,7 +51,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -57,7 +57,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -58,7 +58,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	serviceEnablementClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/client"
 	serviceEnablementUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
@@ -57,6 +57,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
+			// Validate project ID (exists and user has access)
+			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			if err != nil {
+				return err
+			}
+
 			// Configure API client
 			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
@@ -91,14 +97,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				clusters = clusters[:*model.Limit]
 			}
 
-			projectLabel := model.ProjectId
-			if len(clusters) == 0 {
-				projectLabel, err = projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				}
-			}
-
 			return outputResult(params.Printer, model.OutputFormat, projectLabel, clusters)
 		},
 	}
@@ -113,9 +111,6 @@ func configureFlags(cmd *cobra.Command) {
 
 func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
 	if limit != nil && *limit < 1 {

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -43,7 +43,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -42,7 +42,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -17,6 +16,7 @@ import (
 	skeUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
 )
 
@@ -41,6 +41,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Validate project ID (exists and user has access)
+			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			if err != nil {
+				return err
+			}
+
 			// Configure API client
 			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
@@ -62,9 +69,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -42,7 +42,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -41,7 +41,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
@@ -42,16 +41,16 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			// Validate project ID (exists and user has access)
+			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				projectLabel = model.ProjectId
+				return err
 			}
 
 			if !model.AssumeYes {
@@ -93,9 +92,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -42,7 +42,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -41,7 +41,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			projectLabel, err := validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
@@ -42,16 +41,16 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			// Validate project ID (exists and user has access)
+			projectLabel, err := validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				projectLabel = model.ProjectId
+				return err
 			}
 
 			if !model.AssumeYes {
@@ -93,9 +92,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 
 func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -84,7 +84,6 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Validate project ID (exists and user has access)
 			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -85,7 +85,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Validate project ID (exists and user has access)
-			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
+			_, err = validation.ValidateAndGetProjectLabel(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
 	skeUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/validation"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
@@ -79,6 +80,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Validate project ID (exists and user has access)
+			_, err = validation.ValidateProject(ctx, params.Printer, params.CliVersion, cmd, model.ProjectId)
 			if err != nil {
 				return err
 			}
@@ -180,9 +187,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	clusterName := inputArgs[0]
 
 	globalFlags := globalflags.Parse(p, cmd)
-	if globalFlags.ProjectId == "" {
-		return nil, &errors.ProjectIdError{}
-	}
 
 	expTime := flags.FlagToStringPointer(p, cmd, expirationFlag)
 

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -178,6 +178,16 @@ To list all profiles, run:
   $ stackit config profile list`
 
 	FILE_ALREADY_EXISTS = `file %q already exists in the export path. Delete the existing file or define a different export path`
+
+	PROJECT_NOT_FOUND = `the project %[2]q (ID: %[1]s) does not exist.
+
+To list all available projects, run:
+  $ stackit project list`
+
+	PROJECT_ACCESS_DENIED = `you don't have access to the project %[2]q (ID: %[1]s).
+
+To list all available projects, run:
+  $ stackit project list`
 )
 
 type ServerNicAttachMissingNicIdError struct {
@@ -499,3 +509,21 @@ type FileAlreadyExistsError struct {
 }
 
 func (e *FileAlreadyExistsError) Error() string { return fmt.Sprintf(FILE_ALREADY_EXISTS, e.Filename) }
+
+type ProjectNotFoundError struct {
+	ProjectId    string
+	ProjectLabel string
+}
+
+func (e *ProjectNotFoundError) Error() string {
+	return fmt.Sprintf(PROJECT_NOT_FOUND, e.ProjectId, e.ProjectLabel)
+}
+
+type ProjectAccessDeniedError struct {
+	ProjectId    string
+	ProjectLabel string
+}
+
+func (e *ProjectAccessDeniedError) Error() string {
+	return fmt.Sprintf(PROJECT_ACCESS_DENIED, e.ProjectId, e.ProjectLabel)
+}

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -179,12 +179,7 @@ To list all profiles, run:
 
 	FILE_ALREADY_EXISTS = `file %q already exists in the export path. Delete the existing file or define a different export path`
 
-	PROJECT_NOT_FOUND = `the project %[2]q (ID: %[1]s) does not exist.
-
-To list all available projects, run:
-  $ stackit project list`
-
-	PROJECT_ACCESS_DENIED = `you don't have access to the project %[2]q (ID: %[1]s).
+	PROJECT_NOT_FOUND = `the project %[2]q (ID: %[1]s) does not exist or you don't have access to it.
 
 To list all available projects, run:
   $ stackit project list`
@@ -517,13 +512,4 @@ type ProjectNotFoundError struct {
 
 func (e *ProjectNotFoundError) Error() string {
 	return fmt.Sprintf(PROJECT_NOT_FOUND, e.ProjectId, e.ProjectLabel)
-}
-
-type ProjectAccessDeniedError struct {
-	ProjectId    string
-	ProjectLabel string
-}
-
-func (e *ProjectAccessDeniedError) Error() string {
-	return fmt.Sprintf(PROJECT_ACCESS_DENIED, e.ProjectId, e.ProjectLabel)
 }

--- a/internal/pkg/validation/project.go
+++ b/internal/pkg/validation/project.go
@@ -35,7 +35,7 @@ func ValidateProject(ctx context.Context, p *print.Printer, cliVersion string, c
 		// Check for specific HTTP status codes
 		if httpErr, ok := err.(*oapierror.GenericOpenAPIError); ok { //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
 			switch httpErr.StatusCode {
-			case http.StatusNotFound, http.StatusForbidden:
+			case http.StatusForbidden:
 				// Try to get project name for better error message
 				projectLabel := projectId
 				if projectName, nameErr := projectname.GetProjectName(ctx, p, cliVersion, cmd); nameErr == nil {

--- a/internal/pkg/validation/project.go
+++ b/internal/pkg/validation/project.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 )
 
-// ValidateProject validates that the project ID is not empty, exists, and the user has access to it.
-// It returns the project name for display purposes.
-func ValidateProject(ctx context.Context, p *print.Printer, cliVersion string, cmd *cobra.Command, projectId string) (string, error) {
+// ValidateAndGetProjectLabel validates that the project ID is not empty, exists, and the user has access to it.
+// It returns the project label (name or ID) for display purposes.
+func ValidateAndGetProjectLabel(ctx context.Context, p *print.Printer, cliVersion string, cmd *cobra.Command, projectId string) (string, error) {
 	// Check if project ID is empty
 	if projectId == "" {
 		return "", &errors.ProjectIdError{}

--- a/internal/pkg/validation/project.go
+++ b/internal/pkg/validation/project.go
@@ -35,20 +35,13 @@ func ValidateProject(ctx context.Context, p *print.Printer, cliVersion string, c
 		// Check for specific HTTP status codes
 		if httpErr, ok := err.(*oapierror.GenericOpenAPIError); ok { //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
 			switch httpErr.StatusCode {
-			case http.StatusNotFound:
+			case http.StatusNotFound, http.StatusForbidden:
 				// Try to get project name for better error message
 				projectLabel := projectId
 				if projectName, nameErr := projectname.GetProjectName(ctx, p, cliVersion, cmd); nameErr == nil {
 					projectLabel = projectName
 				}
 				return "", &errors.ProjectNotFoundError{ProjectId: projectId, ProjectLabel: projectLabel}
-			case http.StatusForbidden:
-				// Try to get project name for better error message
-				projectLabel := projectId
-				if projectName, nameErr := projectname.GetProjectName(ctx, p, cliVersion, cmd); nameErr == nil {
-					projectLabel = projectName
-				}
-				return "", &errors.ProjectAccessDeniedError{ProjectId: projectId, ProjectLabel: projectLabel}
 			case http.StatusUnauthorized:
 				return "", &errors.AuthError{}
 			}

--- a/internal/pkg/validation/project.go
+++ b/internal/pkg/validation/project.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+)
+
+// ValidateProject validates that the project ID is not empty, exists, and the user has access to it.
+// It returns the project name for display purposes.
+func ValidateProject(ctx context.Context, p *print.Printer, cliVersion string, cmd *cobra.Command, projectId string) (string, error) {
+	// Check if project ID is empty
+	if projectId == "" {
+		return "", &errors.ProjectIdError{}
+	}
+
+	// Configure Resource Manager API client
+	apiClient, err := client.ConfigureClient(p, cliVersion)
+	if err != nil {
+		return "", fmt.Errorf("configure resource manager client: %w", err)
+	}
+
+	// Try to get project details to validate existence and access
+	req := apiClient.GetProject(ctx, projectId)
+	resp, err := req.Execute()
+	if err != nil {
+		// Check for specific HTTP status codes
+		if httpErr, ok := err.(*oapierror.GenericOpenAPIError); ok {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				// Try to get project name for better error message
+				projectLabel := projectId
+				if projectName, nameErr := projectname.GetProjectName(ctx, p, cliVersion, cmd); nameErr == nil {
+					projectLabel = projectName
+				}
+				return "", &errors.ProjectNotFoundError{ProjectId: projectId, ProjectLabel: projectLabel}
+			case http.StatusForbidden:
+				// Try to get project name for better error message
+				projectLabel := projectId
+				if projectName, nameErr := projectname.GetProjectName(ctx, p, cliVersion, cmd); nameErr == nil {
+					projectLabel = projectName
+				}
+				return "", &errors.ProjectAccessDeniedError{ProjectId: projectId, ProjectLabel: projectLabel}
+			case http.StatusUnauthorized:
+				return "", &errors.AuthError{}
+			}
+		}
+		return "", fmt.Errorf("validate project: %w", err)
+	}
+
+	// Project exists and user has access, returning the project name
+	return *resp.Name, nil
+}

--- a/internal/pkg/validation/project.go
+++ b/internal/pkg/validation/project.go
@@ -33,7 +33,7 @@ func ValidateProject(ctx context.Context, p *print.Printer, cliVersion string, c
 	resp, err := req.Execute()
 	if err != nil {
 		// Check for specific HTTP status codes
-		if httpErr, ok := err.(*oapierror.GenericOpenAPIError); ok {
+		if httpErr, ok := err.(*oapierror.GenericOpenAPIError); ok { //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
 			switch httpErr.StatusCode {
 			case http.StatusNotFound:
 				// Try to get project name for better error message


### PR DESCRIPTION
## Description

This change implements validation checks for the project ID, project existence, and user access rights. It also simplifies the project label retrieval logic by reducing boilerplate code.

Jira-Ticket: https://jira.schwarz/browse/STACKITCLI-61

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
