### PR TITLE
fix(dns): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/dns/record-set/create/create_test.go
+++ b/internal/cmd/dns/record-set/create/create_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -34,13 +32,13 @@ var recordTxtOver255Char = []string{
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		zoneIdFlag:    testZoneId,
-		commentFlag:   "comment",
-		nameFlag:      "example.com",
-		recordFlag:    "1.1.1.1",
-		ttlFlag:       "3600",
-		typeFlag:      "SOA", // Non-default value
+		globalflags.ProjectIdFlag: testProjectId,
+		zoneIdFlag:                testZoneId,
+		commentFlag:               "comment",
+		nameFlag:                  "example.com",
+		recordFlag:                "1.1.1.1",
+		ttlFlag:                   "3600",
+		typeFlag:                  "SOA", // Non-default value
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -107,10 +105,10 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "required fields only",
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				zoneIdFlag:    testZoneId,
-				nameFlag:      "example.com",
-				recordFlag:    "1.1.1.1",
+				globalflags.ProjectIdFlag: testProjectId,
+				zoneIdFlag:                testZoneId,
+				nameFlag:                  "example.com",
+				recordFlag:                "1.1.1.1",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -127,12 +125,12 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "zero values",
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				zoneIdFlag:    testZoneId,
-				commentFlag:   "",
-				nameFlag:      "",
-				recordFlag:    "1.1.1.1",
-				ttlFlag:       "0",
+				globalflags.ProjectIdFlag: testProjectId,
+				zoneIdFlag:                testZoneId,
+				commentFlag:               "",
+				nameFlag:                  "",
+				recordFlag:                "1.1.1.1",
+				ttlFlag:                   "0",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -151,21 +149,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/record-set/delete/delete_test.go
+++ b/internal/cmd/dns/record-set/delete/delete_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -35,8 +33,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		zoneIdFlag:    testZoneId,
+		globalflags.ProjectIdFlag: testProjectId,
+		zoneIdFlag:                testZoneId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -104,7 +102,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -112,7 +110,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -120,7 +118,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/record-set/describe/describe_test.go
+++ b/internal/cmd/dns/record-set/describe/describe_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -36,8 +34,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		zoneIdFlag:    testZoneId,
+		globalflags.ProjectIdFlag: testProjectId,
+		zoneIdFlag:                testZoneId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -105,7 +103,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -113,7 +111,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -121,7 +119,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/record-set/list/list_test.go
+++ b/internal/cmd/dns/record-set/list/list_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -31,10 +29,10 @@ var testZoneId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:   testProjectId,
-		zoneIdFlag:      testZoneId,
-		nameLikeFlag:    "some-pattern",
-		orderByNameFlag: "asc",
+		globalflags.ProjectIdFlag: testProjectId,
+		zoneIdFlag:                testZoneId,
+		nameLikeFlag:              "some-pattern",
+		orderByNameFlag:           "asc",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -130,8 +128,8 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "required fields only",
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				zoneIdFlag:    testZoneId,
+				globalflags.ProjectIdFlag: testProjectId,
+				zoneIdFlag:                testZoneId,
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -146,21 +144,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -468,6 +466,7 @@ func TestFetchRecordSets(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		zoneLabel    string
 		recordSets   []dns.RecordSet
 	}
 	tests := []struct {
@@ -485,7 +484,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.recordSets); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.zoneLabel, tt.args.recordSets); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/dns/record-set/update/update_test.go
+++ b/internal/cmd/dns/record-set/update/update_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -45,12 +43,12 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		zoneIdFlag:    testZoneId,
-		commentFlag:   "comment",
-		nameFlag:      "example.com",
-		recordFlag:    "1.1.1.1",
-		ttlFlag:       "3600",
+		globalflags.ProjectIdFlag: testProjectId,
+		zoneIdFlag:                testZoneId,
+		commentFlag:               "comment",
+		nameFlag:                  "example.com",
+		recordFlag:                "1.1.1.1",
+		ttlFlag:                   "3600",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -132,8 +130,8 @@ func TestParseInput(t *testing.T) {
 			description: "required flags only (no values to update)",
 			argValues:   fixtureArgValues(),
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				zoneIdFlag:    testZoneId,
+				globalflags.ProjectIdFlag: testProjectId,
+				zoneIdFlag:                testZoneId,
 			},
 			isValid: false,
 			expectedModel: &inputModel{
@@ -149,12 +147,12 @@ func TestParseInput(t *testing.T) {
 			description: "zero values",
 			argValues:   fixtureArgValues(),
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				zoneIdFlag:    testZoneId,
-				commentFlag:   "",
-				nameFlag:      "",
-				recordFlag:    "1.1.1.1",
-				ttlFlag:       "0",
+				globalflags.ProjectIdFlag: testProjectId,
+				zoneIdFlag:                testZoneId,
+				commentFlag:               "",
+				nameFlag:                  "",
+				recordFlag:                "1.1.1.1",
+				ttlFlag:                   "0",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -174,7 +172,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -182,7 +180,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -190,7 +188,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/zone/clone/clone_test.go
+++ b/internal/cmd/dns/zone/clone/clone_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -36,11 +34,11 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:     testProjectId,
-		nameFlag:          "example",
-		dnsNameFlag:       "example.com",
-		descriptionFlag:   "Example",
-		adjustRecordsFlag: "false",
+		globalflags.ProjectIdFlag: testProjectId,
+		nameFlag:                  "example",
+		dnsNameFlag:               "example.com",
+		descriptionFlag:           "Example",
+		adjustRecordsFlag:         "false",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -117,8 +115,8 @@ func TestParseInput(t *testing.T) {
 			description: "required fields only",
 			argValues:   []string{testZoneId},
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				dnsNameFlag:   "example.com",
+				globalflags.ProjectIdFlag: testProjectId,
+				dnsNameFlag:               "example.com",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -134,7 +132,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -142,7 +140,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -150,7 +148,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/zone/create/create_test.go
+++ b/internal/cmd/dns/zone/create/create_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -25,20 +23,20 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:     testProjectId,
-		nameFlag:          "example",
-		dnsNameFlag:       "example.com",
-		defaultTTLFlag:    "3600",
-		aclFlag:           "0.0.0.0/0",
-		typeFlag:          string(dns.CREATEZONEPAYLOADTYPE_PRIMARY),
-		primaryFlag:       "1.1.1.1",
-		retryTimeFlag:     "600",
-		refreshTimeFlag:   "3600",
-		negativeCacheFlag: "60",
-		isReverseZoneFlag: "false",
-		expireTimeFlag:    "36000000",
-		descriptionFlag:   "Example",
-		contactEmailFlag:  "example@example.com",
+		globalflags.ProjectIdFlag: testProjectId,
+		nameFlag:                  "example",
+		dnsNameFlag:               "example.com",
+		defaultTTLFlag:            "3600",
+		aclFlag:                   "0.0.0.0/0",
+		typeFlag:                  string(dns.CREATEZONEPAYLOADTYPE_PRIMARY),
+		primaryFlag:               "1.1.1.1",
+		retryTimeFlag:             "600",
+		refreshTimeFlag:           "3600",
+		negativeCacheFlag:         "60",
+		isReverseZoneFlag:         "false",
+		expireTimeFlag:            "36000000",
+		descriptionFlag:           "Example",
+		contactEmailFlag:          "example@example.com",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -118,9 +116,9 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "required fields only",
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
-				nameFlag:      "example",
-				dnsNameFlag:   "example.com",
+				globalflags.ProjectIdFlag: testProjectId,
+				nameFlag:                  "example",
+				dnsNameFlag:               "example.com",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -135,19 +133,19 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "zero values",
 			flagValues: map[string]string{
-				projectIdFlag:     testProjectId,
-				nameFlag:          "",
-				dnsNameFlag:       "",
-				defaultTTLFlag:    "0",
-				aclFlag:           "",
-				typeFlag:          "",
-				retryTimeFlag:     "0",
-				refreshTimeFlag:   "0",
-				negativeCacheFlag: "0",
-				isReverseZoneFlag: "false",
-				expireTimeFlag:    "0",
-				descriptionFlag:   "",
-				contactEmailFlag:  "",
+				globalflags.ProjectIdFlag: testProjectId,
+				nameFlag:                  "",
+				dnsNameFlag:               "",
+				defaultTTLFlag:            "0",
+				aclFlag:                   "",
+				typeFlag:                  "",
+				retryTimeFlag:             "0",
+				refreshTimeFlag:           "0",
+				negativeCacheFlag:         "0",
+				isReverseZoneFlag:         "false",
+				expireTimeFlag:            "0",
+				descriptionFlag:           "",
+				contactEmailFlag:          "",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -173,21 +171,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/zone/delete/delete_test.go
+++ b/internal/cmd/dns/zone/delete/delete_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -34,7 +32,7 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -101,7 +99,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -109,7 +107,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -117,7 +115,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/zone/describe/describe_test.go
+++ b/internal/cmd/dns/zone/describe/describe_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -35,7 +33,7 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -102,7 +100,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -110,7 +108,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -118,7 +116,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/dns/zone/list/list_test.go
+++ b/internal/cmd/dns/zone/list/list_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -30,9 +28,9 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:   testProjectId,
-		nameLikeFlag:    "some-pattern",
-		orderByNameFlag: "asc",
+		globalflags.ProjectIdFlag: testProjectId,
+		nameLikeFlag:              "some-pattern",
+		orderByNameFlag:           "asc",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -127,7 +125,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "required fields only",
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
+				globalflags.ProjectIdFlag: testProjectId,
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -141,21 +139,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -462,6 +460,7 @@ func TestFetchZones(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		zones        []dns.Zone
 	}
 	tests := []struct {
@@ -479,7 +478,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.zones); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.zones); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/dns/zone/update/update_test.go
+++ b/internal/cmd/dns/zone/update/update_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -36,17 +34,17 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:     testProjectId,
-		nameFlag:          "example",
-		defaultTTLFlag:    "3600",
-		aclFlag:           "0.0.0.0/0",
-		primaryFlag:       "1.1.1.1",
-		retryTimeFlag:     "600",
-		refreshTimeFlag:   "3600",
-		negativeCacheFlag: "60",
-		expireTimeFlag:    "36000000",
-		descriptionFlag:   "Example",
-		contactEmailFlag:  "example@example.com",
+		globalflags.ProjectIdFlag: testProjectId,
+		nameFlag:                  "example",
+		defaultTTLFlag:            "3600",
+		aclFlag:                   "0.0.0.0/0",
+		primaryFlag:               "1.1.1.1",
+		retryTimeFlag:             "600",
+		refreshTimeFlag:           "3600",
+		negativeCacheFlag:         "60",
+		expireTimeFlag:            "36000000",
+		descriptionFlag:           "Example",
+		contactEmailFlag:          "example@example.com",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -136,7 +134,7 @@ func TestParseInput(t *testing.T) {
 			description: "required flags only (no values to update)",
 			argValues:   fixtureArgValues(),
 			flagValues: map[string]string{
-				projectIdFlag: testProjectId,
+				globalflags.ProjectIdFlag: testProjectId,
 			},
 			isValid: false,
 			expectedModel: &inputModel{
@@ -151,17 +149,17 @@ func TestParseInput(t *testing.T) {
 			description: "zero values",
 			argValues:   fixtureArgValues(),
 			flagValues: map[string]string{
-				projectIdFlag:     testProjectId,
-				nameFlag:          "",
-				defaultTTLFlag:    "0",
-				aclFlag:           "",
-				primaryFlag:       "",
-				retryTimeFlag:     "0",
-				refreshTimeFlag:   "0",
-				negativeCacheFlag: "0",
-				expireTimeFlag:    "0",
-				descriptionFlag:   "",
-				contactEmailFlag:  "",
+				globalflags.ProjectIdFlag: testProjectId,
+				nameFlag:                  "",
+				defaultTTLFlag:            "0",
+				aclFlag:                   "",
+				primaryFlag:               "",
+				retryTimeFlag:             "0",
+				refreshTimeFlag:           "0",
+				negativeCacheFlag:         "0",
+				expireTimeFlag:            "0",
+				descriptionFlag:           "",
+				contactEmailFlag:          "",
 			},
 			isValid: true,
 			expectedModel: &inputModel{
@@ -186,7 +184,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -194,7 +192,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -202,7 +200,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-266 / #893

## Testing

1. With no DNS zones present in your STACKIT project validate the output of the zone list command:
    - `stackit dns zone list` -> Expected output: `No zones found for project "xxx" matching the criteria`
    - `stackit dns zone list --output-format json` -> expected valid JSON output
    - `stackit dns zone list --output-format yaml` -> expected valid YAML output
2. Create a DNS zone: `stackit dns zone create --name my-zone --dns-name www.my-zone.com`
3. Store the zone id into a env variable: `export ZONE_ID="xxx"`
4. With a DNS zone present in your STACKIT project validate the output of the zone list command again:
    - `stackit dns zone list` -> Expected output: Table showing the available DNS zones
    - `stackit dns zone list --output-format json` -> expected valid JSON output
    - `stackit dns zone list --output-format yaml` -> expected valid YAML output
5. With the default DNS records available in your DNS zone: Validate the output of the record-set list command:
    - `stackit dns record-set list --zone-id $ZONE_ID` -> Expected output: Table showing the default DNS zone record sets
    - `stackit dns record-set list --zone-id $ZONE_ID --output-format json`  -> expected valid JSON output
    - `stackit dns record-set list --zone-id $ZONE_ID --output-format yaml`  -> expected valid YAML output
6. Cleanup
    - Delete the DNS zone you created: `stackit dns zone delete $ZONE_ID`

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
