### PR TITLE
fix(mariadb): print valid JSON/YAML for list commands

### DIFF
--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -66,22 +66,19 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list MariaDB credentials: %w", err)
 			}
-			credentials := *resp.CredentialsList
-			if len(credentials) == 0 {
-				instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
-					instanceLabel = model.InstanceId
-				}
-				params.Printer.Info("No credentials found for instance %q\n", instanceLabel)
-				return nil
+			credentials := resp.GetCredentialsList()
+
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
+				instanceLabel = model.InstanceId
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, credentials)
+			return outputResult(params.Printer, model.OutputFormat, instanceLabel, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -125,8 +122,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, credentials []mariadb.CredentialsListItem) error {
+func outputResult(p *print.Printer, outputFormat, instanceLabel string, credentials []mariadb.CredentialsListItem) error {
 	return p.OutputResult(outputFormat, credentials, func() error {
+		if len(credentials) == 0 {
+			p.Outputf("No credentials found for instance %q\n", instanceLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID")
 		for i := range credentials {

--- a/internal/cmd/mariadb/credentials/list/list_test.go
+++ b/internal/cmd/mariadb/credentials/list/list_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -27,9 +25,9 @@ var testInstanceId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:  testProjectId,
-		instanceIdFlag: testInstanceId,
-		limitFlag:      "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		instanceIdFlag:            testInstanceId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -82,21 +80,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -174,8 +172,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		credentials  []mariadb.CredentialsListItem
+		outputFormat  string
+		instanceLabel string
+		credentials   []mariadb.CredentialsListItem
 	}
 	tests := []struct {
 		name    string
@@ -207,7 +206,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.credentials); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.instanceLabel, tt.args.credentials); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -64,15 +64,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get MariaDB instances: %w", err)
 			}
-			instances := *resp.Instances
-			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No instances found for project %q\n", projectLabel)
-				return nil
+			instances := resp.GetInstances()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -80,7 +77,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, instances)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, instances)
 		},
 	}
 
@@ -120,8 +117,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, instances []mariadb.Instance) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, instances []mariadb.Instance) error {
 	return p.OutputResult(outputFormat, instances, func() error {
+		if len(instances) == 0 {
+			p.Outputf("No instances found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {

--- a/internal/cmd/mariadb/instance/list/list_test.go
+++ b/internal/cmd/mariadb/instance/list/list_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -26,8 +24,8 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -79,21 +77,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -151,6 +149,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		instances    []mariadb.Instance
 	}
 	tests := []struct {
@@ -183,7 +182,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.instances); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.instances); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -64,15 +64,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get MariaDB service plans: %w", err)
 			}
-			plans := *resp.Offerings
-			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No plans found for project %q\n", projectLabel)
-				return nil
+			plans := resp.GetOfferings()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -80,7 +77,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, plans)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, plans)
 		},
 	}
 
@@ -120,8 +117,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.API
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, plans []mariadb.Offering) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, plans []mariadb.Offering) error {
 	return p.OutputResult(outputFormat, plans, func() error {
+		if len(plans) == 0 {
+			p.Outputf("No plans found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("OFFERING NAME", "VERSION", "ID", "NAME", "DESCRIPTION")
 		for i := range plans {

--- a/internal/cmd/mariadb/plans/plans_test.go
+++ b/internal/cmd/mariadb/plans/plans_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -26,8 +24,8 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -79,21 +77,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -151,6 +149,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		plans        []mariadb.Offering
 	}
 	tests := []struct {
@@ -183,7 +182,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.plans); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.plans); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-263 / #893

## Testing instructions

1. With no mariadb instance present in your project: Verify output of list cmd
    - `stackit mariadb instance list` -> Expected output: `No instances found for project "xxx"`
    - `stackit mariadb instance list --output-format json` -> Should output valid JSON
    - `stackit mariadb instance list --output-format yaml` -> Should output valid YAML
2. Create a mariadb instance in your project: `stackit mariadb instance create --name my-instance --plan-name stackit-mariadb-1.2.10-replica --version 10.6`
3. With a mariadb instance present in your project: Verify output of list cmd again
    - `stackit mariadb instance list` -> Expected output: Table showing the mariadb instance(s)
    - `stackit mariadb instance list --output-format json` -> Should output valid JSON
    - `stackit mariadb instance list --output-format yaml` -> Should output valid YAML
4. Store the instance id into a env variable: `export INSTANCE_ID="xxx"`
5. With no credentials present for your mariadb instance: verify output of list cmd
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID` -> Expected output: `No credentials found for instance "my-instance"`
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID --output-format json` -> Should output valid JSON
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID --output-format yaml` -> Should output valid YAML
6. Create a credential: `stackit mariadb credentials create --instance-id $INSTANCE_ID`
7. With a credential present for your mariadb instance: verify output of list cmd again
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID` -> Expected output: Table showing the credential(s)
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID --output-format json` -> Should output valid JSON
    - `stackit mariadb credentials list --instance-id $INSTANCE_ID --output-format yaml` -> Should output valid YAML
8. Verify plan list output:
    - `stackit mariadb plans` -> Expected output: A table showing the available plans
    - `stackit mariadb plans --output-format json` -> Should output valid JSON
    - `stackit mariadb plans --output-format yaml` -> Should output valid YAML
9. Cleanup: Delete the mariadb instance: `stackit mariadb instance delete $INSTANCE_ID`

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
