### PR TITLE
refactor: use a func to print input model debug output

### DIFF
--- a/.github/docs/contribution-guide/cmd.go
+++ b/.github/docs/contribution-guide/cmd.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	}
 
 	// Write the input model to the debug logs
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -53,7 +53,7 @@ Please remember to run `make generate-docs` after your changes to keep the comma
 
 Below is a typical structure of a CLI command:
 
-https://github.com/stackitcloud/stackit-cli/blob/85ce44cd18d11169f2548d8657031b5fc6f94740/.github/docs/contribution-guide/cmd.go#L23-L156
+https://github.com/stackitcloud/stackit-cli/blob/main/.github/docs/contribution-guide/cmd.go
 
 Please remember to always add unit tests for `parseInput`, `buildRequest` (in `bar_test.go`), and any other util functions used.
 
@@ -87,7 +87,7 @@ If you want to add a command that uses a STACKIT service `foo` that was not yet 
     1.  This is done in `internal/pkg/services/foo/client/client.go`
     2.  Below is an example of a typical `client.go` file structure:
 
-https://github.com/stackitcloud/stackit-cli/blob/85ce44cd18d11169f2548d8657031b5fc6f94740/.github/docs/contribution-guide/client.go#L12-L35
+https://github.com/stackitcloud/stackit-cli/blob/main/.github/docs/contribution-guide/client.go
 
 ### Local development
 

--- a/internal/cmd/affinity-groups/create/create.go
+++ b/internal/cmd/affinity-groups/create/create.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Policy:          flags.FlagToStringValue(p, cmd, policyFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/affinity-groups/delete/delete.go
+++ b/internal/cmd/affinity-groups/delete/delete.go
@@ -101,14 +101,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		AffinityGroupId: cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/affinity-groups/describe/describe.go
+++ b/internal/cmd/affinity-groups/describe/describe.go
@@ -84,15 +84,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		AffinityGroupId: cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/affinity-groups/list/list.go
+++ b/internal/cmd/affinity-groups/list/list.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/auth/activate-service-account/activate_service_account.go
+++ b/internal/cmd/auth/activate-service-account/activate_service_account.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) *inputModel {
 		OnlyPrintAccessToken:  flags.FlagToBoolValue(p, cmd, onlyPrintAccessTokenFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model
 }
 

--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -77,14 +77,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/beta/alb/create/create.go
+++ b/internal/cmd/beta/alb/create/create.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Configuration:   flags.FlagToStringPointer(p, cmd, configurationFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/delete/delete.go
+++ b/internal/cmd/beta/alb/delete/delete.go
@@ -87,15 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Name:            loadbalancerName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/describe/describe.go
+++ b/internal/cmd/beta/alb/describe/describe.go
@@ -81,15 +81,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Name:            loadbalancerName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/list/list.go
+++ b/internal/cmd/beta/alb/list/list.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/add/add.go
+++ b/internal/cmd/beta/alb/observability-credentials/add/add.go
@@ -96,15 +96,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Password:        flags.FlagToStringPointer(p, cmd, passwordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string fo debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/delete/delete.go
+++ b/internal/cmd/beta/alb/observability-credentials/delete/delete.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsRef:  credentialRef,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/describe/describe.go
+++ b/internal/cmd/beta/alb/observability-credentials/describe/describe.go
@@ -80,15 +80,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialRef:   credentialRef,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/list/list.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list.go
@@ -108,15 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.InfoLevel, modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/update/update.go
+++ b/internal/cmd/beta/alb/observability-credentials/update/update.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) inputM
 		Password:        flags.FlagToStringPointer(p, cmd, passwordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return model
 }
 

--- a/internal/cmd/beta/alb/plans/plans.go
+++ b/internal/cmd/beta/alb/plans/plans.go
@@ -90,15 +90,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/pool/update/update.go
+++ b/internal/cmd/beta/alb/pool/update/update.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		AlbName:         flags.FlagToStringPointer(p, cmd, albNameFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/quotas/quotas.go
+++ b/internal/cmd/beta/alb/quotas/quotas.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/alb/template/template.go
+++ b/internal/cmd/beta/alb/template/template.go
@@ -112,14 +112,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Type:            flags.FlagToStringPointer(p, cmd, typeFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/beta/alb/update/update.go
+++ b/internal/cmd/beta/alb/update/update.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Configuration:   flags.FlagToStringPointer(p, cmd, configurationFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/database/create/create.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Owner:           flags.FlagToStringValue(p, cmd, ownerFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/database/delete/delete.go
@@ -104,15 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      flags.FlagToStringValue(p, cmd, instanceIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/database/describe/describe.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      flags.FlagToStringValue(p, cmd, instanceIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list.go
@@ -120,15 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -196,15 +196,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		RetentionDays:   flags.FlagToInt64Pointer(p, cmd, retentionDaysFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/update/update.go
+++ b/internal/cmd/beta/sqlserverflex/instance/update/update.go
@@ -183,15 +183,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:         version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/options/options.go
+++ b/internal/cmd/beta/sqlserverflex/options/options.go
@@ -190,15 +190,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		InstanceId:        instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Roles:           flags.FlagToStringSlicePointer(p, cmd, rolesFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/user/delete/delete.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/user/describe/describe.go
@@ -102,15 +102,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
+++ b/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/config/profile/create/create.go
+++ b/internal/cmd/config/profile/create/create.go
@@ -105,14 +105,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NoSet:            flags.FlagToBoolValue(p, cmd, noSetFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/config/profile/delete/delete.go
+++ b/internal/cmd/config/profile/delete/delete.go
@@ -106,14 +106,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Profile:         profile,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/config/profile/export/export.go
+++ b/internal/cmd/config/profile/export/export.go
@@ -85,14 +85,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		model.FilePath = filepath.Join(model.FilePath, exportFileName)
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/config/profile/import/import.go
+++ b/internal/cmd/config/profile/import/import.go
@@ -94,14 +94,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		}
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return model, nil
 }

--- a/internal/cmd/config/profile/set/set.go
+++ b/internal/cmd/config/profile/set/set.go
@@ -90,14 +90,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Profile:         profile,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }

--- a/internal/cmd/config/set/set.go
+++ b/internal/cmd/config/set/set.go
@@ -246,15 +246,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ProjectIdSet:     projectIdSet,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/config/unset/unset.go
+++ b/internal/cmd/config/unset/unset.go
@@ -294,14 +294,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command) *inputModel {
 		TokenCustomEndpoint:             flags.FlagToBoolValue(p, cmd, tokenCustomEndpointFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model
 }

--- a/internal/cmd/curl/curl.go
+++ b/internal/cmd/curl/curl.go
@@ -154,15 +154,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		OutputFile:             flags.FlagToStringPointer(p, cmd, outputFileFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -157,15 +157,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		}
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/record-set/delete/delete.go
+++ b/internal/cmd/dns/record-set/delete/delete.go
@@ -131,15 +131,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RecordSetId:     recordSetId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RecordSetId:     recordSetId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/record-set/list/list.go
+++ b/internal/cmd/dns/record-set/list/list.go
@@ -165,15 +165,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PageSize:        pageSize,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/record-set/update/update.go
+++ b/internal/cmd/dns/record-set/update/update.go
@@ -169,15 +169,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		TTL:             ttl,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/clone/clone.go
+++ b/internal/cmd/dns/zone/clone/clone.go
@@ -137,15 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ZoneId:          zoneId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -175,15 +175,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ContactEmail:    flags.FlagToStringPointer(p, cmd, contactEmailFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/delete/delete.go
+++ b/internal/cmd/dns/zone/delete/delete.go
@@ -110,15 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ZoneId:          zoneId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ZoneId:          zoneId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -156,15 +156,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PageSize:        pageSize,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/dns/zone/update/update.go
+++ b/internal/cmd/dns/zone/update/update.go
@@ -176,15 +176,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ContactEmail:    contactEmail,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/git/flavor/list/list.go
+++ b/internal/cmd/git/flavor/list/list.go
@@ -104,15 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/git/instance/create/create.go
+++ b/internal/cmd/git/instance/create/create.go
@@ -130,15 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Acl:             acl,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/git/instance/delete/delete.go
+++ b/internal/cmd/git/instance/delete/delete.go
@@ -116,15 +116,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		InstanceId:      cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/git/instance/describe/describe.go
+++ b/internal/cmd/git/instance/describe/describe.go
@@ -79,15 +79,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		InstanceId:      cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/git/instance/list/list.go
+++ b/internal/cmd/git/instance/list/list.go
@@ -105,15 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/image/create/create.go
+++ b/internal/cmd/image/create/create.go
@@ -329,15 +329,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Protected:   flags.FlagToBoolPointer(p, cmd, protectedFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/image/delete/delete.go
+++ b/internal/cmd/image/delete/delete.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		ImageId:         cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/image/describe/describe.go
+++ b/internal/cmd/image/describe/describe.go
@@ -84,15 +84,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		ImageId:         cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/image/list/list.go
+++ b/internal/cmd/image/list/list.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/image/update/update.go
+++ b/internal/cmd/image/update/update.go
@@ -233,15 +233,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		model.Config = nil
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/key-pair/create/create.go
+++ b/internal/cmd/key-pair/create/create.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PublicKey:       flags.FlagToStringPointer(p, cmd, publicKeyFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string fo debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/key-pair/delete/delete.go
+++ b/internal/cmd/key-pair/delete/delete.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		KeyPairName:     keyPairName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/key-pair/describe/describe.go
+++ b/internal/cmd/key-pair/describe/describe.go
@@ -98,15 +98,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicKey:       flags.FlagToBoolValue(p, cmd, publicKeyFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.InfoLevel, modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/key-pair/update/update.go
+++ b/internal/cmd/key-pair/update/update.go
@@ -103,15 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) inputM
 		KeyPairName:     utils.Ptr(keyPairName),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return model
 }
 

--- a/internal/cmd/load-balancer/create/create.go
+++ b/internal/cmd/load-balancer/create/create.go
@@ -143,15 +143,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Payload:         payload,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/delete/delete.go
+++ b/internal/cmd/load-balancer/delete/delete.go
@@ -100,15 +100,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		LoadBalancerName: loadBalancerName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/describe/describe.go
+++ b/internal/cmd/load-balancer/describe/describe.go
@@ -82,15 +82,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		LoadBalancerName: loadBalancerName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/generate-payload/generate_payload.go
+++ b/internal/cmd/load-balancer/generate-payload/generate_payload.go
@@ -196,15 +196,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		FilePath:         flags.FlagToStringPointer(p, cmd, filePathFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/list/list.go
+++ b/internal/cmd/load-balancer/list/list.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/observability-credentials/add/add.go
+++ b/internal/cmd/load-balancer/observability-credentials/add/add.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Password:        flags.FlagToStringPointer(p, cmd, passwordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
+++ b/internal/cmd/load-balancer/observability-credentials/cleanup/cleanup.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/observability-credentials/delete/delete.go
+++ b/internal/cmd/load-balancer/observability-credentials/delete/delete.go
@@ -98,15 +98,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsRef:  credentialsRef,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/observability-credentials/describe/describe.go
+++ b/internal/cmd/load-balancer/observability-credentials/describe/describe.go
@@ -79,15 +79,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsRef:  credentialsRef,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -150,15 +150,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Unused:          flags.FlagToBoolValue(p, cmd, unusedFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/quota/quota.go
+++ b/internal/cmd/load-balancer/quota/quota.go
@@ -69,15 +69,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/target-pool/add-target/add_target.go
+++ b/internal/cmd/load-balancer/target-pool/add-target/add_target.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		IP:              ip,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/target-pool/describe/describe.go
+++ b/internal/cmd/load-balancer/target-pool/describe/describe.go
@@ -103,15 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		LBName:          cmd.Flag(lbNameFlag).Value.String(),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/target-pool/remove-target/remove_target.go
+++ b/internal/cmd/load-balancer/target-pool/remove-target/remove_target.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		IP:              ip,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/load-balancer/update/update.go
+++ b/internal/cmd/load-balancer/update/update.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Payload:          payload,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/credentials/create/create.go
+++ b/internal/cmd/logme/credentials/create/create.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/credentials/delete/delete.go
+++ b/internal/cmd/logme/credentials/delete/delete.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/credentials/describe/describe.go
+++ b/internal/cmd/logme/credentials/describe/describe.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/credentials/list/list.go
+++ b/internal/cmd/logme/credentials/list/list.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/instance/create/create.go
+++ b/internal/cmd/logme/instance/create/create.go
@@ -186,15 +186,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/instance/delete/delete.go
+++ b/internal/cmd/logme/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/instance/describe/describe.go
+++ b/internal/cmd/logme/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/instance/update/update.go
+++ b/internal/cmd/logme/instance/update/update.go
@@ -196,15 +196,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/logme/plans/plans.go
+++ b/internal/cmd/logme/plans/plans.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/credentials/delete/delete.go
+++ b/internal/cmd/mariadb/credentials/delete/delete.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -186,15 +186,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/instance/delete/delete.go
+++ b/internal/cmd/mariadb/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -194,15 +194,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupId:        backupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/backup/list/list.go
+++ b/internal/cmd/mongodbflex/backup/list/list.go
@@ -128,15 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/backup/restore/restore.go
+++ b/internal/cmd/mongodbflex/backup/restore/restore.go
@@ -171,15 +171,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Timestamp:        flags.FlagToStringValue(p, cmd, timestampFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/backup/schedule/schedule.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule.go
@@ -87,15 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		InstanceId:      *flags.FlagToStringPointer(p, cmd, instanceIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -195,15 +195,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Type:            utils.Ptr(flags.FlagWithDefaultToStringValue(p, cmd, typeFlag)),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/instance/delete/delete.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -187,15 +187,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Type:            instanceType,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		FlavorId:        flags.FlagToStringPointer(p, cmd, flavorIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -128,15 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Roles:           flags.FlagWithDefaultToStringSlicePointer(p, cmd, roleFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/delete/delete.go
+++ b/internal/cmd/mongodbflex/user/delete/delete.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -130,15 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Roles:           roles,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/create/create.go
+++ b/internal/cmd/network-area/create/create.go
@@ -150,15 +150,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:              flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/delete/delete.go
+++ b/internal/cmd/network-area/delete/delete.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		AreaId:          areaId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/describe/describe.go
+++ b/internal/cmd/network-area/describe/describe.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ShowAttachedProjects: flags.FlagToBoolValue(p, cmd, showAttachedProjectsFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -137,15 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/network-range/create/create.go
+++ b/internal/cmd/network-area/network-range/create/create.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		NetworkRange:    flags.FlagToStringPointer(p, cmd, networkRangeFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/network-range/delete/delete.go
+++ b/internal/cmd/network-area/network-range/delete/delete.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NetworkRangeId:  networkRangeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/network-range/describe/describe.go
+++ b/internal/cmd/network-area/network-range/describe/describe.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NetworkRangeId:  networkRangeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		NetworkAreaId:   flags.FlagToStringPointer(p, cmd, networkAreaIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/route/create/create.go
+++ b/internal/cmd/network-area/route/create/create.go
@@ -130,15 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:          flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/route/delete/delete.go
+++ b/internal/cmd/network-area/route/delete/delete.go
@@ -105,15 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RouteId:         routeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/route/describe/describe.go
+++ b/internal/cmd/network-area/route/describe/describe.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RouteId:         routeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -124,15 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		NetworkAreaId:   flags.FlagToStringPointer(p, cmd, networkAreaIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/route/update/update.go
+++ b/internal/cmd/network-area/route/update/update.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-area/update/update.go
+++ b/internal/cmd/network-area/update/update.go
@@ -138,15 +138,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:              flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-interface/create/create.go
+++ b/internal/cmd/network-interface/create/create.go
@@ -192,15 +192,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		model.AllowedAddresses = utils.Ptr(allowedAddressesInner)
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-interface/delete/delete.go
+++ b/internal/cmd/network-interface/delete/delete.go
@@ -94,15 +94,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NicId:           nicId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-interface/describe/describe.go
+++ b/internal/cmd/network-interface/describe/describe.go
@@ -100,15 +100,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NicId:           nicId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-interface/list/list.go
+++ b/internal/cmd/network-interface/list/list.go
@@ -133,15 +133,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		NetworkId:       flags.FlagToStringPointer(p, cmd, networkIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network-interface/update/update.go
+++ b/internal/cmd/network-interface/update/update.go
@@ -184,15 +184,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		model.AllowedAddresses = utils.Ptr(allowedAddressesInner)
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network/create/create.go
+++ b/internal/cmd/network/create/create.go
@@ -185,15 +185,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:             flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network/delete/delete.go
+++ b/internal/cmd/network/delete/delete.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NetworkId:       networkId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network/describe/describe.go
+++ b/internal/cmd/network/describe/describe.go
@@ -85,15 +85,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		NetworkId:       networkId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network/list/list.go
+++ b/internal/cmd/network/list/list.go
@@ -127,15 +127,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/network/update/update.go
+++ b/internal/cmd/network/update/update.go
@@ -163,15 +163,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:             flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/bucket/create/create.go
+++ b/internal/cmd/object-storage/bucket/create/create.go
@@ -110,15 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BucketName:      bucketName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/bucket/delete/delete.go
+++ b/internal/cmd/object-storage/bucket/delete/delete.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BucketName:      bucketName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/bucket/describe/describe.go
+++ b/internal/cmd/object-storage/bucket/describe/describe.go
@@ -81,15 +81,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BucketName:      bucketName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/bucket/list/list.go
+++ b/internal/cmd/object-storage/bucket/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials-group/create/create.go
+++ b/internal/cmd/object-storage/credentials-group/create/create.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		CredentialsGroupName: flags.FlagToStringValue(p, cmd, credentialsGroupNameFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials-group/delete/delete.go
+++ b/internal/cmd/object-storage/credentials-group/delete/delete.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsGroupId: credentialsGroupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -105,15 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials/create/create.go
+++ b/internal/cmd/object-storage/credentials/create/create.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		CredentialsGroupId: flags.FlagToStringValue(p, cmd, credentialsGroupIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials/delete/delete.go
+++ b/internal/cmd/object-storage/credentials/delete/delete.go
@@ -108,15 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:      credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/credentials/list/list.go
+++ b/internal/cmd/object-storage/credentials/list/list.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:              limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/disable/disable.go
+++ b/internal/cmd/object-storage/disable/disable.go
@@ -87,15 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/object-storage/enable/enable.go
+++ b/internal/cmd/object-storage/enable/enable.go
@@ -87,15 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/grafana/describe/describe.go
+++ b/internal/cmd/observability/grafana/describe/describe.go
@@ -103,15 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/grafana/public-read-access/disable/disable.go
+++ b/internal/cmd/observability/grafana/public-read-access/disable/disable.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/grafana/public-read-access/enable/enable.go
+++ b/internal/cmd/observability/grafana/public-read-access/enable/enable.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/grafana/single-sign-on/disable/disable.go
+++ b/internal/cmd/observability/grafana/single-sign-on/disable/disable.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/grafana/single-sign-on/enable/enable.go
+++ b/internal/cmd/observability/grafana/single-sign-on/enable/enable.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/instance/create/create.go
+++ b/internal/cmd/observability/instance/create/create.go
@@ -149,15 +149,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PlanName:        planName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/instance/delete/delete.go
+++ b/internal/cmd/observability/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/instance/describe/describe.go
+++ b/internal/cmd/observability/instance/describe/describe.go
@@ -81,15 +81,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/instance/list/list.go
+++ b/internal/cmd/observability/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/instance/update/update.go
+++ b/internal/cmd/observability/instance/update/update.go
@@ -158,15 +158,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceName:    instanceName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/observability/plans/plans.go
+++ b/internal/cmd/observability/plans/plans.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/credentials/delete/delete.go
+++ b/internal/cmd/opensearch/credentials/delete/delete.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/instance/create/create.go
+++ b/internal/cmd/opensearch/instance/create/create.go
@@ -190,15 +190,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/instance/delete/delete.go
+++ b/internal/cmd/opensearch/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/instance/update/update.go
+++ b/internal/cmd/opensearch/instance/update/update.go
@@ -200,15 +200,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/organization/member/add/add.go
+++ b/internal/cmd/organization/member/add/add.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Role:            flags.FlagToStringPointer(p, cmd, roleFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -124,15 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		SortBy:          flags.FlagWithDefaultToStringValue(p, cmd, sortByFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/organization/member/remove/remove.go
+++ b/internal/cmd/organization/member/remove/remove.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Force:           flags.FlagToBoolValue(p, cmd, forceFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/clone/clone.go
+++ b/internal/cmd/postgresflex/instance/clone/clone.go
@@ -150,15 +150,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RecoveryDate:    utils.Ptr(recoveryTimestampString),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/create/create.go
+++ b/internal/cmd/postgresflex/instance/create/create.go
@@ -196,15 +196,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Type:            utils.Ptr(flags.FlagWithDefaultToStringValue(p, cmd, typeFlag)),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/delete/delete.go
+++ b/internal/cmd/postgresflex/instance/delete/delete.go
@@ -159,15 +159,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ForceDelete:     flags.FlagToBoolValue(p, cmd, forceDeleteFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/describe/describe.go
+++ b/internal/cmd/postgresflex/instance/describe/describe.go
@@ -84,15 +84,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/instance/update/update.go
+++ b/internal/cmd/postgresflex/instance/update/update.go
@@ -187,15 +187,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Type:            instanceType,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/options/options.go
+++ b/internal/cmd/postgresflex/options/options.go
@@ -129,15 +129,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		FlavorId:        flags.FlagToStringPointer(p, cmd, flavorIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Roles:           flags.FlagWithDefaultToStringSlicePointer(p, cmd, roleFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/delete/delete.go
+++ b/internal/cmd/postgresflex/user/delete/delete.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/describe/describe.go
+++ b/internal/cmd/postgresflex/user/describe/describe.go
@@ -100,15 +100,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/list/list.go
+++ b/internal/cmd/postgresflex/user/list/list.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/reset-password/reset_password.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password.go
@@ -116,15 +116,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/postgresflex/user/update/update.go
+++ b/internal/cmd/postgresflex/user/update/update.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Roles:           roles,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -145,15 +145,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		NetworkAreaId:   flags.FlagToStringPointer(p, cmd, networkAreaIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/delete/delete.go
+++ b/internal/cmd/project/delete/delete.go
@@ -90,15 +90,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		IncludeParents:  flags.FlagToBoolValue(p, cmd, includeParentsFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -140,15 +140,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PageSize:          pageSize,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/member/add/add.go
+++ b/internal/cmd/project/member/add/add.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Role:            flags.FlagToStringPointer(p, cmd, roleFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -126,15 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		SortBy:          flags.FlagWithDefaultToStringValue(p, cmd, sortByFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/member/remove/remove.go
+++ b/internal/cmd/project/member/remove/remove.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Force:           flags.FlagToBoolValue(p, cmd, forceFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/project/update/update.go
+++ b/internal/cmd/project/update/update.go
@@ -143,15 +143,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:          labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/associate/associate.go
+++ b/internal/cmd/public-ip/associate/associate.go
@@ -108,15 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:           publicIpId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/create/create.go
+++ b/internal/cmd/public-ip/create/create.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:               flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/delete/delete.go
+++ b/internal/cmd/public-ip/delete/delete.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:      publicIpId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/describe/describe.go
+++ b/internal/cmd/public-ip/describe/describe.go
@@ -86,15 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:      publicIpId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/disassociate/disassociate.go
+++ b/internal/cmd/public-ip/disassociate/disassociate.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:      publicIpId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -127,15 +127,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/ranges/list/list.go
+++ b/internal/cmd/public-ip/ranges/list/list.go
@@ -102,15 +102,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/public-ip/update/update.go
+++ b/internal/cmd/public-ip/update/update.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/quota/list/list.go
+++ b/internal/cmd/quota/list/list.go
@@ -90,15 +90,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/credentials/create/create.go
+++ b/internal/cmd/rabbitmq/credentials/create/create.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/credentials/delete/delete.go
+++ b/internal/cmd/rabbitmq/credentials/delete/delete.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/credentials/describe/describe.go
+++ b/internal/cmd/rabbitmq/credentials/describe/describe.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/credentials/list/list.go
+++ b/internal/cmd/rabbitmq/credentials/list/list.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/instance/create/create.go
+++ b/internal/cmd/rabbitmq/instance/create/create.go
@@ -190,15 +190,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/instance/delete/delete.go
+++ b/internal/cmd/rabbitmq/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/instance/describe/describe.go
+++ b/internal/cmd/rabbitmq/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/instance/list/list.go
+++ b/internal/cmd/rabbitmq/instance/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/instance/update/update.go
+++ b/internal/cmd/rabbitmq/instance/update/update.go
@@ -200,15 +200,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/rabbitmq/plans/plans.go
+++ b/internal/cmd/rabbitmq/plans/plans.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/credentials/create/create.go
+++ b/internal/cmd/redis/credentials/create/create.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ShowPassword:    flags.FlagToBoolValue(p, cmd, showPasswordFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/credentials/delete/delete.go
+++ b/internal/cmd/redis/credentials/delete/delete.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/credentials/describe/describe.go
+++ b/internal/cmd/redis/credentials/describe/describe.go
@@ -95,15 +95,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CredentialsId:   credentialsId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/credentials/list/list.go
+++ b/internal/cmd/redis/credentials/list/list.go
@@ -118,15 +118,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/instance/create/create.go
+++ b/internal/cmd/redis/instance/create/create.go
@@ -186,15 +186,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/instance/delete/delete.go
+++ b/internal/cmd/redis/instance/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/instance/describe/describe.go
+++ b/internal/cmd/redis/instance/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/instance/list/list.go
+++ b/internal/cmd/redis/instance/list/list.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/instance/update/update.go
+++ b/internal/cmd/redis/instance/update/update.go
@@ -194,15 +194,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Version:              version,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/redis/plans/plans.go
+++ b/internal/cmd/redis/plans/plans.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Acls:            flags.FlagToStringSlicePointer(p, cmd, aclFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/instance/delete/delete.go
+++ b/internal/cmd/secrets-manager/instance/delete/delete.go
@@ -91,15 +91,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/instance/describe/describe.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe.go
@@ -89,15 +89,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		InstanceId:      instanceId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/instance/update/update.go
+++ b/internal/cmd/secrets-manager/instance/update/update.go
@@ -110,15 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Acls:            acls,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Write:           utils.Ptr(flags.FlagToBoolValue(p, cmd, writeFlag)),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/user/delete/delete.go
+++ b/internal/cmd/secrets-manager/user/delete/delete.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/user/describe/describe.go
+++ b/internal/cmd/secrets-manager/user/describe/describe.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -121,15 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/secrets-manager/user/update/update.go
+++ b/internal/cmd/secrets-manager/user/update/update.go
@@ -137,15 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UserId:          userId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/create/create.go
+++ b/internal/cmd/security-group/create/create.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Stateful:    flags.FlagToBoolPointer(p, cmd, statefulFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/delete/delete.go
+++ b/internal/cmd/security-group/delete/delete.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		SecurityGroupId: cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/describe/describe.go
+++ b/internal/cmd/security-group/describe/describe.go
@@ -85,15 +85,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		SecurityGroupId: cliArgs[0],
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -99,15 +99,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/rule/create/create.go
+++ b/internal/cmd/security-group/rule/create/create.go
@@ -165,15 +165,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ProtocolName:          flags.FlagToStringPointer(p, cmd, protocolNameFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/rule/delete/delete.go
+++ b/internal/cmd/security-group/rule/delete/delete.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		SecurityGroupId:     flags.FlagToStringPointer(p, cmd, securityGroupIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/rule/describe/describe.go
+++ b/internal/cmd/security-group/rule/describe/describe.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		SecurityGroupId:     flags.FlagToStringPointer(p, cmd, securityGroupIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/rule/list/list.go
+++ b/internal/cmd/security-group/rule/list/list.go
@@ -132,15 +132,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		SecurityGroupId: flags.FlagToStringPointer(p, cmd, securityGroupIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/security-group/update/update.go
+++ b/internal/cmd/security-group/update/update.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 		return nil, fmt.Errorf("no flags have been passed")
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/create/create.go
+++ b/internal/cmd/server/backup/create/create.go
@@ -129,15 +129,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		BackupVolumeIds:       flags.FlagToStringSliceValue(p, cmd, backupVolumeIdsFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/delete/delete.go
+++ b/internal/cmd/server/backup/delete/delete.go
@@ -97,15 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/describe/describe.go
+++ b/internal/cmd/server/backup/describe/describe.go
@@ -94,15 +94,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupId:        backupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/disable/disable.go
+++ b/internal/cmd/server/backup/disable/disable.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/enable/enable.go
+++ b/internal/cmd/server/backup/enable/enable.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/list/list.go
+++ b/internal/cmd/server/backup/list/list.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/restore/restore.go
+++ b/internal/cmd/server/backup/restore/restore.go
@@ -110,15 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		StartServerAfterRestore: flags.FlagToBoolValue(p, cmd, startServerAfterRestoreFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/schedule/create/create.go
+++ b/internal/cmd/server/backup/schedule/create/create.go
@@ -143,15 +143,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		BackupVolumeIds:       flags.FlagToStringSliceValue(p, cmd, backupVolumeIdsFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/schedule/delete/delete.go
+++ b/internal/cmd/server/backup/schedule/delete/delete.go
@@ -109,15 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/schedule/describe/describe.go
+++ b/internal/cmd/server/backup/schedule/describe/describe.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupScheduleId: backupScheduleId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/schedule/list/list.go
+++ b/internal/cmd/server/backup/schedule/list/list.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/schedule/update/update.go
+++ b/internal/cmd/server/backup/schedule/update/update.go
@@ -142,15 +142,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupVolumeIds:       flags.FlagToStringSliceValue(p, cmd, backupVolumeIdsFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/volume-backup/delete/delete.go
+++ b/internal/cmd/server/backup/volume-backup/delete/delete.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/backup/volume-backup/restore/restore.go
+++ b/internal/cmd/server/backup/volume-backup/restore/restore.go
@@ -105,15 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		RestoreVolumeId: flags.FlagToStringValue(p, cmd, restoreVolumeIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/command/create/create.go
+++ b/internal/cmd/server/command/create/create.go
@@ -131,15 +131,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	}
 	model.Params = &parsedParams
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/command/describe/describe.go
+++ b/internal/cmd/server/command/describe/describe.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CommandId:       commandId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/command/list/list.go
+++ b/internal/cmd/server/command/list/list.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/command/template/describe/describe.go
+++ b/internal/cmd/server/command/template/describe/describe.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		CommandTemplateName: commandTemplateName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/command/template/list/list.go
+++ b/internal/cmd/server/command/template/list/list.go
@@ -102,15 +102,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/console/console.go
+++ b/internal/cmd/server/console/console.go
@@ -93,15 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -267,15 +267,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Volumes:                       flags.FlagToStringSlicePointer(p, cmd, volumesFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/deallocate/deallocate.go
+++ b/internal/cmd/server/deallocate/deallocate.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/delete/delete.go
+++ b/internal/cmd/server/delete/delete.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -85,15 +85,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/log/log.go
+++ b/internal/cmd/server/log/log.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Length:          utils.Ptr(length),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/machine-type/describe/describe.go
+++ b/internal/cmd/server/machine-type/describe/describe.go
@@ -85,15 +85,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		MachineType:     machineType,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/machine-type/list/list.go
+++ b/internal/cmd/server/machine-type/list/list.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/network-interface/attach/attach.go
+++ b/internal/cmd/server/network-interface/attach/attach.go
@@ -152,15 +152,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Create:          create,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/network-interface/detach/detach.go
+++ b/internal/cmd/server/network-interface/detach/detach.go
@@ -154,15 +154,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Delete:          deleteValue,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/network-interface/list/list.go
+++ b/internal/cmd/server/network-interface/list/list.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/create/create.go
+++ b/internal/cmd/server/os-update/create/create.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		MaintenanceWindow: flags.FlagWithDefaultToInt64Value(p, cmd, maintenanceWindowFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/describe/describe.go
+++ b/internal/cmd/server/os-update/describe/describe.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		UpdateId:        updateId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/disable/disable.go
+++ b/internal/cmd/server/os-update/disable/disable.go
@@ -104,15 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/enable/enable.go
+++ b/internal/cmd/server/os-update/enable/enable.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/list/list.go
+++ b/internal/cmd/server/os-update/list/list.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/schedule/create/create.go
+++ b/internal/cmd/server/os-update/schedule/create/create.go
@@ -134,15 +134,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Enabled:           flags.FlagToBoolValue(p, cmd, enabledFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/schedule/delete/delete.go
+++ b/internal/cmd/server/os-update/schedule/delete/delete.go
@@ -96,15 +96,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        flags.FlagToStringValue(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/schedule/describe/describe.go
+++ b/internal/cmd/server/os-update/schedule/describe/describe.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ScheduleId:      scheduleId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/schedule/list/list.go
+++ b/internal/cmd/server/os-update/schedule/list/list.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/os-update/schedule/update/update.go
+++ b/internal/cmd/server/os-update/schedule/update/update.go
@@ -130,15 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Enabled:           flags.FlagToBoolPointer(p, cmd, enabledFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/public-ip/attach/attach.go
+++ b/internal/cmd/server/public-ip/attach/attach.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:      volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/public-ip/detach/detach.go
+++ b/internal/cmd/server/public-ip/detach/detach.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PublicIpId:      publicIpId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/reboot/reboot.go
+++ b/internal/cmd/server/reboot/reboot.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		HardReboot:      flags.FlagToBoolValue(p, cmd, hardRebootFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/rescue/rescue.go
+++ b/internal/cmd/server/rescue/rescue.go
@@ -126,15 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ImageId:         flags.FlagToStringPointer(p, cmd, imageIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/resize/resize.go
+++ b/internal/cmd/server/resize/resize.go
@@ -126,15 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		MachineType:     flags.FlagToStringPointer(p, cmd, machineTypeFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServiceAccMail:  serviceAccMail,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServiceAccMail:  serviceAccMail,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/service-account/list/list.go
+++ b/internal/cmd/server/service-account/list/list.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringPointer(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/start/start.go
+++ b/internal/cmd/server/start/start.go
@@ -105,15 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/stop/stop.go
+++ b/internal/cmd/server/stop/stop.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/unrescue/unrescue.go
+++ b/internal/cmd/server/unrescue/unrescue.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ServerId:        serverId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/update/update.go
+++ b/internal/cmd/server/update/update.go
@@ -114,15 +114,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/volume/attach/attach.go
+++ b/internal/cmd/server/volume/attach/attach.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:            volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/volume/describe/describe.go
+++ b/internal/cmd/server/volume/describe/describe.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:        volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/volume/detach/detach.go
+++ b/internal/cmd/server/volume/detach/detach.go
@@ -112,15 +112,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:        volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/volume/list/list.go
+++ b/internal/cmd/server/volume/list/list.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		ServerId:        flags.FlagToStringPointer(p, cmd, serverIdFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/server/volume/update/update.go
+++ b/internal/cmd/server/volume/update/update.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:            volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -100,15 +100,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Name:            flags.FlagToStringPointer(p, cmd, nameFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -87,15 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Email:           email,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -73,15 +73,7 @@ func parseInput(p *print.Printer, _ *cobra.Command, inputArgs []string) (*inputM
 		Email: email,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -140,15 +140,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		PublicKey:           flags.FlagToStringPointer(p, cmd, publicKeyFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/key/delete/delete.go
+++ b/internal/cmd/service-account/key/delete/delete.go
@@ -108,15 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		KeyId:               keyId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/key/describe/describe.go
+++ b/internal/cmd/service-account/key/describe/describe.go
@@ -98,15 +98,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		KeyId:               keyId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:               limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/key/update/update.go
+++ b/internal/cmd/service-account/key/update/update.go
@@ -149,15 +149,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Deactivate:          deactivate,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		TTLDays:             &ttlDays,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -128,15 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:               limit,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/service-account/token/revoke/revoke.go
+++ b/internal/cmd/service-account/token/revoke/revoke.go
@@ -111,15 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		TokenId:             tokenId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -179,15 +179,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Payload:         payload,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/delete/delete.go
+++ b/internal/cmd/ske/cluster/delete/delete.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -81,15 +81,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/generate-payload/generate_payload.go
+++ b/internal/cmd/ske/cluster/generate-payload/generate_payload.go
@@ -117,15 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		FilePath:        flags.FlagToStringPointer(p, cmd, filePathFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/hibernate/hibernate.go
+++ b/internal/cmd/ske/cluster/hibernate/hibernate.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -130,15 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Limit:           flags.FlagToInt64Pointer(p, cmd, limitFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/maintenance/maintenance.go
+++ b/internal/cmd/ske/cluster/maintenance/maintenance.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/reconcile/reconcile.go
+++ b/internal/cmd/ske/cluster/reconcile/reconcile.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/update/update.go
+++ b/internal/cmd/ske/cluster/update/update.go
@@ -141,15 +141,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Payload:         payload,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/cluster/wakeup/wakeup.go
+++ b/internal/cmd/ske/cluster/wakeup/wakeup.go
@@ -92,15 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/credentials/complete-rotation/complete_rotation.go
+++ b/internal/cmd/ske/credentials/complete-rotation/complete_rotation.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/credentials/start-rotation/start_rotation.go
+++ b/internal/cmd/ske/credentials/start-rotation/start_rotation.go
@@ -122,15 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ClusterName:     clusterName,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -70,15 +70,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -101,15 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		GlobalFlagModel: globalFlags,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/kubeconfig/create/create.go
+++ b/internal/cmd/ske/kubeconfig/create/create.go
@@ -215,15 +215,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Overwrite:       flags.FlagToBoolValue(p, cmd, overwriteFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -119,15 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		VolumeTypes:        volumeTypes,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/create/create.go
+++ b/internal/cmd/volume/backup/create/create.go
@@ -166,15 +166,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:          *labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/delete/delete.go
+++ b/internal/cmd/volume/backup/delete/delete.go
@@ -107,15 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupId:        backupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/describe/describe.go
+++ b/internal/cmd/volume/backup/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupId:        backupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/list/list.go
+++ b/internal/cmd/volume/backup/list/list.go
@@ -123,15 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   labelSelector,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/restore/restore.go
+++ b/internal/cmd/volume/backup/restore/restore.go
@@ -120,15 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		BackupId:        backupId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/backup/update/update.go
+++ b/internal/cmd/volume/backup/update/update.go
@@ -115,15 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          *labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/create/create.go
+++ b/internal/cmd/volume/create/create.go
@@ -155,15 +155,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		SourceType:       flags.FlagToStringPointer(p, cmd, sourceTypeFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/delete/delete.go
+++ b/internal/cmd/volume/delete/delete.go
@@ -113,15 +113,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:        volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/describe/describe.go
+++ b/internal/cmd/volume/describe/describe.go
@@ -86,15 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:        volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/list/list.go
+++ b/internal/cmd/volume/list/list.go
@@ -124,15 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/performance-class/describe/describe.go
+++ b/internal/cmd/volume/performance-class/describe/describe.go
@@ -86,15 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumePerformanceClass: volumePerformanceClass,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/performance-class/list/list.go
+++ b/internal/cmd/volume/performance-class/list/list.go
@@ -125,15 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/resize/resize.go
+++ b/internal/cmd/volume/resize/resize.go
@@ -106,15 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		VolumeId:        volumeId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/snapshot/create/create.go
+++ b/internal/cmd/volume/snapshot/create/create.go
@@ -147,15 +147,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		Labels:          *labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/snapshot/delete/delete.go
+++ b/internal/cmd/volume/snapshot/delete/delete.go
@@ -110,15 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		SnapshotId:      snapshotId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/snapshot/describe/describe.go
+++ b/internal/cmd/volume/snapshot/describe/describe.go
@@ -83,15 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		SnapshotId:      snapshotId,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/snapshot/list/list.go
+++ b/internal/cmd/volume/snapshot/list/list.go
@@ -124,15 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 		LabelSelector:   labelSelector,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/snapshot/update/update.go
+++ b/internal/cmd/volume/snapshot/update/update.go
@@ -120,15 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          *labels,
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/cmd/volume/update/update.go
+++ b/internal/cmd/volume/update/update.go
@@ -120,15 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		Labels:          flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
 
-	if p.IsVerbosityDebug() {
-		modelStr, err := print.BuildDebugStrFromInputModel(model)
-		if err != nil {
-			p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
-		} else {
-			p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
-		}
-	}
-
+	p.DebugInputModel(model)
 	return &model, nil
 }
 

--- a/internal/pkg/print/debug.go
+++ b/internal/pkg/print/debug.go
@@ -16,11 +16,11 @@ import (
 
 var defaultHTTPHeaders = []string{"Accept", "Content-Type", "Content-Length", "User-Agent", "Date", "Referrer-Policy", "Traceparent"}
 
-// BuildDebugStrFromInputModel converts an input model to a user-friendly string representation.
+// buildDebugStrFromInputModel converts an input model to a user-friendly string representation.
 // This function converts the input model to a map, removes empty values, and generates a string representation of the map.
 // The purpose of this function is to provide a more readable output than the default JSON representation.
 // It is particularly useful when outputting to the slog logger, as the JSON format with escaped quotes does not look good.
-func BuildDebugStrFromInputModel(model any) (string, error) {
+func buildDebugStrFromInputModel(model any) (string, error) {
 	// Marshaling and Unmarshaling is the best way to convert the struct to a map
 	modelBytes, err := json.Marshal(model)
 	if err != nil {

--- a/internal/pkg/print/debug_test.go
+++ b/internal/pkg/print/debug_test.go
@@ -171,7 +171,7 @@ func TestBuildDebugStrFromInputModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			model := tt.model
-			actual, err := BuildDebugStrFromInputModel(model)
+			actual, err := buildDebugStrFromInputModel(model)
 			if err != nil {
 				if !tt.isValid {
 					return

--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -51,7 +51,7 @@ type Printer struct {
 	Verbosity Level
 }
 
-// Creates a new printer, including setting up the default logger.
+// NewPrinter creates a new printer, including setting up the default logger.
 func NewPrinter() *Printer {
 	w := os.Stderr
 	logger := slog.New(
@@ -227,4 +227,16 @@ func (p *Printer) IsVerbosityWarning() bool {
 // Returns True if the verbosity level is set to Error, False otherwise.
 func (p *Printer) IsVerbosityError() bool {
 	return p.Verbosity == ErrorLevel
+}
+
+// DebugInputModel prints the given input model in case verbosity level is set to Debug, does nothing otherwise
+func (p *Printer) DebugInputModel(model any) {
+	if p.IsVerbosityDebug() {
+		modelStr, err := buildDebugStrFromInputModel(model)
+		if err != nil {
+			p.Debug(ErrorLevel, "convert model to string for debugging: %v", err)
+		} else {
+			p.Debug(DebugLevel, "parsed input values: %s", modelStr)
+		}
+	}
 }


### PR DESCRIPTION
## Description

I replaced some boilerplate code with a new printer func. 

Old: 

```golang
if p.IsVerbosityDebug() {
    modelStr, err := print.BuildDebugStrFromInputModel(model)
    if err != nil {
	    p.Debug(print.ErrorLevel, "convert model to string for debugging: %v", err)
    } else {
	    p.Debug(print.DebugLevel, "parsed input values: %s", modelStr)
    }
}
```

New: 
```golang
p.DebugInputModel(model)
```

New func is located here: `internal/pkg/print/print.go`

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
