### PR TITLE
fix(sqlserverflex): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/beta/sqlserverflex/database/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list_test.go
@@ -21,7 +21,8 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &sqlserverflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -175,6 +176,8 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		instanceId   string
+		projectLabel string
 		databases    []sqlserverflex.Database
 	}
 	tests := []struct {
@@ -199,7 +202,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.databases); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.instanceId, tt.args.projectLabel, tt.args.databases); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/beta/sqlserverflex/instance/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list_test.go
@@ -20,7 +20,8 @@ type testCtxKey struct{}
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &sqlserverflex.APIClient{}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -151,6 +152,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		instances    []sqlserverflex.InstanceListInstance
 	}
 	tests := []struct {
@@ -175,7 +177,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.instances); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.instances); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/beta/sqlserverflex/user/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list_test.go
@@ -21,7 +21,8 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &sqlserverflex.APIClient{}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -167,8 +168,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		users        []sqlserverflex.InstanceListUser
+		outputFormat  string
+		instanceLabel string
+		users         []sqlserverflex.InstanceListUser
 	}
 	tests := []struct {
 		name    string
@@ -192,7 +194,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.users); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.instanceLabel, tt.args.users); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->
relates to STACKITCLI-272 / #893

## Testing

1. Verify the output of the instance list command with no sqlserverflex instance available in your project:
    - `stackit beta sqlserverflex instance list` -> Expected output: `No instances found for project "xxx"`
    - `stackit beta sqlserverflex instance list --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex instance list --output-format yaml` -> expected valid YAML output
2. Create a sqlserverflex instance: `stackit beta sqlserverflex instance create --name my-instance --flavor-id 4.16-Single --storage-size 20`
3. Store the id of your instance into an env variable: `export INSTANCE_ID="xxx"`
4. With some instance available in your project, verify the output of the instance list command again:
    - `stackit beta sqlserverflex instance list` -> Expected output: Table showing the available instances
    - `stackit beta sqlserverflex instance list --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex instance list --output-format yaml` -> expected valid YAML output
5. With no users present for your instance, verify the output of the user list command:
    - `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID` -> Expected output: `No users found for instance "my-instance"`
    -  `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID --output-format yaml` -> expected valid YAML output
6. Create a user for your instance: `stackit beta sqlserverflex user create --instance-id $INSTANCE_ID --username johndoe --roles "##STACKIT_DatabaseManager##"`
7. With a user present for your instance, verify the output of the user list command again:
    - `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID` -> Expected output: Table showing the available users
    -  `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex user list --instance-id $INSTANCE_ID --output-format yaml` -> expected valid YAML output
8. With no databases available for your instance, verify the output of the database list command:
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID` -> Expected output: `No databases found for instance xxx on xxx`
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID --output-format yaml` -> expected valid YAML output
9. Create a database: `stackit beta sqlserverflex database create my-database --instance-id $INSTANCE_ID --owner johndoe`
10. With a database available for your instance, verify the output of the database list command:
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID` -> Expected output: Table showing the available databases
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID --output-format json` -> expected valid JSON output
    - `stackit beta sqlserverflex database list --instance-id $INSTANCE_ID --output-format yaml` -> expected valid YAML output
11. Validate the output of the options list command:
    - Flavors:
        - `stackit beta sqlserverflex options --flavors` -> Expected output: Table showing the available flavors
        - `stackit beta sqlserverflex options --flavors --output-format json` -> expected valid JSON output
        - `stackit beta sqlserverflex options --flavors --output-format yaml` -> expected valid YAML output
    - Versions:         
        - `stackit beta sqlserverflex options --versions` -> Expected output: Table showing the available versions
        - `stackit beta sqlserverflex options --versions --output-format json` -> expected valid JSON output
        - `stackit beta sqlserverflex options --versions --output-format yaml` -> expected valid YAML output
    - ...
12. Cleanup - Delete the instance: `stackit beta sqlserverflex instance delete $INSTANCE_ID` 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
