### PR TITLE
refactor: implement a new output result func to handle json/yaml output in a central place

### DIFF
--- a/.github/docs/contribution-guide/cmd.go
+++ b/.github/docs/contribution-guide/cmd.go
@@ -2,7 +2,6 @@ package bar
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -17,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	"gopkg.in/yaml.v2"
 	// (...)
 )
 
@@ -118,22 +116,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *foo.APIClie
 
 // Output result based on the configured output format
 func outputResult(p *print.Printer, cmd *cobra.Command, outputFormat string, resources []foo.Resource) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resources, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal resource list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.Marshal(resources)
-		if err != nil {
-			return fmt.Errorf("marshal resource list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	default:
+	// the output result handles JSON/YAML output, you can pass your own callback func for pretty (default) output format
+	return p.OutputResult(outputFormat, resources, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATE")
 		for i := range resources {
@@ -145,5 +129,5 @@ func outputResult(p *print.Printer, cmd *cobra.Command, outputFormat string, res
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/affinity-groups/create/create.go
+++ b/internal/cmd/affinity-groups/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -121,21 +119,9 @@ func outputResult(p *print.Printer, model inputModel, resp iaas.AffinityGroup) e
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.GlobalFlagModel.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal affinity group: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal affinity group: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created affinity group %q with id %s\n", model.Name, utils.PtrString(resp.Id))
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/affinity-groups/describe/describe.go
+++ b/internal/cmd/affinity-groups/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -93,20 +91,8 @@ func outputResult(p *print.Printer, model inputModel, resp iaas.AffinityGroup) e
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.GlobalFlagModel.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal affinity group: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal affinity group: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+
+	return p.OutputResult(outputFormat, resp, func() error {
 		table := tables.NewTable()
 
 		if resp.HasId() {
@@ -129,6 +115,6 @@ func outputResult(p *print.Printer, model inputModel, resp iaas.AffinityGroup) e
 		if err := table.Display(p); err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/affinity-groups/list/list.go
+++ b/internal/cmd/affinity-groups/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -115,20 +113,8 @@ func outputResult(p *print.Printer, model inputModel, items []iaas.AffinityGroup
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.GlobalFlagModel.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal affinity groups: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal affinity groups: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "POLICY")
 		for _, item := range items {
@@ -143,6 +129,7 @@ func outputResult(p *print.Printer, model inputModel, items []iaas.AffinityGroup
 		if err := table.Display(p); err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}
-	}
-	return nil
+
+		return nil
+	})
 }

--- a/internal/cmd/beta/alb/create/create.go
+++ b/internal/cmd/beta/alb/create/create.go
@@ -162,29 +162,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("create loadbalancer response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s application loadbalancer for %q. Name: %s\n", operationState, projectLabel, utils.PtrString(resp.Name))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/alb/describe/describe.go
+++ b/internal/cmd/beta/alb/describe/describe.go
@@ -2,7 +2,6 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
@@ -89,54 +87,27 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 	return apiClient.GetLoadBalancer(ctx, model.ProjectId, model.Region, model.Name)
 }
 
-func outputResult(p *print.Printer, outputFormat string, response *alb.LoadBalancer) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(response, "", "  ")
+func outputResult(p *print.Printer, outputFormat string, loadbalancer *alb.LoadBalancer) error {
+	return p.OutputResult(outputFormat, loadbalancer, func() error {
+		content := []tables.Table{}
 
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
+		content = append(content, buildLoadBalancerTable(loadbalancer))
+
+		if loadbalancer.Listeners != nil {
+			content = append(content, buildListenersTable(*loadbalancer.Listeners))
 		}
-		p.Outputln(string(details))
+
+		if loadbalancer.TargetPools != nil {
+			content = append(content, buildTargetPoolsTable(*loadbalancer.TargetPools))
+		}
+
+		err := tables.DisplayTables(p, content)
+		if err != nil {
+			return fmt.Errorf("display output: %w", err)
+		}
 
 		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(response, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
-		if err := outputResultAsTable(p, response); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func outputResultAsTable(p *print.Printer, loadbalancer *alb.LoadBalancer) error {
-	content := []tables.Table{}
-
-	content = append(content, buildLoadBalancerTable(loadbalancer))
-
-	if loadbalancer.Listeners != nil {
-		content = append(content, buildListenersTable(*loadbalancer.Listeners))
-	}
-
-	if loadbalancer.TargetPools != nil {
-		content = append(content, buildTargetPoolsTable(*loadbalancer.TargetPools))
-	}
-
-	err := tables.DisplayTables(p, content)
-	if err != nil {
-		return fmt.Errorf("display output: %w", err)
-	}
-
-	return nil
+	})
 }
 
 func buildLoadBalancerTable(loadbalancer *alb.LoadBalancer) tables.Table {

--- a/internal/cmd/beta/alb/list/list.go
+++ b/internal/cmd/beta/alb/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -128,24 +126,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 	return request
 }
 func outputResult(p *print.Printer, outputFormat string, items []alb.LoadBalancer) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "EXTERNAL ADDRESS", "REGION", "STATUS", "VERSION", "ERRORS")
 		for i := range items {
@@ -169,5 +150,5 @@ func outputResult(p *print.Printer, outputFormat string, items []alb.LoadBalance
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/alb/observability-credentials/add/add.go
+++ b/internal/cmd/beta/alb/observability-credentials/add/add.go
@@ -2,7 +2,6 @@ package add
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -13,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
@@ -115,25 +113,10 @@ func outputResult(p *print.Printer, outputFormat string, item *alb.CreateCredent
 		return fmt.Errorf("no credential found")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(item, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal credential: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(item, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal credential: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+	return p.OutputResult(outputFormat, item, func() error {
 		if item.Credential != nil {
-			p.Outputf("Created credential %s\n",
-				utils.PtrString(item.Credential.CredentialsRef),
-			)
+			p.Outputf("Created credential %s\n", utils.PtrString(item.Credential.CredentialsRef))
 		}
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/beta/alb/observability-credentials/describe/describe.go
+++ b/internal/cmd/beta/alb/observability-credentials/describe/describe.go
@@ -2,7 +2,6 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
@@ -89,26 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, response alb.CredentialsResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(response, "", "  ")
-
-		if err != nil {
-			return fmt.Errorf("marshal credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(response, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-
-		if err != nil {
-			return fmt.Errorf("marshal credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, response, func() error {
 		table := tables.NewTable()
 		table.AddRow("CREDENTIAL REF", utils.PtrString(response.CredentialsRef))
 		table.AddSeparator()
@@ -120,7 +99,6 @@ func outputResult(p *print.Printer, outputFormat string, response alb.Credential
 		table.AddSeparator()
 
 		p.Outputln(table.Render())
-	}
-
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/beta/alb/observability-credentials/list/list.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -17,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
@@ -122,22 +120,8 @@ func outputResult(p *print.Printer, outputFormat string, items []alb.Credentials
 		p.Outputln("no credentials found")
 		return nil
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-	default:
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("CREDENTIAL REF", "DISPLAYNAME", "USERNAME", "REGION")
 
@@ -151,6 +135,6 @@ func outputResult(p *print.Printer, outputFormat string, items []alb.Credentials
 		}
 
 		p.Outputln(table.Render())
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/beta/alb/observability-credentials/update/update.go
+++ b/internal/cmd/beta/alb/observability-credentials/update/update.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
@@ -132,23 +130,11 @@ func outputResult(p *print.Printer, model inputModel, response *alb.UpdateCreden
 		outputFormat = model.GlobalFlagModel.OutputFormat
 	}
 	if response == nil {
-		return fmt.Errorf("no response passewd")
+		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(response.Credential, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal credential: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(response.Credential, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal credential: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+
+	return p.OutputResult(outputFormat, response.Credential, func() error {
 		p.Outputf("Updated credential %q\n", utils.PtrString(model.CredentialsRef))
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/beta/alb/plans/plans.go
+++ b/internal/cmd/beta/alb/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -101,24 +99,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, items []alb.PlanDetails) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("PLAN ID", "NAME", "FLAVOR", "MAX CONNS", "DESCRIPTION")
 		for _, item := range items {
@@ -135,5 +116,5 @@ func outputResult(p *print.Printer, outputFormat string, items []alb.PlanDetails
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/alb/pool/update/update.go
+++ b/internal/cmd/beta/alb/pool/update/update.go
@@ -156,29 +156,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("update target pool response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal target pool: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal target pool: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Updated"
 		if model.Async {
 			operationState = "Triggered update of"
 		}
 		p.Outputf("%s application target pool for %q. Name: %s\n", operationState, projectLabel, utils.PtrString(resp.Name))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/alb/quotas/quotas.go
+++ b/internal/cmd/beta/alb/quotas/quotas.go
@@ -2,10 +2,8 @@ package quotas
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -93,24 +91,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, response alb.GetQuotaResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(response, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal quotas: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(response, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal quotas: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, response, func() error {
 		table := tables.NewTable()
 		table.AddRow("REGION", utils.PtrString(response.Region))
 		table.AddSeparator()
@@ -121,5 +102,5 @@ func outputResult(p *print.Printer, outputFormat string, response alb.GetQuotaRe
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/alb/update/update.go
+++ b/internal/cmd/beta/alb/update/update.go
@@ -192,29 +192,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("update loadbalancer response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal loadbalancer: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Updated"
 		if model.Async {
 			operationState = "Triggered update of"
 		}
 		p.Outputf("%s application loadbalancer for %q. Name: %s\n", operationState, projectLabel, utils.PtrString(resp.Name))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/database/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/database/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -129,25 +127,9 @@ func outputResult(p *print.Printer, outputFormat, databaseName string, resp *sql
 	if resp == nil {
 		return fmt.Errorf("sqlserverflex response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created database %q\n", databaseName)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/database/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/database/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -106,24 +104,8 @@ func outputResult(p *print.Printer, outputFormat string, resp *sqlserverflex.Get
 	if resp == nil || resp.Database == nil {
 		return fmt.Errorf("database response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		database := resp.Database
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(database.Id))
@@ -149,5 +131,5 @@ func outputResult(p *print.Printer, outputFormat string, resp *sqlserverflex.Get
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/database/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -130,24 +128,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverfl
 }
 
 func outputResult(p *print.Printer, outputFormat string, databases []sqlserverflex.Database) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(databases, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(databases, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex database list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, databases, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME")
 		for i := range databases {
@@ -160,5 +141,5 @@ func outputResult(p *print.Printer, outputFormat string, databases []sqlserverfl
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -264,29 +262,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("sqlserverflex response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServerFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServerFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -95,24 +93,8 @@ func outputResult(p *print.Printer, outputFormat string, instance *sqlserverflex
 	if instance == nil {
 		return fmt.Errorf("instance response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		var acls string
 		if instance.Acl != nil && instance.Acl.HasItems() {
 			aclsArray := *instance.Acl.Items
@@ -150,5 +132,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *sqlserverflex
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/instance/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverfl
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []sqlserverflex.InstanceListInstance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS")
 		for i := range instances {
@@ -157,5 +138,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []sqlserverfl
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/instance/update/update.go
+++ b/internal/cmd/beta/sqlserverflex/instance/update/update.go
@@ -2,11 +2,9 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -248,29 +246,12 @@ func outputResult(p *print.Printer, model *inputModel, instanceLabel string, res
 	if resp == nil {
 		return fmt.Errorf("instance response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal update SQLServerFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal update SQLServerFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Updated"
 		if model.Async {
 			operationState = "Triggered update of"
 		}
 		p.Info("%s instance %q\n", operationState, instanceLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/options/options.go
+++ b/internal/cmd/beta/sqlserverflex/options/options.go
@@ -2,10 +2,8 @@ package options
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -276,55 +274,35 @@ func outputResult(p *print.Printer, model *inputModel, flavors *sqlserverflex.Li
 		}
 	}
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(options, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQL Server Flex options: %w", err)
+	return p.OutputResult(model.OutputFormat, options, func() error {
+		content := []tables.Table{}
+		if model.Flavors && len(*options.Flavors) != 0 {
+			content = append(content, buildFlavorsTable(*options.Flavors))
 		}
-		p.Outputln(string(details))
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(options, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQL Server Flex options: %w", err)
+		if model.Versions && len(*options.Versions) != 0 {
+			content = append(content, buildVersionsTable(*options.Versions))
 		}
-		p.Outputln(string(details))
+		if model.Storages && options.Storages.Storages != nil && len(*options.Storages.Storages.StorageClasses) != 0 {
+			content = append(content, buildStoragesTable(*options.Storages.Storages))
+		}
+		if model.UserRoles && len(options.UserRoles.UserRoles) != 0 {
+			content = append(content, buildUserRoles(options.UserRoles))
+		}
+		if model.DBCompatibilities && len(options.DBCompatibilities.DBCompatibilities) != 0 {
+			content = append(content, buildDBCompatibilitiesTable(options.DBCompatibilities.DBCompatibilities))
+		}
+		// Rendered at last because table is very long
+		if model.DBCollations && len(options.DBCollations.DBCollations) != 0 {
+			content = append(content, buildDBCollationsTable(options.DBCollations.DBCollations))
+		}
+
+		err := tables.DisplayTables(p, content)
+		if err != nil {
+			return fmt.Errorf("display output: %w", err)
+		}
 
 		return nil
-	default:
-		return outputResultAsTable(p, model, options)
-	}
-}
-
-func outputResultAsTable(p *print.Printer, model *inputModel, options *options) error {
-	content := []tables.Table{}
-	if model.Flavors && len(*options.Flavors) != 0 {
-		content = append(content, buildFlavorsTable(*options.Flavors))
-	}
-	if model.Versions && len(*options.Versions) != 0 {
-		content = append(content, buildVersionsTable(*options.Versions))
-	}
-	if model.Storages && options.Storages.Storages != nil && len(*options.Storages.Storages.StorageClasses) != 0 {
-		content = append(content, buildStoragesTable(*options.Storages.Storages))
-	}
-	if model.UserRoles && len(options.UserRoles.UserRoles) != 0 {
-		content = append(content, buildUserRoles(options.UserRoles))
-	}
-	if model.DBCompatibilities && len(options.DBCompatibilities.DBCompatibilities) != 0 {
-		content = append(content, buildDBCompatibilitiesTable(options.DBCompatibilities.DBCompatibilities))
-	}
-	// Rendered at last because table is very long
-	if model.DBCollations && len(options.DBCollations.DBCollations) != 0 {
-		content = append(content, buildDBCollationsTable(options.DBCollations.DBCollations))
-	}
-
-	err := tables.DisplayTables(p, content)
-	if err != nil {
-		return fmt.Errorf("display output: %w", err)
-	}
-
-	return nil
+	})
 }
 
 func buildFlavorsTable(flavors []sqlserverflex.InstanceFlavorEntry) tables.Table {

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -140,24 +138,7 @@ func outputResult(p *print.Printer, model *inputModel, instanceLabel string, use
 	if user == nil {
 		return fmt.Errorf("user response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, user, func() error {
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
@@ -175,5 +156,5 @@ func outputResult(p *print.Printer, model *inputModel, instanceLabel string, use
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/user/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/user/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -115,24 +113,8 @@ func outputResult(p *print.Printer, outputFormat string, user *sqlserverflex.Use
 	if user == nil {
 		return fmt.Errorf("user response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(user.Id))
 		table.AddSeparator()
@@ -160,5 +142,5 @@ func outputResult(p *print.Printer, outputFormat string, user *sqlserverflex.Use
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/user/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -131,24 +129,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverfl
 }
 
 func outputResult(p *print.Printer, outputFormat string, users []sqlserverflex.InstanceListUser) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(users, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(users, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, users, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "USERNAME")
 		for i := range users {
@@ -164,5 +145,5 @@ func outputResult(p *print.Printer, outputFormat string, users []sqlserverflex.I
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
+++ b/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
@@ -2,10 +2,8 @@ package resetpassword
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -130,24 +128,8 @@ func outputResult(p *print.Printer, outputFormat, userLabel, instanceLabel strin
 	if user == nil {
 		return fmt.Errorf("single user response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex reset password: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SQLServer Flex reset password: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		p.Outputf("Reset password for user %q of instance %q\n\n", userLabel, instanceLabel)
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("New password: %s\n", utils.PtrString(user.Password))
@@ -155,5 +137,5 @@ func outputResult(p *print.Printer, outputFormat, userLabel, instanceLabel strin
 			p.Outputf("New URI: %s\n", *user.Uri)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/config/profile/list/list.go
+++ b/internal/cmd/config/profile/list/list.go
@@ -1,10 +1,7 @@
 package list
 
 import (
-	"encoding/json"
 	"fmt"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -93,22 +90,7 @@ func buildOutput(profiles []string, activeProfile string) []profileInfo {
 }
 
 func outputResult(p *print.Printer, outputFormat string, profiles []profileInfo) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(profiles, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal config list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(profiles, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal config list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	default:
+	return p.OutputResult(outputFormat, profiles, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "ACTIVE", "EMAIL")
 		for _, profile := range profiles {
@@ -129,5 +111,5 @@ func outputResult(p *print.Printer, outputFormat string, profiles []profileInfo)
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/record-set/create/create.go
+++ b/internal/cmd/dns/record-set/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -182,29 +180,12 @@ func outputResult(p *print.Printer, model *inputModel, zoneLabel string, resp *d
 	if resp == nil {
 		return fmt.Errorf("record set response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS record-set: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS record-set: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s record set for zone %s. Record set ID: %s\n", operationState, zoneLabel, utils.PtrString(resp.Rrset.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/record-set/describe/describe.go
+++ b/internal/cmd/dns/record-set/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -110,24 +108,8 @@ func outputResult(p *print.Printer, outputFormat string, recordSet *dns.RecordSe
 	if recordSet == nil {
 		return fmt.Errorf("record set response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(recordSet, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS record set: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(recordSet, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS record set: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, recordSet, func() error {
 		recordsData := make([]string, 0, len(*recordSet.Records))
 		for _, r := range *recordSet.Records {
 			recordsData = append(recordsData, *r.Content)
@@ -152,5 +134,5 @@ func outputResult(p *print.Printer, outputFormat string, recordSet *dns.RecordSe
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/record-set/list/list.go
+++ b/internal/cmd/dns/record-set/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -242,24 +240,7 @@ func fetchRecordSets(ctx context.Context, model *inputModel, apiClient dnsClient
 }
 
 func outputResult(p *print.Printer, outputFormat string, recordSets []dns.RecordSet) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(recordSets, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS record set list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(recordSets, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS record set list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, recordSets, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS", "TTL", "TYPE", "RECORD DATA")
 		for i := range recordSets {
@@ -284,5 +265,5 @@ func outputResult(p *print.Printer, outputFormat string, recordSets []dns.Record
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/zone/clone/clone.go
+++ b/internal/cmd/dns/zone/clone/clone.go
@@ -2,10 +2,8 @@ package clone
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -156,29 +154,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("dns zone response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Cloned"
 		if model.Async {
 			operationState = "Triggered cloning of"
 		}
 		p.Outputf("%s zone for project %q. Zone ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Zone.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/zone/create/create.go
+++ b/internal/cmd/dns/zone/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -203,29 +201,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 	if resp == nil {
 		return fmt.Errorf("dns zone response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s zone for project %q. Zone ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Zone.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/zone/describe/describe.go
+++ b/internal/cmd/dns/zone/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -95,24 +93,8 @@ func outputResult(p *print.Printer, outputFormat string, zone *dns.Zone) error {
 	if zone == nil {
 		return fmt.Errorf("zone response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(zone, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(zone, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, zone, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(zone.Id))
 		table.AddSeparator()
@@ -149,5 +131,5 @@ func outputResult(p *print.Printer, outputFormat string, zone *dns.Zone) error {
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/dns/zone/list/list.go
+++ b/internal/cmd/dns/zone/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -231,25 +229,7 @@ func fetchZones(ctx context.Context, model *inputModel, apiClient dnsClient) ([]
 }
 
 func outputResult(p *print.Printer, outputFormat string, zones []dns.Zone) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		// Show details
-		details, err := json.MarshalIndent(zones, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(zones, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal DNS zone list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, zones, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATE", "TYPE", "DNS NAME", "RECORD COUNT")
 		for i := range zones {
@@ -268,5 +248,5 @@ func outputResult(p *print.Printer, outputFormat string, zones []dns.Zone) error
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/git/flavor/list/list.go
+++ b/internal/cmd/git/flavor/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -113,24 +111,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, flavors []git.Flavor) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(flavors, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability flavor list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(flavors, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability flavor list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, flavors, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "DESCRIPTION", "DISPLAY_NAME", "AVAILABLE", "SKU")
 		for i := range flavors {
@@ -149,5 +130,5 @@ func outputResult(p *print.Printer, outputFormat string, flavors []git.Flavor) e
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/git/instance/create/create.go
+++ b/internal/cmd/git/instance/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -154,25 +152,9 @@ func outputResult(p *print.Printer, model *inputModel, resp *git.Instance) error
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal iminstanceage: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created instance %q with id %s\n", model.Name, utils.PtrString(model.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/git/instance/describe/describe.go
+++ b/internal/cmd/git/instance/describe/describe.go
@@ -2,12 +2,10 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -91,24 +89,8 @@ func outputResult(p *print.Printer, outputFormat string, resp *git.Instance) err
 	if resp == nil {
 		return fmt.Errorf("instance not found")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		table := tables.NewTable()
 		if id := resp.Id; id != nil {
 			table.AddRow("ID", *id)
@@ -140,5 +122,5 @@ func outputResult(p *print.Printer, outputFormat string, resp *git.Instance) err
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/git/instance/list/list.go
+++ b/internal/cmd/git/instance/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -114,24 +112,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []git.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "URL", "VERSION", "STATE", "CREATED")
 		for i := range instances {
@@ -151,5 +132,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []git.Instanc
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/image/create/create.go
+++ b/internal/cmd/image/create/create.go
@@ -3,7 +3,6 @@ package create
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"io"
@@ -11,7 +10,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -403,25 +401,9 @@ func outputResult(p *print.Printer, model *inputModel, resp *iaas.ImageCreateRes
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal image: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal image: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created image %q with id %s\n", model.Name, utils.PtrString(model.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/image/describe/describe.go
+++ b/internal/cmd/image/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -92,24 +90,8 @@ func outputResult(p *print.Printer, outputFormat string, resp *iaas.Image) error
 	if resp == nil {
 		return fmt.Errorf("image not found")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal image: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal image: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		table := tables.NewTable()
 		if id := resp.Id; id != nil {
 			table.AddRow("ID", *id)
@@ -169,5 +151,5 @@ func outputResult(p *print.Printer, outputFormat string, resp *iaas.Image) error
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/image/list/list.go
+++ b/internal/cmd/image/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -138,24 +136,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return request
 }
 func outputResult(p *print.Printer, outputFormat string, items []iaas.Image) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal image list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal image list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "OS", "ARCHITECTURE", "DISTRIBUTION", "VERSION", "LABELS")
 		for i := range items {
@@ -194,5 +175,5 @@ func outputResult(p *print.Printer, outputFormat string, items []iaas.Image) err
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/key-pair/create/create.go
+++ b/internal/cmd/key-pair/create/create.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -13,7 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -130,24 +128,11 @@ func outputResult(p *print.Printer, outputFormat string, item *iaas.Keypair) err
 		return fmt.Errorf("no key pair found")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(item, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal key pair: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(item, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal key pair: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+	return p.OutputResult(outputFormat, item, func() error {
 		p.Outputf("Created key pair %q.\nkey pair Fingerprint: %q\n",
 			utils.PtrString(item.Name),
 			utils.PtrString(item.Fingerprint),
 		)
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -130,22 +128,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, keyPairs []iaas.Keypair) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(keyPairs, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal key pairs: %w", err)
-		}
-		p.Outputln(string(details))
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(keyPairs, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal key pairs: %w", err)
-		}
-		p.Outputln(string(details))
-
-	default:
+	return p.OutputResult(outputFormat, keyPairs, func() error {
 		table := tables.NewTable()
 		table.SetHeader("KEY PAIR NAME", "LABELS", "FINGERPRINT", "CREATED AT", "UPDATED AT")
 
@@ -169,6 +152,6 @@ func outputResult(p *print.Printer, outputFormat string, keyPairs []iaas.Keypair
 		}
 
 		p.Outputln(table.Render())
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/key-pair/update/update.go
+++ b/internal/cmd/key-pair/update/update.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -14,7 +13,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -112,21 +110,9 @@ func outputResult(p *print.Printer, model inputModel, keyPair iaas.Keypair) erro
 	if model.GlobalFlagModel != nil {
 		outputFormat = model.GlobalFlagModel.OutputFormat
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(keyPair, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal key pair: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(keyPair, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal key pair: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+
+	return p.OutputResult(outputFormat, keyPair, func() error {
 		p.Outputf("Updated labels of key pair %q\n", utils.PtrString(model.KeyPairName))
-	}
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/load-balancer/list/list.go
+++ b/internal/cmd/load-balancer/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -125,24 +123,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *loadbalance
 }
 
 func outputResult(p *print.Printer, outputFormat string, loadBalancers []loadbalancer.LoadBalancer) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(loadBalancers, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal load balancer list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(loadBalancers, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal load balancer list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, loadBalancers, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "STATE", "IP ADDRESS", "LISTENERS", "TARGET POOLS")
 		for i := range loadBalancers {
@@ -170,5 +151,5 @@ func outputResult(p *print.Printer, outputFormat string, loadBalancers []loadbal
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/load-balancer/observability-credentials/add/add.go
+++ b/internal/cmd/load-balancer/observability-credentials/add/add.go
@@ -2,10 +2,8 @@ package add
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -142,25 +140,8 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resp *loa
 		return fmt.Errorf("nil observability credentials response")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Added Load Balancer observability credentials on project %q. Credentials reference: %q\n", projectLabel, utils.PtrString(resp.Credential.CredentialsRef))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/load-balancer/observability-credentials/describe/describe.go
+++ b/internal/cmd/load-balancer/observability-credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -89,24 +87,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *loadbalance
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials *loadbalancer.GetCredentialsResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		if credentials == nil || credentials.Credential == nil {
 			return fmt.Errorf("credentials response is empty")
 		}
@@ -124,5 +105,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *loadbalanc
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -160,24 +158,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *loadbalance
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []loadbalancer.CredentialsResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Load Balancer observability credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("REFERENCE", "DISPLAY NAME", "USERNAME")
 		for i := range credentials {
@@ -190,7 +171,7 @@ func outputResult(p *print.Printer, outputFormat string, credentials []loadbalan
 		}
 
 		return nil
-	}
+	})
 }
 
 func getFilterOp(used, unused bool) (int, error) {

--- a/internal/cmd/load-balancer/quota/quota.go
+++ b/internal/cmd/load-balancer/quota/quota.go
@@ -2,11 +2,9 @@ package quota
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -82,9 +80,8 @@ func outputResult(p *print.Printer, outputFormat string, quota *loadbalancer.Get
 	if quota == nil {
 		return fmt.Errorf("quota response is empty")
 	}
-	switch outputFormat {
-	case print.PrettyOutputFormat:
 
+	return p.OutputResult(outputFormat, quota, func() error {
 		maxLoadBalancers := "Unlimited"
 		if quota.MaxLoadBalancers != nil && *quota.MaxLoadBalancers != -1 {
 			maxLoadBalancers = strconv.FormatInt(*quota.MaxLoadBalancers, 10)
@@ -93,22 +90,5 @@ func outputResult(p *print.Printer, outputFormat string, quota *loadbalancer.Get
 		p.Outputf("Maximum number of load balancers allowed: %s\n", maxLoadBalancers)
 
 		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(quota, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal quota: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
-		details, err := json.MarshalIndent(quota, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal quota: %w", err)
-		}
-
-		p.Outputln(string(details))
-
-		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/credentials/create/create.go
+++ b/internal/cmd/logme/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,8 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 	if !showPassword && resp.HasRaw() && resp.Raw.Credentials != nil {
 		resp.Raw.Credentials.Password = utils.Ptr("hidden")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
 		// The username field cannot be set by the user so we only display it if it's not returned empty
 		if resp.HasRaw() && resp.Raw.Credentials != nil {
@@ -157,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 		}
 		p.Outputf("URI: %s\n", utils.PtrString(resp.Uri))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/credentials/describe/describe.go
+++ b/internal/cmd/logme/credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -109,24 +107,7 @@ func outputResult(p *print.Printer, outputFormat string, credentials *logme.Cred
 		return fmt.Errorf("credentials is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(credentials.Id))
 		table.AddSeparator()
@@ -148,5 +129,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *logme.Cred
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/credentials/list/list.go
+++ b/internal/cmd/logme/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -129,24 +127,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []logme.CredentialsListItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID")
 		for i := range credentials {
@@ -159,5 +140,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []logme.Cre
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/instance/create/create.go
+++ b/internal/cmd/logme/instance/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -249,29 +247,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		return fmt.Errorf("response is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.InstanceId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/instance/describe/describe.go
+++ b/internal/cmd/logme/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *logme.Instanc
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
@@ -142,5 +123,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *logme.Instanc
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []logme.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {
@@ -165,5 +146,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []logme.Insta
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/logme/plans/plans.go
+++ b/internal/cmd/logme/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []logme.Offering) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal LogMe plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal LogMe plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {
@@ -166,5 +147,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []logme.Offering)
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,24 +122,8 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 	if !showPassword && resp.HasRaw() && resp.Raw.Credentials != nil {
 		resp.Raw.Credentials.Password = utils.Ptr("hidden")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
 		// The username field cannot be set by the user, so we only display it if it's not returned empty
 		if resp.HasRaw() && resp.Raw.Credentials != nil {
@@ -158,5 +140,5 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 		}
 		p.Outputf("URI: %s\n", utils.PtrString(resp.Uri))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -109,24 +107,7 @@ func outputResult(p *print.Printer, outputFormat string, credentials *mariadb.Cr
 		return fmt.Errorf("credentials is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(credentials.Id))
 		table.AddSeparator()
@@ -146,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *mariadb.Cr
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -128,24 +126,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []mariadb.CredentialsListItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID")
 		for i := range credentials {
@@ -158,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []mariadb.C
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -249,29 +247,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		return fmt.Errorf("response is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.InstanceId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *mariadb.Insta
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
@@ -144,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *mariadb.Insta
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []mariadb.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {
@@ -165,5 +146,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []mariadb.Ins
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []mariadb.Offering) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MariaDB plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {
@@ -166,5 +147,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []mariadb.Offerin
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -119,24 +117,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup mongodbflex.Backup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backup, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))
 		table.AddSeparator()
@@ -155,5 +136,5 @@ func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup m
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/backup/list/list.go
+++ b/internal/cmd/mongodbflex/backup/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -142,24 +140,7 @@ func outputResult(p *print.Printer, outputFormat string, backups []mongodbflex.B
 		return fmt.Errorf("restore jobs is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backups, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backups list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backups, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backups list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backups, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "CREATED AT", "EXPIRES AT", "BACKUP SIZE", "RESTORE STATUS")
 		for i := range backups {
@@ -179,5 +160,5 @@ func outputResult(p *print.Printer, outputFormat string, backups []mongodbflex.B
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -2,10 +2,8 @@ package restorejobs
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -132,24 +130,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat string, restoreJobs []mongodbflex.RestoreInstanceStatus) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(restoreJobs, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex restore jobs list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(restoreJobs, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex restore jobs list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, restoreJobs, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "BACKUP ID", "BACKUP INSTANCE ID", "DATE", "STATUS")
 		for i := range restoreJobs {
@@ -169,5 +150,5 @@ func outputResult(p *print.Printer, outputFormat string, restoreJobs []mongodbfl
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/backup/schedule/schedule.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule.go
@@ -2,10 +2,8 @@ package schedule
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -119,24 +117,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		output.WeeklySnapshotRetentionWeeks = (*instance.Options)["weeklySnapshotRetentionWeeks"]
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(output, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, output, func() error {
 		table := tables.NewTable()
 		table.AddRow("BACKUP SCHEDULE (UTC)", output.BackupSchedule)
 		table.AddSeparator()
@@ -157,5 +138,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -270,29 +268,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		return fmt.Errorf("create instance response is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDBFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDBFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		var instanceType string
 		if instance.HasReplicas() {
 			var err error
@@ -168,5 +149,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,24 +122,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []mongodbflex.InstanceListInstance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS")
 		for i := range instances {
@@ -158,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []mongodbflex
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -2,11 +2,9 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -305,29 +303,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, instanceLab
 		return fmt.Errorf("resp is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal update MongoDBFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal update MongoDBFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Updated"
 		if async {
 			operationState = "Triggered update of"
 		}
 		p.Info("%s instance %q\n", operationState, instanceLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -2,12 +2,10 @@ package options
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -182,25 +180,9 @@ func outputResult(p *print.Printer, model *inputModel, flavors *mongodbflex.List
 		}
 	}
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(options, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex options: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(options, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex options: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, options, func() error {
 		return outputResultAsTable(p, model, options)
-	}
+	})
 }
 
 func outputResultAsTable(p *print.Printer, model *inputModel, options *options) error {

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -147,24 +145,7 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *mo
 		return fmt.Errorf("user is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
@@ -175,5 +156,5 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *mo
 		p.Outputf("URI: %s\n", utils.PtrString(user.Uri))
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -111,24 +109,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat string, user mongodbflex.InstanceResponseUser) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(user.Id))
 		table.AddSeparator()
@@ -148,5 +129,5 @@ func outputResult(p *print.Printer, outputFormat string, user mongodbflex.Instan
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -132,24 +130,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat string, users []mongodbflex.ListUser) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(users, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(users, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, users, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "USERNAME")
 		for i := range users {
@@ -165,5 +146,5 @@ func outputResult(p *print.Printer, outputFormat string, users []mongodbflex.Lis
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -2,10 +2,8 @@ package resetpassword
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -131,28 +129,11 @@ func outputResult(p *print.Printer, outputFormat, userLabel, instanceLabel strin
 		return fmt.Errorf("user is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex reset password: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal MongoDB Flex reset password: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		p.Outputf("Reset password for user %q of instance %q\n\n", userLabel, instanceLabel)
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("New password: %s\n", utils.PtrString(user.Password))
 		p.Outputf("New URI: %s\n", utils.PtrString(user.Uri))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/create/create.go
+++ b/internal/cmd/network-area/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -186,25 +184,8 @@ func outputResult(p *print.Printer, outputFormat, orgLabel string, networkArea *
 	if networkArea == nil {
 		return fmt.Errorf("network area is nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkArea, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkArea, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkArea, func() error {
 		p.Outputf("Created STACKIT Network Area for organization %q.\nNetwork area ID: %s\n", orgLabel, utils.PtrString(networkArea.AreaId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/describe/describe.go
+++ b/internal/cmd/network-area/describe/describe.go
@@ -2,12 +2,10 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -126,24 +124,8 @@ func outputResult(p *print.Printer, outputFormat string, networkArea *iaas.Netwo
 	if networkArea == nil {
 		return fmt.Errorf("network area is nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkArea, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkArea, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkArea, func() error {
 		var routes []string
 		var networkRanges []string
 
@@ -219,5 +201,5 @@ func outputResult(p *print.Printer, outputFormat string, networkArea *iaas.Netwo
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -150,24 +148,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, networkAreas []iaas.NetworkArea) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkAreas, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkAreas, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkAreas, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "Name", "Status", "Network Ranges", "# Attached Projects")
 
@@ -191,5 +172,5 @@ func outputResult(p *print.Printer, outputFormat string, networkAreas []iaas.Net
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/network-range/create/create.go
+++ b/internal/cmd/network-area/network-range/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -132,25 +130,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, networkRange iaas.NetworkRange) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkRange, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network range: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkRange, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network range: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkRange, func() error {
 		p.Outputf("Created network range for SNA %q.\nNetwork range ID: %s\n", networkAreaLabel, utils.PtrString(networkRange.NetworkRangeId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/network-range/describe/describe.go
+++ b/internal/cmd/network-area/network-range/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -105,24 +103,8 @@ func outputResult(p *print.Printer, outputFormat string, networkRange *iaas.Netw
 	if networkRange == nil {
 		return fmt.Errorf("network range is nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkRange, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network range: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkRange, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network range: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkRange, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(networkRange.NetworkRangeId))
 		table.AddSeparator()
@@ -133,5 +115,5 @@ func outputResult(p *print.Printer, outputFormat string, networkRange *iaas.Netw
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -134,24 +132,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, networkRanges []iaas.NetworkRange) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkRanges, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network ranges: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkRanges, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network ranges: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkRanges, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "Network Range")
 
@@ -161,5 +142,5 @@ func outputResult(p *print.Printer, outputFormat string, networkRanges []iaas.Ne
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/route/create/create.go
+++ b/internal/cmd/network-area/route/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -150,25 +148,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, route iaas.Route) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(route, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(route, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, route, func() error {
 		p.Outputf("Created static route for SNA %q.\nStatic route ID: %s\n", networkAreaLabel, utils.PtrString(route.RouteId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/route/describe/describe.go
+++ b/internal/cmd/network-area/route/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -107,24 +105,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, route iaas.Route) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(route, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(route, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, route, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(route.RouteId))
 		table.AddSeparator()
@@ -145,5 +126,5 @@ func outputResult(p *print.Printer, outputFormat string, route iaas.Route) error
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -133,24 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, routes []iaas.Route) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(routes, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal static routes: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(routes, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal static routes: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, routes, func() error {
 		table := tables.NewTable()
 		table.SetHeader("Static Route ID", "Next Hop", "Prefix")
 
@@ -164,5 +145,5 @@ func outputResult(p *print.Printer, outputFormat string, routes []iaas.Route) er
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/route/update/update.go
+++ b/internal/cmd/network-area/route/update/update.go
@@ -2,10 +2,8 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -129,25 +127,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, route iaas.Route) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(route, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(route, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal static route: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, route, func() error {
 		p.Outputf("Updated static route for SNA %q.\nStatic route ID: %s\n", networkAreaLabel, utils.PtrString(route.RouteId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-area/update/update.go
+++ b/internal/cmd/network-area/update/update.go
@@ -2,12 +2,10 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -162,25 +160,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, networkArea iaas.NetworkArea) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networkArea, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networkArea, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network area: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networkArea, func() error {
 		p.Outputf("Updated STACKIT Network Area for project %q.\n", projectLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-interface/create/create.go
+++ b/internal/cmd/network-interface/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -215,25 +213,8 @@ func outputResult(p *print.Printer, outputFormat, projectId string, nic *iaas.NI
 	if nic == nil {
 		return fmt.Errorf("nic is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(nic, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(nic, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, nic, func() error {
 		p.Outputf("Created network interface for project %q.\nNIC ID: %s\n", projectId, utils.PtrString(nic.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-interface/describe/describe.go
+++ b/internal/cmd/network-interface/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -113,24 +111,7 @@ func outputResult(p *print.Printer, outputFormat string, nic *iaas.NIC) error {
 	if nic == nil {
 		return fmt.Errorf("nic is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(nic, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(nic, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, nic, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(nic.Id))
 		table.AddSeparator()
@@ -181,5 +162,5 @@ func outputResult(p *print.Printer, outputFormat string, nic *iaas.NIC) error {
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-interface/list/list.go
+++ b/internal/cmd/network-interface/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -147,24 +145,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, nics []iaas.NIC) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(nics, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal nics: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(nics, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal nics: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, nics, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "NIC SECURITY", "DEVICE ID", "IPv4 ADDRESS", "STATUS", "TYPE")
 
@@ -183,5 +164,5 @@ func outputResult(p *print.Printer, outputFormat string, nics []iaas.NIC) error 
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network-interface/update/update.go
+++ b/internal/cmd/network-interface/update/update.go
@@ -2,11 +2,9 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -205,25 +203,8 @@ func outputResult(p *print.Printer, outputFormat, projectId string, nic *iaas.NI
 	if nic == nil {
 		return fmt.Errorf("nic is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(nic, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(nic, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network interface: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, nic, func() error {
 		p.Outputf("Updated network interface for project %q.\n", projectId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network/create/create.go
+++ b/internal/cmd/network/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -243,29 +241,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 	if network == nil {
 		return fmt.Errorf("network cannot be nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(network, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(network, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, network, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s network for project %q.\nNetwork ID: %s\n", operationState, projectLabel, utils.PtrString(network.NetworkId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network/describe/describe.go
+++ b/internal/cmd/network/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, network *iaas.Network) 
 	if network == nil {
 		return fmt.Errorf("network cannot be nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(network, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(network, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, network, func() error {
 		var ipv4nameservers []string
 		if network.Nameservers != nil {
 			ipv4nameservers = append(ipv4nameservers, *network.Nameservers...)
@@ -197,5 +178,5 @@ func outputResult(p *print.Printer, outputFormat string, network *iaas.Network) 
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/network/list/list.go
+++ b/internal/cmd/network/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -140,24 +138,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, networks []iaas.Network) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(networks, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(networks, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal network: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, networks, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS", "PUBLIC IP", "PREFIXES", "ROUTED")
 
@@ -183,5 +164,5 @@ func outputResult(p *print.Printer, outputFormat string, networks []iaas.Network
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/bucket/create/create.go
+++ b/internal/cmd/object-storage/bucket/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,29 +122,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, bucketName 
 		return fmt.Errorf("create bucket response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s bucket %q\n", operationState, bucketName)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/bucket/describe/describe.go
+++ b/internal/cmd/object-storage/bucket/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -95,24 +93,7 @@ func outputResult(p *print.Printer, outputFormat string, bucket *objectstorage.B
 		return fmt.Errorf("bucket is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(bucket, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(bucket, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, bucket, func() error {
 		table := tables.NewTable()
 		table.AddRow("Name", utils.PtrString(bucket.Name))
 		table.AddSeparator()
@@ -128,5 +109,5 @@ func outputResult(p *print.Printer, outputFormat string, bucket *objectstorage.B
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/bucket/list/list.go
+++ b/internal/cmd/object-storage/bucket/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -127,24 +125,7 @@ func outputResult(p *print.Printer, outputFormat string, buckets []objectstorage
 		return fmt.Errorf("buckets is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(buckets, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(buckets, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage bucket list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, buckets, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "REGION", "URL (PATH STYLE)", "URL (VIRTUAL HOSTED STYLE)")
 		for i := range buckets {
@@ -162,5 +143,5 @@ func outputResult(p *print.Printer, outputFormat string, buckets []objectstorage
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/credentials-group/create/create.go
+++ b/internal/cmd/object-storage/credentials-group/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -110,29 +108,12 @@ func outputResult(p *print.Printer, outputFormat string, resp *objectstorage.Cre
 		return fmt.Errorf("create createndials group response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created credentials group %q. Credentials group ID: %s\n\n",
 			utils.PtrString(resp.CredentialsGroup.DisplayName),
 			utils.PtrString(resp.CredentialsGroup.CredentialsGroupId),
 		)
 		p.Outputf("URN: %s\n", utils.PtrString(resp.CredentialsGroup.Urn))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -115,24 +113,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentialsGroups []objectstorage.CredentialsGroup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentialsGroups, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials group list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentialsGroups, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials group list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentialsGroups, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "URN")
 		for i := range credentialsGroups {
@@ -148,5 +129,5 @@ func outputResult(p *print.Printer, outputFormat string, credentialsGroups []obj
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/credentials/create/create.go
+++ b/internal/cmd/object-storage/credentials/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -135,24 +133,7 @@ func outputResult(p *print.Printer, outputFormat, credentialsGroupLabel string, 
 		return fmt.Errorf("create access key response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		expireDate := "Never"
 		if resp.Expires != nil && resp.Expires.IsSet() && *resp.Expires.Get() != "" {
 			expireDate = *resp.Expires.Get()
@@ -164,5 +145,5 @@ func outputResult(p *print.Printer, outputFormat, credentialsGroupLabel string, 
 		p.Outputf("Expire Date: %s\n", expireDate)
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/object-storage/credentials/list/list.go
+++ b/internal/cmd/object-storage/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -130,24 +128,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []objectstorage.AccessKey) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Object Storage credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("CREDENTIALS ID", "ACCESS KEY ID", "EXPIRES AT")
 		for i := range credentials {
@@ -161,5 +142,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []objectsto
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/credentials/create/create.go
+++ b/internal/cmd/observability/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -116,24 +114,7 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, resp *ob
 		return fmt.Errorf("response is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q.\n\n", instanceLabel)
 
 		if resp.Credentials != nil {
@@ -146,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, resp *ob
 			p.Outputf("Password: %s\n", utils.PtrString(resp.Credentials.Password))
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/credentials/list/list.go
+++ b/internal/cmd/observability/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -126,24 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []observability.ServiceKeysList) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("USERNAME")
 		for i := range credentials {
@@ -156,5 +137,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []observabi
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/grafana/describe/describe.go
+++ b/internal/cmd/observability/grafana/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,24 +122,7 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, graf
 		return fmt.Errorf("grafanaConfigs is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(grafanaConfigs, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Grafana configs: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(grafanaConfigs, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Grafana configs: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, grafanaConfigs, func() error {
 		initialAdminPassword := utils.PtrString(instance.Instance.GrafanaAdminPassword)
 		if !showPassword {
 			initialAdminPassword = "<hidden>"
@@ -163,5 +144,5 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, graf
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/instance/create/create.go
+++ b/internal/cmd/observability/instance/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -198,29 +196,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		return fmt.Errorf("resp is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.InstanceId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/instance/describe/describe.go
+++ b/internal/cmd/observability/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -95,24 +93,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *observability
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.Id))
 		table.AddSeparator()
@@ -144,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *observability
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/instance/list/list.go
+++ b/internal/cmd/observability/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []observability.ProjectInstanceFull) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "PLAN", "STATUS")
 		for i := range instances {
@@ -158,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []observabili
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/plans/plans.go
+++ b/internal/cmd/observability/plans/plans.go
@@ -2,7 +2,6 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -17,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/observability"
 )
@@ -124,24 +122,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []observability.Plan) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Observability plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Observability plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "PLAN NAME", "DESCRIPTION")
 		for i := range plans {
@@ -160,5 +141,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []observability.P
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/scrape-config/describe/describe.go
+++ b/internal/cmd/observability/scrape-config/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -105,24 +103,7 @@ func outputResult(p *print.Printer, outputFormat string, config *observability.J
 		return fmt.Errorf(`config is nil`)
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(config, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal scrape configuration: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(config, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal scrape configuration: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, config, func() error {
 		saml2Enabled := "Enabled"
 		if config.Params != nil {
 			saml2 := (*config.Params)["saml2"]
@@ -187,5 +168,5 @@ func outputResult(p *print.Printer, outputFormat string, config *observability.J
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/observability/scrape-config/list/list.go
+++ b/internal/cmd/observability/scrape-config/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -129,24 +127,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 }
 
 func outputResult(p *print.Printer, outputFormat string, configs []observability.Job) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(configs, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal scrape configurations list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(configs, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal scrape configurations list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, configs, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "TARGETS", "SCRAPE INTERVAL")
 		for i := range configs {
@@ -174,5 +155,5 @@ func outputResult(p *print.Printer, outputFormat string, configs []observability
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/credentials/create/create.go
+++ b/internal/cmd/opensearch/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,8 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 	if !showPassword {
 		resp.Raw.Credentials.Password = utils.Ptr("hidden")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
 		// The username field cannot be set by the user so we only display it if it's not returned empty
 		if resp.HasRaw() && resp.Raw.Credentials != nil {
@@ -157,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 		}
 		p.Outputf("URI: %s\n", *resp.Uri)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/credentials/describe/describe.go
+++ b/internal/cmd/opensearch/credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -109,24 +107,7 @@ func outputResult(p *print.Printer, outputFormat string, credentials *opensearch
 		return fmt.Errorf("credentials is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(credentials.Id))
 		table.AddSeparator()
@@ -146,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *opensearch
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/credentials/list/list.go
+++ b/internal/cmd/opensearch/credentials/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -17,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/opensearch"
 )
@@ -129,24 +127,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []opensearch.CredentialsListItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID")
 		for i := range credentials {
@@ -159,5 +140,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []opensearc
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/instance/create/create.go
+++ b/internal/cmd/opensearch/instance/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -250,29 +248,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient openSearchCl
 }
 
 func outputResult(p *print.Printer, outputFormat string, async bool, projectLabel, instanceId string, resp *opensearch.CreateInstanceResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/instance/describe/describe.go
+++ b/internal/cmd/opensearch/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *opensearch.In
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
@@ -144,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *opensearch.In
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/instance/list/list.go
+++ b/internal/cmd/opensearch/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []opensearch.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {
@@ -158,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []opensearch.
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/opensearch/plans/plans.go
+++ b/internal/cmd/opensearch/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *opensearch.
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []opensearch.Offering) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal OpenSearch plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {
@@ -166,5 +147,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []opensearch.Offe
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/organization/member/list/list.go
+++ b/internal/cmd/organization/member/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -149,25 +147,7 @@ func outputResult(p *print.Printer, outputFormat, sortBy string, members []autho
 	}
 	sort.SliceStable(members, sortFn)
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		// Show details
-		details, err := json.MarshalIndent(members, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal members: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(members, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal members: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, members, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SUBJECT", "ROLE")
 		for i := range members {
@@ -191,5 +171,5 @@ func outputResult(p *print.Printer, outputFormat, sortBy string, members []autho
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/organization/role/list/list.go
+++ b/internal/cmd/organization/role/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -122,25 +120,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 }
 
 func outputRolesResult(p *print.Printer, outputFormat string, roles []authorization.Role) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		// Show details
-		details, err := json.MarshalIndent(roles, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal roles: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(roles, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal roles: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, roles, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ROLE NAME", "ROLE DESCRIPTION", "PERMISSION NAME", "PERMISSION DESCRIPTION")
 		for i := range roles {
@@ -165,5 +145,5 @@ func outputRolesResult(p *print.Printer, outputFormat string, roles []authorizat
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/backup/describe/describe.go
+++ b/internal/cmd/postgresflex/backup/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -117,24 +115,7 @@ func outputResult(p *print.Printer, outputFormat string, backup postgresflex.Bac
 	}
 	backupExpireDate := backupStartTime.AddDate(backupExpireYearOffset, backupExpireMonthOffset, backupExpireDayOffset).Format(time.DateOnly)
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backup, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal backup for PostgreSQL Flex backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal backup for PostgreSQL Flex backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))
 		table.AddSeparator()
@@ -152,5 +133,5 @@ func outputResult(p *print.Printer, outputFormat string, backup postgresflex.Bac
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/backup/list/list.go
+++ b/internal/cmd/postgresflex/backup/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -135,24 +133,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 }
 
 func outputResult(p *print.Printer, outputFormat string, backups []postgresflex.Backup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backups, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex backup list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backups, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex backup list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backups, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "CREATED AT", "EXPIRES AT", "BACKUP SIZE")
 		for i := range backups {
@@ -178,5 +159,5 @@ func outputResult(p *print.Printer, outputFormat string, backups []postgresflex.
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/instance/clone/clone.go
+++ b/internal/cmd/postgresflex/instance/clone/clone.go
@@ -2,10 +2,8 @@ package clone
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -202,29 +200,13 @@ func outputResult(p *print.Printer, outputFormat string, async bool, instanceLab
 	if resp == nil {
 		return fmt.Errorf("response not set")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance clone: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance clone: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Cloned"
 		if async {
 			operationState = "Triggered cloning of"
 		}
 		p.Info("%s instance from instance %q. New Instance ID: %s\n", operationState, instanceLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/instance/create/create.go
+++ b/internal/cmd/postgresflex/instance/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -270,29 +268,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 	if resp == nil {
 		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/instance/describe/describe.go
+++ b/internal/cmd/postgresflex/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *postgresflex.
 	if instance == nil {
 		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		acls := ""
 		if instance.HasAcl() && instance.Acl.HasItems() {
 			acls = utils.JoinStringPtr(instance.Acl.Items, ",")
@@ -163,5 +144,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *postgresflex.
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/instance/list/list.go
+++ b/internal/cmd/postgresflex/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -125,24 +123,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []postgresflex.InstanceListInstance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		caser := cases.Title(language.English)
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS")
@@ -160,5 +141,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []postgresfle
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/instance/update/update.go
+++ b/internal/cmd/postgresflex/instance/update/update.go
@@ -2,11 +2,9 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -305,29 +303,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, instanceLab
 		return fmt.Errorf("no response passed")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Updated"
 		if async {
 			operationState = "Triggered update of"
 		}
 		p.Info("%s instance %q\n", operationState, instanceLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/user/create/create.go
+++ b/internal/cmd/postgresflex/user/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -140,24 +138,8 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, resp *po
 	if resp == nil {
 		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex user: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		if user := resp.Item; user != nil {
 			p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 			p.Outputf("Username: %s\n", utils.PtrString(user.Username))
@@ -169,5 +151,5 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, resp *po
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/user/describe/describe.go
+++ b/internal/cmd/postgresflex/user/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -110,24 +108,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 }
 
 func outputResult(p *print.Printer, outputFormat string, user postgresflex.UserResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(user.Id))
 		table.AddSeparator()
@@ -145,5 +126,5 @@ func outputResult(p *print.Printer, outputFormat string, user postgresflex.UserR
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/user/list/list.go
+++ b/internal/cmd/postgresflex/user/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -131,24 +129,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *postgresfle
 }
 
 func outputResult(p *print.Printer, outputFormat string, users []postgresflex.ListUsersResponseItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(users, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(users, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, users, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "USERNAME")
 		for i := range users {
@@ -164,5 +145,5 @@ func outputResult(p *print.Printer, outputFormat string, users []postgresflex.Li
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/postgresflex/user/reset-password/reset_password.go
+++ b/internal/cmd/postgresflex/user/reset-password/reset_password.go
@@ -2,10 +2,8 @@ package resetpassword
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -129,24 +127,7 @@ func outputResult(p *print.Printer, outputFormat, userLabel, instanceLabel strin
 	if user == nil {
 		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgresFlex user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		p.Outputf("Reset password for user %q of instance %q\n\n", userLabel, instanceLabel)
 		if item := user.Item; item != nil {
 			p.Outputf("Username: %s\n", utils.PtrString(item.Username))
@@ -154,5 +135,5 @@ func outputResult(p *print.Printer, outputFormat, userLabel, instanceLabel strin
 			p.Outputf("New URI: %s\n", utils.PtrString(item.Uri))
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -2,11 +2,9 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
@@ -212,25 +210,8 @@ func outputResult(p *print.Printer, model inputModel, resp *resourcemanager.Proj
 	if model.GlobalFlagModel == nil {
 		return fmt.Errorf("globalflags are empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal project: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal project: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		p.Outputf("Created project under the parent with ID %q. Project ID: %s\n", utils.PtrString(model.ParentId), utils.PtrString(resp.ProjectId))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/project/describe/describe.go
+++ b/internal/cmd/project/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -115,24 +113,8 @@ func outputResult(p *print.Printer, outputFormat string, project *resourcemanage
 	if project == nil {
 		return fmt.Errorf("response not set")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(project, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal project details: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(project, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal project details: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, project, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(project.ProjectId))
 		table.AddSeparator()
@@ -151,5 +133,5 @@ func outputResult(p *print.Printer, outputFormat string, project *resourcemanage
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -213,24 +211,7 @@ func fetchProjects(ctx context.Context, model *inputModel, apiClient resourceMan
 }
 
 func outputResult(p *print.Printer, outputFormat string, projects []resourcemanager.Project) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(projects, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal projects list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(projects, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal projects list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, projects, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATE", "PARENT ID")
 		for i := range projects {
@@ -254,5 +235,5 @@ func outputResult(p *print.Printer, outputFormat string, projects []resourcemana
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/project/member/list/list.go
+++ b/internal/cmd/project/member/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -154,25 +152,7 @@ func outputResult(p *print.Printer, model inputModel, members []authorization.Me
 	}
 	sort.SliceStable(members, sortFn)
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		// Show details
-		details, err := json.MarshalIndent(members, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal members: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(members, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal members: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, members, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SUBJECT", "ROLE")
 		for i := range members {
@@ -196,5 +176,5 @@ func outputResult(p *print.Printer, model inputModel, members []authorization.Me
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/project/role/list/list.go
+++ b/internal/cmd/project/role/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -124,25 +122,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *authorizati
 }
 
 func outputRolesResult(p *print.Printer, outputFormat string, roles []authorization.Role) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		// Show details
-		details, err := json.MarshalIndent(roles, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal roles: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(roles, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal roles: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, roles, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ROLE NAME", "ROLE DESCRIPTION", "PERMISSION NAME", "PERMISSION DESCRIPTION")
 		for i := range roles {
@@ -165,5 +145,5 @@ func outputRolesResult(p *print.Printer, outputFormat string, roles []authorizat
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/public-ip/create/create.go
+++ b/internal/cmd/public-ip/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -127,25 +125,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, publicIp iaas.PublicIp) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(publicIp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(publicIp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, publicIp, func() error {
 		p.Outputf("Created public IP for project %q.\nPublic IP ID: %s\n", projectLabel, utils.PtrString(publicIp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/public-ip/describe/describe.go
+++ b/internal/cmd/public-ip/describe/describe.go
@@ -2,11 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -95,24 +92,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, publicIp iaas.PublicIp) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(publicIp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(publicIp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, publicIp, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(publicIp.Id))
 		table.AddSeparator()
@@ -138,5 +118,5 @@ func outputResult(p *print.Printer, outputFormat string, publicIp iaas.PublicIp)
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -141,24 +139,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, publicIps []iaas.PublicIp) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(publicIps, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(publicIps, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, publicIps, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "IP ADDRESS", "USED BY")
 
@@ -174,5 +155,5 @@ func outputResult(p *print.Printer, outputFormat string, publicIps []iaas.Public
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/public-ip/ranges/list/list.go
+++ b/internal/cmd/public-ip/ranges/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -107,24 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func outputResult(p *print.Printer, outputFormat string, publicIpRanges []iaas.PublicNetwork) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(publicIpRanges, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal public IP ranges: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(publicIpRanges, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal public IP ranges: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, publicIpRanges, func() error {
 		if len(publicIpRanges) == 0 {
 			p.Outputln("No public IP ranges found")
 			return nil
@@ -137,5 +118,5 @@ func outputResult(p *print.Printer, outputFormat string, publicIpRanges []iaas.P
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/public-ip/update/update.go
+++ b/internal/cmd/public-ip/update/update.go
@@ -2,10 +2,7 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -130,25 +127,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, model *inputModel, publicIpLabel string, publicIp *iaas.PublicIp) error {
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(publicIp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(publicIp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal public IP: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, publicIp, func() error {
 		p.Outputf("Updated public IP %q.\n", publicIpLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/quota/list/list.go
+++ b/internal/cmd/quota/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -104,25 +102,7 @@ func outputResult(p *print.Printer, outputFormat string, quotas *iaas.QuotaList)
 	if quotas == nil {
 		return fmt.Errorf("quotas is nil")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(quotas, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal quota list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(quotas, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal quota list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, quotas, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "LIMIT", "CURRENT USAGE", "PERCENT")
 		if val := quotas.BackupGigabytes; val != nil {
@@ -167,7 +147,7 @@ func outputResult(p *print.Printer, outputFormat string, quotas *iaas.QuotaList)
 		}
 
 		return nil
-	}
+	})
 }
 
 func conv(n *int64) string {

--- a/internal/cmd/rabbitmq/credentials/create/create.go
+++ b/internal/cmd/rabbitmq/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -131,24 +129,8 @@ func outputResult(p *print.Printer, model inputModel, instanceLabel string, resp
 		}
 		resp.Raw.Credentials.Password = utils.Ptr("hidden")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
 		// The username field cannot be set by the user so we only display it if it's not returned empty
 		if resp.HasRaw() && resp.Raw.Credentials != nil {
@@ -165,5 +147,5 @@ func outputResult(p *print.Printer, model inputModel, instanceLabel string, resp
 		}
 		p.Outputf("URI: %s\n", utils.PtrString(resp.Uri))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/credentials/describe/describe.go
+++ b/internal/cmd/rabbitmq/credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -108,24 +106,8 @@ func outputResult(p *print.Printer, outputFormat string, credentials *rabbitmq.C
 	if credentials == nil {
 		return fmt.Errorf("no response passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(credentials.Id))
 		table.AddSeparator()
@@ -145,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *rabbitmq.C
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/credentials/list/list.go
+++ b/internal/cmd/rabbitmq/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -128,24 +126,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 }
 
 func outputResult(p *print.Printer, outputFormat string, credentials []rabbitmq.CredentialsListItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID")
 		for i := range credentials {
@@ -158,5 +139,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials []rabbitmq.
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/instance/create/create.go
+++ b/internal/cmd/rabbitmq/instance/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -260,29 +258,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel, instanceId 
 		return fmt.Errorf("no response passed")
 	}
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/instance/describe/describe.go
+++ b/internal/cmd/rabbitmq/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -96,24 +94,8 @@ func outputResult(p *print.Printer, outputFormat string, instance *rabbitmq.Inst
 	if instance == nil {
 		return fmt.Errorf("no instance passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
@@ -143,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *rabbitmq.Inst
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/instance/list/list.go
+++ b/internal/cmd/rabbitmq/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []rabbitmq.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {
@@ -167,5 +148,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []rabbitmq.In
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/rabbitmq/plans/plans.go
+++ b/internal/cmd/rabbitmq/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,24 +122,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *rabbitmq.AP
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []rabbitmq.Offering) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal RabbitMQ plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {
@@ -167,5 +148,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []rabbitmq.Offeri
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/credentials/create/create.go
+++ b/internal/cmd/redis/credentials/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -133,24 +131,7 @@ func outputResult(p *print.Printer, model inputModel, instanceLabel string, resp
 		resp.Raw.Credentials.Password = utils.Ptr("hidden")
 	}
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
 		// The username field cannot be set by the user, so we only display it if it's not returned empty
 		if resp.HasRaw() && resp.Raw.Credentials != nil {
@@ -167,5 +148,5 @@ func outputResult(p *print.Printer, model inputModel, instanceLabel string, resp
 		}
 		p.Outputf("URI: %s\n", utils.PtrString(resp.Uri))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/credentials/describe/describe.go
+++ b/internal/cmd/redis/credentials/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -108,24 +106,8 @@ func outputResult(p *print.Printer, outputFormat string, credentials *redis.Cred
 	if credentials == nil {
 		return fmt.Errorf("no credentials passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(credentials.Id))
 		table.AddSeparator()
@@ -145,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat string, credentials *redis.Cred
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/credentials/list/list.go
+++ b/internal/cmd/redis/credentials/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -128,24 +126,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat, instanceLabel string, credentials []redis.CredentialsListItem) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(credentials, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(credentials, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis credentials list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, credentials, func() error {
 		if len(credentials) == 0 {
 			p.Outputf("No credentials found for instance %q\n", instanceLabel)
 			return nil
@@ -163,5 +144,5 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, credenti
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/instance/create/create.go
+++ b/internal/cmd/redis/instance/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -254,29 +252,13 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel, instanceId 
 	if resp == nil {
 		return fmt.Errorf("no response defined")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, resp, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/instance/describe/describe.go
+++ b/internal/cmd/redis/instance/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -96,24 +94,8 @@ func outputResult(p *print.Printer, outputFormat string, instance *redis.Instanc
 	if instance == nil {
 		return fmt.Errorf("no instance passed")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance: %w", err)
-		}
-		p.Outputln(string(details))
 
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
@@ -143,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *redis.Instanc
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/instance/list/list.go
+++ b/internal/cmd/redis/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -122,24 +120,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, instances []redis.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		if len(instances) == 0 {
 			p.Outputf("No instances found for project %q\n", projectLabel)
 			return nil
@@ -168,5 +149,5 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, instances
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/redis/plans/plans.go
+++ b/internal/cmd/redis/plans/plans.go
@@ -2,10 +2,8 @@ package plans
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *redis.APICl
 }
 
 func outputResult(p *print.Printer, outputFormat string, plans []redis.Offering) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(plans, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Redis plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(plans, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Redis plans: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, plans, func() error {
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {
@@ -166,5 +147,5 @@ func outputResult(p *print.Printer, outputFormat string, plans []redis.Offering)
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -155,25 +153,8 @@ func outputResult(p *print.Printer, outputFormat, projectLabel, instanceId strin
 		return fmt.Errorf("instance is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instance, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instance, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instance, func() error {
 		p.Outputf("Created instance for project %q. Instance ID: %s\n", projectLabel, instanceId)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/instance/describe/describe.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -115,24 +113,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *secretsmanage
 		*secretsmanager.ListACLsResponse
 	}{instance, aclList}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(output, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, output, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.Id))
 		table.AddSeparator()
@@ -162,5 +143,5 @@ func outputResult(p *print.Printer, outputFormat string, instance *secretsmanage
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -124,24 +122,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 }
 
 func outputResult(p *print.Printer, outputFormat string, instances []secretsmanager.Instance) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(instances, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, instances, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATE", "SECRETS")
 		for i := range instances {
@@ -159,5 +140,5 @@ func outputResult(p *print.Printer, outputFormat string, instances []secretsmana
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -135,24 +133,7 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *se
 		return fmt.Errorf("user is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
@@ -160,5 +141,5 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *se
 		p.Outputf("Write Access: %s\n", utils.PtrString(user.Write))
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/user/describe/describe.go
+++ b/internal/cmd/secrets-manager/user/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -107,24 +105,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 }
 
 func outputResult(p *print.Printer, outputFormat string, user secretsmanager.User) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(user, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(user, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, user, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(user.Id))
 		table.AddSeparator()
@@ -146,5 +127,5 @@ func outputResult(p *print.Printer, outputFormat string, user secretsmanager.Use
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -131,24 +129,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmana
 }
 
 func outputResult(p *print.Printer, outputFormat string, users []secretsmanager.User) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(users, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(users, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Secrets Manager user list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, users, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "USERNAME", "DESCRIPTION", "WRITE ACCESS")
 		for i := range users {
@@ -166,5 +147,5 @@ func outputResult(p *print.Printer, outputFormat string, users []secretsmanager.
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/create/create.go
+++ b/internal/cmd/security-group/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -130,25 +128,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, name string, resp iaas.SecurityGroup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal security group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal security group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created security group %q.\nSecurity Group ID %s\n", name, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/describe/describe.go
+++ b/internal/cmd/security-group/describe/describe.go
@@ -2,7 +2,6 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -93,24 +91,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *iaas.SecurityGrou
 	if resp == nil {
 		return fmt.Errorf("security group response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal security group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal security group: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		var content []tables.Table
 
 		table := tables.NewTable()
@@ -209,5 +190,5 @@ func outputResult(p *print.Printer, outputFormat string, resp *iaas.SecurityGrou
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -112,24 +110,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return request
 }
 func outputResult(p *print.Printer, outputFormat string, items []iaas.SecurityGroup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(items, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(items, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal PostgreSQL Flex instance list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, items, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATEFUL", "DESCRIPTION", "LABELS")
 		for _, item := range items {
@@ -156,5 +137,5 @@ func outputResult(p *print.Printer, outputFormat string, items []iaas.SecurityGr
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/rule/create/create.go
+++ b/internal/cmd/security-group/rule/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -215,29 +213,12 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel, securityGro
 	if securityGroupRule == nil {
 		return fmt.Errorf("security group rule is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(securityGroupRule, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal security group rule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(securityGroupRule, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal security group rule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, securityGroupRule, func() error {
 		operationState := "Created"
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s security group rule for security group %q in project %q.\nSecurity group rule ID: %s\n", operationState, securityGroupName, projectLabel, utils.PtrString(securityGroupRule.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/rule/describe/describe.go
+++ b/internal/cmd/security-group/rule/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -109,24 +107,7 @@ func outputResult(p *print.Printer, outputFormat string, securityGroupRule *iaas
 	if securityGroupRule == nil {
 		return fmt.Errorf("security group rule is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(securityGroupRule, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal security group rule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(securityGroupRule, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal security group rule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, securityGroupRule, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(securityGroupRule.Id))
 		table.AddSeparator()
@@ -178,5 +159,5 @@ func outputResult(p *print.Printer, outputFormat string, securityGroupRule *iaas
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/security-group/rule/list/list.go
+++ b/internal/cmd/security-group/rule/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -18,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -141,24 +139,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, securityGroupRules []iaas.SecurityGroupRule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(securityGroupRules, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal security group rules: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(securityGroupRules, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal security group rules: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, securityGroupRules, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "ETHER TYPE", "DIRECTION", "PROTOCOL", "REMOTE SECURITY GROUP ID")
 
@@ -184,5 +165,5 @@ func outputResult(p *print.Printer, outputFormat string, securityGroupRules []ia
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/create/create.go
+++ b/internal/cmd/server/backup/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -148,25 +146,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverbackup.BackupJob) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Triggered creation of server backup for server %s. Backup ID: %s\n", serverLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/describe/describe.go
+++ b/internal/cmd/server/backup/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -104,24 +102,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat string, backup serverbackup.Backup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backup, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server backup: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))
 		table.AddSeparator()
@@ -152,5 +133,5 @@ func outputResult(p *print.Printer, outputFormat string, backup serverbackup.Bac
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/list/list.go
+++ b/internal/cmd/server/backup/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -132,24 +130,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat string, backups []serverbackup.Backup) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backups, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Server Backup list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backups, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Server Backup list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, backups, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE (GB)", "STATUS", "CREATED AT", "EXPIRES AT", "LAST RESTORED AT", "VOLUME BACKUPS")
 		for i := range backups {
@@ -176,5 +157,5 @@ func outputResult(p *print.Printer, outputFormat string, backups []serverbackup.
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/schedule/create/create.go
+++ b/internal/cmd/server/backup/schedule/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -167,25 +165,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverbackup.BackupSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created server backup schedule for server %s. Backup Schedule ID: %s\n", serverLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/schedule/describe/describe.go
+++ b/internal/cmd/server/backup/schedule/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -103,24 +101,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedule serverbackup.BackupSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(schedule, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(schedule, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, schedule, func() error {
 		table := tables.NewTable()
 		table.AddRow("SCHEDULE ID", utils.PtrString(schedule.Id))
 		table.AddSeparator()
@@ -144,5 +125,5 @@ func outputResult(p *print.Printer, outputFormat string, schedule serverbackup.B
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/schedule/list/list.go
+++ b/internal/cmd/server/backup/schedule/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -133,24 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedules []serverbackup.BackupSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(schedules, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Server Backup Schedules list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(schedules, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Server Backup Schedules list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, schedules, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SCHEDULE ID", "SCHEDULE NAME", "ENABLED", "RRULE", "BACKUP NAME", "BACKUP RETENTION DAYS", "BACKUP VOLUME IDS")
 		for i := range schedules {
@@ -180,5 +161,5 @@ func outputResult(p *print.Printer, outputFormat string, schedules []serverbacku
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/backup/schedule/update/update.go
+++ b/internal/cmd/server/backup/schedule/update/update.go
@@ -2,10 +2,8 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -178,25 +176,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 }
 
 func outputResult(p *print.Printer, outputFormat string, resp serverbackup.BackupSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal update server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal update server backup schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Info("Updated server backup schedule %s\n", utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/command/create/create.go
+++ b/internal/cmd/server/command/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -145,25 +143,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp runcommand.NewCommandResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server command: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server command: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created server command for server %s. Command ID: %s\n", serverLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/command/describe/describe.go
+++ b/internal/cmd/server/command/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -102,24 +100,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.
 }
 
 func outputResult(p *print.Printer, outputFormat string, command runcommand.CommandDetails) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(command, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server command: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(command, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server command: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, command, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(command.Id))
 		table.AddSeparator()
@@ -145,5 +126,5 @@ func outputResult(p *print.Printer, outputFormat string, command runcommand.Comm
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/command/list/list.go
+++ b/internal/cmd/server/command/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -132,24 +130,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.
 }
 
 func outputResult(p *print.Printer, outputFormat string, commands []runcommand.Commands) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(commands, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server command list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(commands, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server command list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, commands, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "TEMPLATE NAME", "TEMPLATE TITLE", "STATUS", "STARTED_AT", "FINISHED_AT")
 		for i := range commands {
@@ -168,5 +149,5 @@ func outputResult(p *print.Printer, outputFormat string, commands []runcommand.C
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/command/template/describe/describe.go
+++ b/internal/cmd/server/command/template/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -102,24 +100,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.
 }
 
 func outputResult(p *print.Printer, outputFormat string, commandTemplate runcommand.CommandTemplateSchema) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(commandTemplate, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server command template: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(commandTemplate, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server command template: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, commandTemplate, func() error {
 		table := tables.NewTable()
 		table.AddRow("NAME", utils.PtrString(commandTemplate.Name))
 		table.AddSeparator()
@@ -143,5 +124,5 @@ func outputResult(p *print.Printer, outputFormat string, commandTemplate runcomm
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/command/template/list/list.go
+++ b/internal/cmd/server/command/template/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -112,24 +110,7 @@ func buildRequest(ctx context.Context, _ *inputModel, apiClient *runcommand.APIC
 }
 
 func outputResult(p *print.Printer, outputFormat string, templates []runcommand.CommandTemplate) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(templates, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server command template list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(templates, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server command template list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, templates, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NAME", "OS TYPE", "TITLE")
 		for i := range templates {
@@ -151,5 +132,5 @@ func outputResult(p *print.Printer, outputFormat string, templates []runcommand.
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/console/console.go
+++ b/internal/cmd/server/console/console.go
@@ -2,11 +2,9 @@ package console
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -102,24 +100,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, serverUrl iaas.ServerConsoleUrl) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serverUrl, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal url: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serverUrl, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal url: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, serverUrl, func() error {
 		if _, ok := serverUrl.GetUrlOk(); !ok {
 			return fmt.Errorf("server url is nil")
 		}
@@ -132,5 +113,5 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, serverUrl 
 		p.Outputf("Remote console URL %q for server %q\n", unescapedURL, serverLabel)
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -328,25 +326,8 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, server *i
 	if server == nil {
 		return fmt.Errorf("server response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(server, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(server, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, server, func() error {
 		p.Outputf("Created server for project %q.\nServer ID: %s\n", projectLabel, utils.PtrString(server.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/log/log.go
+++ b/internal/cmd/server/log/log.go
@@ -2,11 +2,9 @@ package log
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -134,25 +132,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel, log string) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(log, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal url: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(log, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal url: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, log, func() error {
 		p.Outputf("Log for server %q\n%s", serverLabel, log)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/machine-type/describe/describe.go
+++ b/internal/cmd/server/machine-type/describe/describe.go
@@ -2,10 +2,7 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -97,24 +94,7 @@ func outputResult(p *print.Printer, outputFormat string, machineType *iaas.Machi
 	if machineType == nil {
 		return fmt.Errorf("api response for machine type is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(machineType, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server machine type: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(machineType, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server machine type: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, machineType, func() error {
 		table := tables.NewTable()
 		table.AddRow("NAME", utils.PtrString(machineType.Name))
 		table.AddSeparator()
@@ -132,5 +112,5 @@ func outputResult(p *print.Printer, outputFormat string, machineType *iaas.Machi
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/machine-type/list/list.go
+++ b/internal/cmd/server/machine-type/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -126,24 +124,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, machineTypes iaas.MachineTypeListResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(machineTypes, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal machineTypes: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(machineTypes, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal machineTypes: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, machineTypes, func() error {
 		table := tables.NewTable()
 		table.SetTitle("Machine-Types")
 
@@ -160,5 +141,5 @@ func outputResult(p *print.Printer, outputFormat string, machineTypes iaas.Machi
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/network-interface/list/list.go
+++ b/internal/cmd/server/network-interface/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -134,24 +132,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverId string, serverNics []iaas.NIC) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serverNics, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server network interfaces: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serverNics, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server network interfaces: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, serverNics, func() error {
 		table := tables.NewTable()
 		table.SetHeader("NIC ID", "SERVER ID")
 
@@ -163,5 +144,5 @@ func outputResult(p *print.Printer, outputFormat, serverId string, serverNics []
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/create/create.go
+++ b/internal/cmd/server/os-update/create/create.go
@@ -2,12 +2,10 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -131,25 +129,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverupdate.Update) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server os-update: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server os-update: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Triggered creation of server os-update for server %s. Update ID: %s\n", serverLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/describe/describe.go
+++ b/internal/cmd/server/os-update/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -102,24 +100,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat string, update serverupdate.Update) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(update, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server update: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(update, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server update: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, update, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(update.Id))
 		table.AddSeparator()
@@ -142,5 +123,5 @@ func outputResult(p *print.Printer, outputFormat string, update serverupdate.Upd
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/list/list.go
+++ b/internal/cmd/server/os-update/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 )
@@ -133,24 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat string, updates []serverupdate.Update) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(updates, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server os-update list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(updates, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server os-update list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, updates, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "STATUS", "INSTALLED UPDATES", "FAILED UPDATES", "START DATE", "END DATE")
 		for i := range updates {
@@ -182,5 +163,5 @@ func outputResult(p *print.Printer, outputFormat string, updates []serverupdate.
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/schedule/create/create.go
+++ b/internal/cmd/server/os-update/schedule/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -150,25 +148,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverupdate.UpdateSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Outputf("Created server os-update schedule for server %s. os-update Schedule ID: %s\n", serverLabel, utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/schedule/describe/describe.go
+++ b/internal/cmd/server/os-update/schedule/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -102,24 +100,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedule serverupdate.UpdateSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(schedule, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(schedule, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, schedule, func() error {
 		table := tables.NewTable()
 		table.AddRow("SCHEDULE ID", utils.PtrString(schedule.Id))
 		table.AddSeparator()
@@ -138,5 +119,5 @@ func outputResult(p *print.Printer, outputFormat string, schedule serverupdate.U
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/schedule/list/list.go
+++ b/internal/cmd/server/os-update/schedule/list/list.go
@@ -2,12 +2,10 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -132,24 +130,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedules []serverupdate.UpdateSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(schedules, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal Server os-update Schedules list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(schedules, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal Server os-update Schedules list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, schedules, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SCHEDULE ID", "SCHEDULE NAME", "ENABLED", "RRULE", "MAINTENANCE WINDOW")
 		for i := range schedules {
@@ -167,5 +148,5 @@ func outputResult(p *print.Printer, outputFormat string, schedules []serverupdat
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/os-update/schedule/update/update.go
+++ b/internal/cmd/server/os-update/schedule/update/update.go
@@ -2,10 +2,8 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -160,25 +158,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 }
 
 func outputResult(p *print.Printer, outputFormat string, resp serverupdate.UpdateSchedule) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal update server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal update server os-update schedule: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		p.Info("Updated server os-update schedule %s\n", utils.PtrString(resp.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -2,7 +2,6 @@ package attach
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -116,25 +114,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serviceAccMail, serverLabel string, serviceAccounts iaas.ServiceAccountMailListResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serviceAccounts, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serviceAccounts, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, serviceAccounts, func() error {
 		p.Outputf("Attached service account %q to server %q\n", serviceAccMail, serverLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -2,7 +2,6 @@ package detach
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -116,25 +114,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serviceAccMail, serverLabel string, service iaas.ServiceAccountMailListResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(service, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(service, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, service, func() error {
 		p.Outputf("Detached service account %q from server %q\n", serviceAccMail, serverLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/service-account/list/list.go
+++ b/internal/cmd/server/service-account/list/list.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -15,7 +14,6 @@ import (
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
@@ -133,24 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverId, serverName string, serviceAccounts []string) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serviceAccounts, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service accounts list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serviceAccounts, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service accounts list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, serviceAccounts, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SERVER ID", "SERVER NAME", "SERVICE ACCOUNT")
 		for i := range serviceAccounts {
@@ -161,5 +142,5 @@ func outputResult(p *print.Printer, outputFormat, serverId, serverName string, s
 			return fmt.Errorf("rednder table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/update/update.go
+++ b/internal/cmd/server/update/update.go
@@ -2,10 +2,7 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -130,25 +127,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, server *iaas.Server) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(server, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(server, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, server, func() error {
 		p.Outputf("Updated server %q.\n", serverLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/volume/attach/attach.go
+++ b/internal/cmd/server/volume/attach/attach.go
@@ -2,10 +2,8 @@ package attach
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -136,25 +134,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, volumeLabel, serverLabel string, volume iaas.VolumeAttachment) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volume, func() error {
 		p.Outputf("Attached volume %q to server %q\n", volumeLabel, serverLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/volume/describe/describe.go
+++ b/internal/cmd/server/volume/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel, volumeLabel string, volume iaas.VolumeAttachment) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volume, func() error {
 		table := tables.NewTable()
 		table.AddRow("SERVER ID", utils.PtrString(volume.ServerId))
 		table.AddSeparator()
@@ -161,5 +142,5 @@ func outputResult(p *print.Printer, outputFormat, serverLabel, volumeLabel strin
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/volume/list/list.go
+++ b/internal/cmd/server/volume/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -123,24 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, volumeNames []string, volumes []iaas.VolumeAttachment) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volumes, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server volume list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volumes, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server volume list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volumes, func() error {
 		table := tables.NewTable()
 		table.SetHeader("SERVER ID", "SERVER NAME", "VOLUME ID", "VOLUME NAME")
 		for i := range volumes {
@@ -156,5 +137,5 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, volumeName
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/server/volume/update/update.go
+++ b/internal/cmd/server/volume/update/update.go
@@ -2,10 +2,8 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -132,25 +130,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, volumeLabel, serverLabel string, volume iaas.VolumeAttachment) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal server volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volume, func() error {
 		p.Outputf("Updated attached volume %q of server %q\n", volumeLabel, serverLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -117,25 +115,8 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, serviceAc
 		return fmt.Errorf("service account is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serviceAccount, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serviceAccount, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service account: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, serviceAccount, func() error {
 		p.Outputf("Created service account for project %q. Email: %s\n", projectLabel, utils.PtrString(serviceAccount.Email))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -133,24 +131,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 }
 
 func outputResult(p *print.Printer, outputFormat string, keys []serviceaccount.ServiceAccountKeyListResponse) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(keys, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal keys metadata: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(keys, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal keys metadata: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, keys, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "ACTIVE", "CREATED_AT", "VALID_UNTIL")
 		for i := range keys {
@@ -172,5 +153,5 @@ func outputResult(p *print.Printer, outputFormat string, keys []serviceaccount.S
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -117,20 +115,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 }
 
 func outputResult(p *print.Printer, outputFormat string, serviceAccounts []serviceaccount.ServiceAccount) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(serviceAccounts, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service accounts list: %w", err)
-		}
-		p.Outputln(string(details))
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(serviceAccounts, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service accounts list: %w", err)
-		}
-		p.Outputln(string(details))
-	default:
+	return p.OutputResult(outputFormat, serviceAccounts, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "EMAIL")
 		for i := range serviceAccounts {
@@ -144,7 +129,6 @@ func outputResult(p *print.Printer, outputFormat string, serviceAccounts []servi
 		if err != nil {
 			return fmt.Errorf("render table: %w", err)
 		}
-	}
-
-	return nil
+		return nil
+	})
 }

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -140,27 +138,10 @@ func outputResult(p *print.Printer, outputFormat, serviceAccountEmail string, to
 		return fmt.Errorf("token is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(token, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal service account access token: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(token, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal service account access token: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, token, func() error {
 		p.Outputf("Created access token for service account %s. Token ID: %s\n\n", serviceAccountEmail, utils.PtrString(token.Id))
 		p.Outputf("Valid until: %s\n", utils.PtrString(token.ValidUntil))
 		p.Outputf("Token: %s\n", utils.PtrString(token.Token))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -138,24 +136,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 }
 
 func outputResult(p *print.Printer, outputFormat string, tokensMetadata []serviceaccount.AccessTokenMetadata) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(tokensMetadata, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal tokens metadata: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(tokensMetadata, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal tokens metadata: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, tokensMetadata, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "ACTIVE", "CREATED_AT", "VALID_UNTIL")
 		for i := range tokensMetadata {
@@ -173,5 +154,5 @@ func outputResult(p *print.Printer, outputFormat string, tokensMetadata []servic
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -195,29 +194,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		return fmt.Errorf("cluster is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(cluster, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(cluster, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, cluster, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
 		p.Outputf("%s cluster for project %q. Cluster name: %s\n", operationState, projectLabel, utils.PtrString(cluster.Name))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/ske/cluster/describe/describe.go
+++ b/internal/cmd/ske/cluster/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -95,24 +93,7 @@ func outputResult(p *print.Printer, outputFormat string, cluster *ske.Cluster) e
 		return fmt.Errorf("cluster is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(cluster, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(cluster, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, cluster, func() error {
 		acl := []string{}
 		if cluster.Extensions != nil && cluster.Extensions.Acl != nil {
 			acl = *cluster.Extensions.Acl.AllowedCidrs
@@ -140,7 +121,7 @@ func outputResult(p *print.Printer, outputFormat string, cluster *ske.Cluster) e
 		}
 
 		return nil
-	}
+	})
 }
 
 func handleClusterErrors(clusterErrs []ske.ClusterError, table *tables.Table) {

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -140,24 +138,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *ske.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, clusters []ske.Cluster) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(clusters, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(clusters, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster list: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, clusters, func() error {
 		if len(clusters) == 0 {
 			p.Outputf("No clusters found for project %q\n", projectLabel)
 			return nil
@@ -196,5 +177,5 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, clusters 
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/ske/cluster/update/update.go
+++ b/internal/cmd/ske/cluster/update/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -157,29 +156,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, clusterName
 		return fmt.Errorf("cluster is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(cluster, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(cluster, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE cluster: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, cluster, func() error {
 		operationState := "Updated"
 		if async {
 			operationState = "Triggered update of"
 		}
 		p.Info("%s cluster %q\n", operationState, clusterName)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -2,10 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -84,24 +82,7 @@ func outputResult(p *print.Printer, outputFormat string, project *serviceenablem
 		return fmt.Errorf("project is nil")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(project, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE project details: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(project, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE project details: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, project, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", projectId)
 		table.AddSeparator()
@@ -114,5 +95,5 @@ func outputResult(p *print.Printer, outputFormat string, project *serviceenablem
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/ske/options/options.go
+++ b/internal/cmd/ske/options/options.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -156,25 +155,9 @@ func outputResult(p *print.Printer, model *inputModel, options *ske.ProviderOpti
 		options.VolumeTypes = nil
 	}
 
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(options, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal SKE options: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(options, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal SKE options: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, options, func() error {
 		return outputResultAsTable(p, options)
-	}
+	})
 }
 
 func outputResultAsTable(p *print.Printer, options *ske.ProviderOptions) error {

--- a/internal/cmd/volume/backup/create/create.go
+++ b/internal/cmd/volume/backup/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -190,29 +188,12 @@ func outputResult(p *print.Printer, outputFormat string, async bool, sourceLabel
 		return fmt.Errorf("create backup response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(resp, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(resp, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, resp, func() error {
 		if async {
 			p.Outputf("Triggered backup of %s in %s. Backup ID: %s\n", sourceLabel, projectLabel, utils.PtrString(resp.Id))
 		} else {
 			p.Outputf("Created backup of %s in %s. Backup ID: %s\n", sourceLabel, projectLabel, utils.PtrString(resp.Id))
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/backup/describe/describe.go
+++ b/internal/cmd/volume/backup/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -97,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, backup *iaas.Backup) er
 		return fmt.Errorf("backup response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backup, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))
 		table.AddSeparator()
@@ -150,5 +131,5 @@ func outputResult(p *print.Printer, outputFormat string, backup *iaas.Backup) er
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/backup/list/list.go
+++ b/internal/cmd/volume/backup/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -142,24 +140,7 @@ func outputResult(p *print.Printer, outputFormat string, backups []iaas.Backup) 
 		return fmt.Errorf("backups is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backups, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal backup list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backups, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal backup list: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, backups, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE", "STATUS", "SNAPSHOT ID", "VOLUME ID", "AVAILABILITY ZONE", "LABELS", "CREATED AT", "UPDATED AT")
 
@@ -190,5 +171,5 @@ func outputResult(p *print.Printer, outputFormat string, backups []iaas.Backup) 
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/backup/update/update.go
+++ b/internal/cmd/volume/backup/update/update.go
@@ -2,10 +2,8 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -136,25 +134,8 @@ func outputResult(p *print.Printer, outputFormat, backupLabel string, backup *ia
 		return fmt.Errorf("backup response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(backup, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(backup, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal backup: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, backup, func() error {
 		p.Outputf("Updated backup %q\n", backupLabel)
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/create/create.go
+++ b/internal/cmd/volume/create/create.go
@@ -2,10 +2,8 @@ package create
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -186,25 +184,8 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, volu
 	if volume == nil {
 		return fmt.Errorf("volume response is empty")
 	}
-	switch model.OutputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(model.OutputFormat, volume, func() error {
 		p.Outputf("Created volume for project %q.\nVolume ID: %s\n", projectLabel, utils.PtrString(volume.Id))
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/describe/describe.go
+++ b/internal/cmd/volume/describe/describe.go
@@ -2,11 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -98,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, volume *iaas.Volume) er
 	if volume == nil {
 		return fmt.Errorf("volume response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volume, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(volume.Id))
 		table.AddSeparator()
@@ -155,5 +135,5 @@ func outputResult(p *print.Printer, outputFormat string, volume *iaas.Volume) er
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/list/list.go
+++ b/internal/cmd/volume/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -138,24 +136,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, volumes []iaas.Volume) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volumes, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volumes, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volumes, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "Name", "Status", "Server", "Availability Zone", "Size (GB)")
 
@@ -174,5 +155,5 @@ func outputResult(p *print.Printer, outputFormat string, volumes []iaas.Volume) 
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/performance-class/describe/describe.go
+++ b/internal/cmd/volume/performance-class/describe/describe.go
@@ -2,11 +2,8 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -98,24 +95,7 @@ func outputResult(p *print.Printer, outputFormat string, performanceClass *iaas.
 	if performanceClass == nil {
 		return fmt.Errorf("performanceClass response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(performanceClass, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume performance class: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(performanceClass, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume performance class: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, performanceClass, func() error {
 		table := tables.NewTable()
 		table.AddRow("NAME", utils.PtrString(performanceClass.Name))
 		table.AddSeparator()
@@ -140,5 +120,5 @@ func outputResult(p *print.Printer, outputFormat string, performanceClass *iaas.
 			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/performance-class/list/list.go
+++ b/internal/cmd/volume/performance-class/list/list.go
@@ -2,10 +2,8 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/goccy/go-yaml"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -139,24 +137,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat string, performanceClasses []iaas.VolumePerformanceClass) error {
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(performanceClasses, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume performance class: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(performanceClasses, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume performance class: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, performanceClasses, func() error {
 		table := tables.NewTable()
 		table.SetHeader("Name", "Description")
 
@@ -167,5 +148,5 @@ func outputResult(p *print.Printer, outputFormat string, performanceClasses []ia
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/snapshot/describe/describe.go
+++ b/internal/cmd/volume/snapshot/describe/describe.go
@@ -2,11 +2,9 @@ package describe
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -96,24 +94,7 @@ func outputResult(p *print.Printer, outputFormat string, snapshot *iaas.Snapshot
 		return fmt.Errorf("get snapshot response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(snapshot, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal snapshot: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(snapshot, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal snapshot: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, snapshot, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(snapshot.Id))
 		table.AddSeparator()
@@ -145,5 +126,5 @@ func outputResult(p *print.Printer, outputFormat string, snapshot *iaas.Snapshot
 		}
 
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/snapshot/list/list.go
+++ b/internal/cmd/volume/snapshot/list/list.go
@@ -2,11 +2,9 @@ package list
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
@@ -141,24 +139,7 @@ func outputResult(p *print.Printer, outputFormat string, snapshots []iaas.Snapsh
 		return fmt.Errorf("list snapshots response is empty")
 	}
 
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(snapshots, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal snapshots: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(snapshots, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal snapshots: %w", err)
-		}
-		p.Outputln(string(details))
-		return nil
-
-	default:
+	return p.OutputResult(outputFormat, snapshots, func() error {
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE", "STATUS", "VOLUME ID", "LABELS", "CREATED AT", "UPDATED AT")
 
@@ -186,5 +167,5 @@ func outputResult(p *print.Printer, outputFormat string, snapshots []iaas.Snapsh
 
 		p.Outputln(table.Render())
 		return nil
-	}
+	})
 }

--- a/internal/cmd/volume/update/update.go
+++ b/internal/cmd/volume/update/update.go
@@ -2,10 +2,7 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-
-	"github.com/goccy/go-yaml"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -140,25 +137,8 @@ func outputResult(p *print.Printer, outputFormat, volumeLabel string, volume *ia
 	if volume == nil {
 		return fmt.Errorf("volume response is empty")
 	}
-	switch outputFormat {
-	case print.JSONOutputFormat:
-		details, err := json.MarshalIndent(volume, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	case print.YAMLOutputFormat:
-		details, err := yaml.MarshalWithOptions(volume, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
-		if err != nil {
-			return fmt.Errorf("marshal volume: %w", err)
-		}
-		p.Outputln(string(details))
-
-		return nil
-	default:
+	return p.OutputResult(outputFormat, volume, func() error {
 		p.Outputf("Updated volume %q.\n", volumeLabel)
 		return nil
-	}
+	})
 }

--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -2,9 +2,12 @@ package print
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
+
+	"github.com/goccy/go-yaml"
 
 	"log/slog"
 	"os"
@@ -238,5 +241,28 @@ func (p *Printer) DebugInputModel(model any) {
 		} else {
 			p.Debug(DebugLevel, "parsed input values: %s", modelStr)
 		}
+	}
+}
+
+func (p *Printer) OutputResult(outputFormat string, output any, prettyOutputFunc func() error) error {
+	switch outputFormat {
+	case JSONOutputFormat:
+		details, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal json: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	case YAMLOutputFormat:
+		details, err := yaml.MarshalWithOptions(output, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
+		if err != nil {
+			return fmt.Errorf("marshal yaml: %w", err)
+		}
+		p.Outputln(string(details))
+
+		return nil
+	default:
+		return prettyOutputFunc()
 	}
 }

--- a/internal/pkg/print/print_test.go
+++ b/internal/pkg/print/print_test.go
@@ -860,3 +860,79 @@ func TestIsVerbosityError(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputResult(t *testing.T) {
+	type args struct {
+		outputFormat     string
+		output           any
+		prettyOutputFunc func() error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "output format is JSON",
+			args: args{
+				outputFormat: JSONOutputFormat,
+				output:       struct{}{},
+			},
+		},
+		{
+			name: "output format is JSON and output is nil",
+			args: args{
+				outputFormat: JSONOutputFormat,
+				output:       nil,
+			},
+		},
+		{
+			name: "output format is YAML",
+			args: args{
+				outputFormat: YAMLOutputFormat,
+				output:       struct{}{},
+			},
+		},
+		{
+			name: "output format is YAML and output is nil",
+			args: args{
+				outputFormat: YAMLOutputFormat,
+				output:       nil,
+			},
+		},
+		{
+			name: "should return error of pretty output func",
+			args: args{
+				outputFormat: PrettyOutputFormat,
+				output:       struct{}{},
+				prettyOutputFunc: func() error {
+					return fmt.Errorf("dummy error")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success of pretty output func",
+			args: args{
+				outputFormat: PrettyOutputFormat,
+				output:       struct{}{},
+				prettyOutputFunc: func() error {
+					return nil
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			p := &Printer{
+				Cmd:       cmd,
+				Verbosity: ErrorLevel,
+			}
+
+			if err := p.OutputResult(tt.args.outputFormat, tt.args.output, tt.args.prettyOutputFunc); (err != nil) != tt.wantErr {
+				t.Errorf("OutputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Previously basically every command had a `outputResult` func which looked like the one below. Every single `outputResult` func duplicated the code for the `JSON`/`YAML` output functionality.

```golang
func outputResult(p *print.Printer, cmd *cobra.Command, outputFormat string, resources []foo.Resource) error {
	switch outputFormat {
	case print.JSONOutputFormat:
		details, err := json.MarshalIndent(resources, "", "  ")
		if err != nil {
			return fmt.Errorf("marshal resource list: %w", err)
		}
		p.Outputln(string(details))
		return nil
	case print.YAMLOutputFormat:
		details, err := yaml.Marshal(resources)
		if err != nil {
			return fmt.Errorf("marshal resource list: %w", err)
		}
		p.Outputln(string(details))
		return nil
	default:
		// pretty output functionality, e.g. tables, ...
	}
}
```

Now there's a new function implemented in the printer, which handles the `JSON`/`YAML` output for us in one central place so we don't have to duplicate the switch-statement for every subcommand. 

New function which can be found in `internal/pkg/print/print.go`: It takes an `output` param for the `JSON`/`YAML` output and a callback function (`prettyOutputFunc` param) so you can define a custom pretty output depending on your needs of the sub-command you're implementing.

```golang
func (p *Printer) OutputResult(outputFormat string, output any, prettyOutputFunc func() error) error {
	switch outputFormat {
	case JSONOutputFormat:
		details, err := json.MarshalIndent(output, "", "  ")
		if err != nil {
			return fmt.Errorf("marshal json: %w", err)
		}
		p.Outputln(string(details))

		return nil
	case YAMLOutputFormat:
		details, err := yaml.MarshalWithOptions(output, yaml.IndentSequence(true), yaml.UseJSONMarshaler())
		if err != nil {
			return fmt.Errorf("marshal yaml: %w", err)
		}
		p.Outputln(string(details))

		return nil
	default:
		return prettyOutputFunc()
	}
}
```

The new function can be used like this:

```golang
func outputResult(p *print.Printer, outputFormat string, items []alb.LoadBalancer) error {
	return p.OutputResult(outputFormat, items, func() error {
		table := tables.NewTable()
		table.SetHeader("NAME", "EXTERNAL ADDRESS", "REGION", "STATUS", "VERSION", "ERRORS")
		for i := range items {
			item := &items[i]

			var errNo int
			if item.Errors != nil {
				errNo = len(*item.Errors)
			}
			table.AddRow(utils.PtrString(item.Name),
				utils.PtrString(item.ExternalAddress),
				utils.PtrString(item.Region),
				utils.PtrString(item.Status),
				utils.PtrString(item.Version),
				errNo,
			)
		}
		err := table.Display(p)
		if err != nil {
			return fmt.Errorf("render table: %w", err)
		}

		return nil
	})
}
```

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
