### PR TITLE
fix(postgresflex): remove storage class flag from instance update cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v0.31.0
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.1
-	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.2.1
+	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.0
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.17.1
 	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.3.1
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.13.1

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/stackitcloud/stackit-sdk-go/services/observability v0.15.0 h1:MA5i1Sc
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.15.0/go.mod h1:tJEOi6L0le4yQZPGwalup/PZ13gqs1aCQDqlUs2cYW0=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.1 h1:50n87uZn0EvSP9hJGLqd3Wm2hfqbyh7BMGGCk7axgqA=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.1/go.mod h1:jfguuSPa56Z5Bzs/Xg/CI37XzPo5Zn5lzC5LhfuT8Qc=
-github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.2.1 h1:K8vXele3U6b5urcSIpq21EkVblWfPDY3eMPSuQ48TkI=
-github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.2.1/go.mod h1:hyhw+I19NtjKmRLcUkY4boaTxnYSPFGbpn4RxvGqH2s=
+github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.0 h1:bRTjGuRURl7Gs2eumIqW0hXTzoOBA1nWZkfcligMsZY=
+github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.0/go.mod h1:I/2cg1SU61M+8X1UDVB154D13I2Uk0wObKvo6Je6NFs=
 github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v0.25.1 h1:ALrDCBih8Fu8e6530KdOjuH0iMxOLntO381BbKFlTFY=
 github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v0.25.1/go.mod h1:+qGWSehoV0Js3FalgvT/bOgPj+UqW4I7lP5s8uAxP+o=
 github.com/stackitcloud/stackit-sdk-go/services/redis v0.25.1 h1:8uPt82Ez34OYMOijjEYxB1zUW6kiybkt6veQKl0AL68=

--- a/internal/cmd/postgresflex/instance/update/update.go
+++ b/internal/cmd/postgresflex/instance/update/update.go
@@ -33,7 +33,6 @@ const (
 	flavorIdFlag       = "flavor-id"
 	cpuFlag            = "cpu"
 	ramFlag            = "ram"
-	storageClassFlag   = "storage-class"
 	storageSizeFlag    = "storage-size"
 	versionFlag        = "version"
 	typeFlag           = "type"
@@ -135,7 +134,6 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
 	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")
 	cmd.Flags().Int64(ramFlag, 0, "Amount of RAM (in GB)")
-	cmd.Flags().String(storageClassFlag, "", "Storage class")
 	cmd.Flags().Int64(storageSizeFlag, 0, "Storage size (in GB)")
 	cmd.Flags().String(versionFlag, "", "Version")
 	cmd.Flags().Var(flags.EnumFlag(false, "", typeFlagOptions...), typeFlag, fmt.Sprintf("Instance type, one of %q", typeFlagOptions))
@@ -155,13 +153,12 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	ram := flags.FlagToInt64Pointer(p, cmd, ramFlag)
 	acl := flags.FlagToStringSlicePointer(p, cmd, aclFlag)
 	backupSchedule := flags.FlagToStringPointer(p, cmd, backupScheduleFlag)
-	storageClass := flags.FlagToStringPointer(p, cmd, storageClassFlag)
 	storageSize := flags.FlagToInt64Pointer(p, cmd, storageSizeFlag)
 	version := flags.FlagToStringPointer(p, cmd, versionFlag)
 	instanceType := flags.FlagToStringPointer(p, cmd, typeFlag)
 
 	if instanceName == nil && flavorId == nil && cpu == nil && ram == nil && acl == nil &&
-		backupSchedule == nil && storageClass == nil && storageSize == nil && version == nil && instanceType == nil {
+		backupSchedule == nil && storageSize == nil && version == nil && instanceType == nil {
 		return nil, &cliErr.EmptyUpdateError{}
 	}
 
@@ -181,7 +178,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		FlavorId:        flavorId,
 		CPU:             cpu,
 		RAM:             ram,
-		StorageClass:    storageClass,
 		StorageSize:     storageSize,
 		Version:         version,
 		Type:            instanceType,
@@ -265,11 +261,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient PostgreSQLFl
 		payloadAcl = &postgresflex.ACL{Items: model.ACL}
 	}
 
-	var payloadStorage *postgresflex.Storage
+	var payloadStorage *postgresflex.StorageUpdate
 	if model.StorageClass != nil || model.StorageSize != nil {
-		payloadStorage = &postgresflex.Storage{
-			Class: model.StorageClass,
-			Size:  model.StorageSize,
+		payloadStorage = &postgresflex.StorageUpdate{
+			Size: model.StorageSize,
 		}
 	}
 


### PR DESCRIPTION
storage class change via update is non-functional and deprecated on API side

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1029

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
