### PR TITLE
fix(logme): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/logme/credentials/list/list_test.go
+++ b/internal/cmd/logme/credentials/list/list_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/logme"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -27,9 +25,9 @@ var testInstanceId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:  testProjectId,
-		instanceIdFlag: testInstanceId,
-		limitFlag:      "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		instanceIdFlag:            testInstanceId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -82,21 +80,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -174,8 +172,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		credentials  []logme.CredentialsListItem
+		outputFormat  string
+		instanceLabel string
+		credentials   []logme.CredentialsListItem
 	}
 	tests := []struct {
 		name    string
@@ -206,7 +205,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.credentials); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.instanceLabel, tt.args.credentials); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/logme/instance/list/list.go
+++ b/internal/cmd/logme/instance/list/list.go
@@ -64,15 +64,12 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get LogMe instances: %w", err)
 			}
-			instances := *resp.Instances
-			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No instances found for project %q\n", projectLabel)
-				return nil
+			instances := resp.GetInstances()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -80,7 +77,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, instances)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, instances)
 		},
 	}
 
@@ -120,8 +117,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logme.APICl
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, instances []logme.Instance) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, instances []logme.Instance) error {
 	return p.OutputResult(outputFormat, instances, func() error {
+		if len(instances) == 0 {
+			p.Outputf("No instances found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "LAST OPERATION TYPE", "LAST OPERATION STATE")
 		for i := range instances {

--- a/internal/cmd/logme/instance/list/list_test.go
+++ b/internal/cmd/logme/instance/list/list_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/logme"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -26,8 +24,8 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -79,21 +77,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -151,6 +149,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		instances    []logme.Instance
 	}
 	tests := []struct {
@@ -182,7 +181,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.instances); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.instances); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/logme/plans/plans_test.go
+++ b/internal/cmd/logme/plans/plans_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/logme"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -26,8 +24,8 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -79,21 +77,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -151,6 +149,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		plans        []logme.Offering
 	}
 	tests := []struct {
@@ -182,7 +181,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.plans); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.plans); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-264 / #893

## Testing

1. With no logme instance present in your project: Verify output of list cmd
    - `stackit logme instance list` -> Expected output: No instances found for project "xxx"
    - `stackit logme instance list --output-format json` -> Should output valid JSON
    - `stackit logme instance list --output-format yaml` -> Should output valid YAML
2. Create a logme instance in your project: ` stackit logme instance create --name my-instance2 --plan-name stackit-logme2-1.2.50-replica --version 2`
3. With a logme instance present in your project: Verify output of list cmd again
    - `stackit logme instance list` -> Expected output: Table showing the logme instance(s)
    - `stackit logme instance list --output-format json` -> Should output valid JSON
    - `stackit logme instance list --output-format yaml` -> Should output valid YAML
4. Store the instance id into a env variable: export INSTANCE_ID="xxx"
5. With no credentials being present for your logme instance: Verify output of list cmd
    - `stackit logme credentials list --instance-id $INSTANCE_ID` -> Expected output: `No credentials found for instance "my-instance2"
    - `stackit logme credentials list --instance-id $INSTANCE_ID --output-format json` -> Sould output valid JSON
    - `stackit logme credentials list --instance-id $INSTANCE_ID --output-format yaml` -> Sould output valid YAML
6. Create a credential for your logme instance: `stackit logme credentials create --instance-id $INSTANCE_ID`
7. With a credential being present for your logme instance: Verify output of list cmd again
    - `stackit logme credentials list --instance-id $INSTANCE_ID` -> Expected output: Table showing the existing credentials
    - `stackit logme credentials list --instance-id $INSTANCE_ID --output-format json` -> Sould output valid JSON
    - `stackit logme credentials list --instance-id $INSTANCE_ID --output-format yaml` -> Sould output valid YAML
8. Verify plan list output:
    - `stackit logme plans` -> Expected output: A table showing the available plans
    - `stackit logme plans --output-format json` -> Should output valid JSON
    - `stackit logme plans --output-format yaml` -> Should output valid YAML
9. Cleanup: Delete the mariadb instance: `stackit logme instance delete $INSTANCE_ID`

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
