### PR TITLE
fix(objectstorage): print valid JSON/YAML for list cmds

### DIFF
--- a/internal/cmd/object-storage/bucket/create/create_test.go
+++ b/internal/cmd/object-storage/bucket/create/create_test.go
@@ -15,16 +15,16 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
-var testBucketName = "my-bucket"
+
+const (
+	testRegion     = "eu01"
+	testBucketName = "my-bucket"
+)
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -38,8 +38,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -107,7 +107,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -115,7 +115,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -123,7 +123,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/bucket/delete/delete_test.go
+++ b/internal/cmd/object-storage/bucket/delete/delete_test.go
@@ -13,16 +13,16 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
-var testBucketName = "my-bucket"
+
+const (
+	testRegion     = "eu01"
+	testBucketName = "my-bucket"
+)
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -36,8 +36,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -105,7 +105,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -113,7 +113,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -121,7 +121,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/bucket/describe/describe_test.go
+++ b/internal/cmd/object-storage/bucket/describe/describe_test.go
@@ -15,16 +15,16 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
-var testBucketName = "my-bucket"
+
+const (
+	testRegion     = "eu01"
+	testBucketName = "my-bucket"
+)
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -38,8 +38,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -107,7 +107,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -115,7 +115,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -123,7 +123,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/bucket/list/list_test.go
+++ b/internal/cmd/object-storage/bucket/list/list_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -28,9 +25,9 @@ var testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -83,21 +80,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -155,6 +152,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		buckets      []objectstorage.Bucket
 	}
 	tests := []struct {
@@ -179,7 +177,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.buckets); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.buckets); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/object-storage/credentials-group/create/create_test.go
+++ b/internal/cmd/object-storage/credentials-group/create/create_test.go
@@ -16,22 +16,22 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testCredentialsGroupName = "test-name"
-var testRegion = "eu01"
+
+const (
+	testCredentialsGroupName = "test-name"
+	testRegion               = "eu01"
+)
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:            testProjectId,
-		credentialsGroupNameFlag: testCredentialsGroupName,
-		regionFlag:               testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		credentialsGroupNameFlag:  testCredentialsGroupName,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -95,21 +95,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/credentials-group/delete/delete_test.go
+++ b/internal/cmd/object-storage/credentials-group/delete/delete_test.go
@@ -13,16 +13,14 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
 var testCredentialsGroupId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -36,8 +34,8 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -105,7 +103,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -113,7 +111,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -121,7 +119,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/credentials-group/list/list.go
+++ b/internal/cmd/object-storage/credentials-group/list/list.go
@@ -63,11 +63,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list Object Storage credentials groups: %w", err)
 			}
-			credentialsGroups := *resp.CredentialsGroups
-			if len(credentialsGroups) == 0 {
-				params.Printer.Info("No credentials groups found for your project")
-				return nil
-			}
+			credentialsGroups := resp.GetCredentialsGroups()
 
 			// Truncate output
 			if model.Limit != nil && len(credentialsGroups) > int(*model.Limit) {
@@ -114,6 +110,11 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *objectstora
 
 func outputResult(p *print.Printer, outputFormat string, credentialsGroups []objectstorage.CredentialsGroup) error {
 	return p.OutputResult(outputFormat, credentialsGroups, func() error {
+		if len(credentialsGroups) == 0 {
+			p.Outputf("No credentials groups found for your project")
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "URN")
 		for i := range credentialsGroups {

--- a/internal/cmd/object-storage/credentials-group/list/list_test.go
+++ b/internal/cmd/object-storage/credentials-group/list/list_test.go
@@ -16,21 +16,19 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		limitFlag:     "10",
-		regionFlag:    "eu01",
+		globalflags.ProjectIdFlag: testProjectId,
+		limitFlag:                 "10",
+		globalflags.RegionFlag:    "eu01",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -83,21 +81,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/credentials/create/create_test.go
+++ b/internal/cmd/object-storage/credentials/create/create_test.go
@@ -17,24 +17,24 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
 var testCredentialsGroupId = uuid.NewString()
-var testExpirationDate = "2024-01-01T00:00:00Z"
-var testRegion = "eu01"
+
+const (
+	testExpirationDate = "2024-01-01T00:00:00Z"
+	testRegion         = "eu01"
+)
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:          testProjectId,
-		credentialsGroupIdFlag: testCredentialsGroupId,
-		expireDateFlag:         testExpirationDate,
-		regionFlag:             testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		credentialsGroupIdFlag:    testCredentialsGroupId,
+		expireDateFlag:            testExpirationDate,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -109,21 +109,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/credentials/delete/delete_test.go
+++ b/internal/cmd/object-storage/credentials/delete/delete_test.go
@@ -13,17 +13,17 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
 var testCredentialsGroupId = uuid.NewString()
-var testCredentialsId = "keyID"
-var testRegion = "eu01"
+
+const (
+	testCredentialsId = "keyID"
+	testRegion        = "eu01"
+)
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
@@ -37,9 +37,9 @@ func fixtureArgValues(mods ...func(argValues []string)) []string {
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:          testProjectId,
-		credentialsGroupIdFlag: testCredentialsGroupId,
-		regionFlag:             testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		credentialsGroupIdFlag:    testCredentialsGroupId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -109,7 +109,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id missing",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
@@ -117,7 +117,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 1",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
@@ -125,7 +125,7 @@ func TestParseInput(t *testing.T) {
 			description: "project id invalid 2",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/credentials/list/list_test.go
+++ b/internal/cmd/object-storage/credentials/list/list_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -29,10 +26,10 @@ var testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag:          testProjectId,
-		credentialsGroupIdFlag: testCredentialsGroupId,
-		limitFlag:              "10",
-		regionFlag:             testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		credentialsGroupIdFlag:    testCredentialsGroupId,
+		limitFlag:                 "10",
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -87,21 +84,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},
@@ -179,8 +176,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		credentials  []objectstorage.AccessKey
+		outputFormat          string
+		credentialsGroupLabel string
+		credentials           []objectstorage.AccessKey
 	}
 	tests := []struct {
 		name    string
@@ -211,7 +209,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.credentials); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.credentialsGroupLabel, tt.args.credentials); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/object-storage/disable/disable_test.go
+++ b/internal/cmd/object-storage/disable/disable_test.go
@@ -13,20 +13,18 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -78,21 +76,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/object-storage/enable/enable_test.go
+++ b/internal/cmd/object-storage/enable/enable_test.go
@@ -13,20 +13,18 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-var regionFlag = globalflags.RegionFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &objectstorage.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
-		regionFlag:    testRegion,
+		globalflags.ProjectIdFlag: testProjectId,
+		globalflags.RegionFlag:    testRegion,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -78,21 +76,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->
relates to STACKITCLI-267 / #893

## Testing

1. With no object storage bucket present in your project, verify the bucket list command output:
    - `stackit object-storage bucket list` -> Expected output: `No buckets found for project xxx`
    - `stackit object-storage bucket list --output-format json` -> expected: valid JSON output
    - `stackit object-storage bucket list --output-format yaml` -> expected: valid YAML output
3. Create an object storage bucket: `stackit object-storage bucket create my-bucket`
4. With an object storage bucket present in your project, verify the bucket list command output again:
     - `stackit object-storage bucket list` -> Expected output: Table showing the available object storage buckets
    - `stackit object-storage bucket list --output-format json` -> expected: valid JSON output
    - `stackit object-storage bucket list --output-format yaml` -> expected: valid YAML output
5. Verify the output of the credentials group list command (FYI: it's not possible to verify this for the case where no object storage credentials group is present in the project because there's always a default group present)
    - `stackit object-storage credentials-group list` -> Expected output: Table showing the available object storage credentials groups
    - `stackit object-storage credentials-group list --output-format json` -> expected: valid JSON output
    - `stackit object-storage credentials-group list --output-format yaml` -> expected: valid YAML output
7. Choose one from the existing credentials groups (with existing credentials in them) and verify the credentials list command for them:
    - `stackit object-storage credentials list --credentials-group-id xxx` -> Expected output: Table showing the available credentials
    - `stackit object-storage credentials list --credentials-group-id xxx --output-format json` -> expected: valid JSON output
    - `stackit object-storage credentials list --credentials-group-id xxx --output-format yaml` -> expected: valid YAML output
8. Create a new credential group (`stackit object-storage credentials-group create --name example`), then verify the credential list command output for it again
    - `stackit object-storage credentials list --credentials-group-id xxx` -> Expected output: `No credentials found for credentials group "example"`
    - `stackit object-storage credentials list --credentials-group-id xxx --output-format json` -> expected: valid JSON output
    - `stackit object-storage credentials list --credentials-group-id xxx --output-format yaml` -> expected: valid YAML output
10. Cleanup: 
    - Delete the credentials group you created: `stackit object-storage credentials-group delete xxx`
    - Delete the object storage bucket: `stackit object-storage bucket delete my-bucket`

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
