### PR TITLE
fix(alb): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/beta/alb/list/list_test.go
+++ b/internal/cmd/beta/alb/list/list_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -19,11 +21,14 @@ import (
 type testCtxKey struct{}
 
 var (
-	testCtx             = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient          = &alb.APIClient{}
-	testProjectId       = uuid.NewString()
-	testRegion          = "eu01"
-	testLimit     int64 = 10
+	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient    = &alb.APIClient{}
+	testProjectId = uuid.NewString()
+)
+
+const (
+	testRegion       = "eu01"
+	testLimit  int64 = 10
 )
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -41,7 +46,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	model := &inputModel{
 		GlobalFlagModel: &globalflags.GlobalFlagModel{ProjectId: testProjectId, Region: testRegion, Verbosity: globalflags.VerbosityDefault},
-		Limit:           &testLimit,
+		Limit:           utils.Ptr(testLimit),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -136,6 +141,7 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		items        []alb.LoadBalancer
 	}
 	tests := []struct {
@@ -164,7 +170,7 @@ func Test_outputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.items); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.items); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/beta/alb/observability-credentials/list/list.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list.go
@@ -68,13 +68,9 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list credentials: %w", err)
 			}
+			items := resp.GetCredentials()
 
-			if resp.Credentials == nil || len(*resp.Credentials) == 0 {
-				params.Printer.Info("No credentials found\n")
-				return nil
-			}
-
-			items := *resp.Credentials
+			// Truncate output
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
@@ -116,12 +112,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 }
 
 func outputResult(p *print.Printer, outputFormat string, items []alb.CredentialsResponse) error {
-	if items == nil {
-		p.Outputln("no credentials found")
-		return nil
-	}
-
 	return p.OutputResult(outputFormat, items, func() error {
+		if len(items) == 0 {
+			p.Outputf("No credentials found\n")
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("CREDENTIAL REF", "DISPLAYNAME", "USERNAME", "REGION")
 

--- a/internal/cmd/beta/alb/plans/plans_test.go
+++ b/internal/cmd/beta/alb/plans/plans_test.go
@@ -21,8 +21,9 @@ var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	testClient    = &alb.APIClient{}
 	testProjectId = uuid.NewString()
-	testRegion    = "eu01"
 )
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -132,6 +133,7 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		items        []alb.PlanDetails
 	}
 	tests := []struct {
@@ -160,7 +162,7 @@ func Test_outputResult(t *testing.T) {
 	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.items); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.projectLabel, tt.args.items); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-273 / #893

## Testing

1. With no application load balancers available in your STACKIT project verify the output of the application load balancer list command: 
    - `stackit beta alb list` -> Expected output: `No load balancers found for project "dev-tools-e2e-test"`
    - `stackit beta alb list --output-format json` -> expected valid JSON output
    - `stackit beta alb list --output-format YAML` -> expected valid YAML output
2. With no application load balancer observability credential present, verify the output of the credentials list command:
    - `stackit beta alb observability-credentials list` -> Expected output: `no credentials found`
    - `stackit beta alb observability-credentials list --output-format json` -> expected valid JSON output
    - `stackit beta alb observability-credentials list --output-format yaml` -> expected valid YAML output
3. Create some observability credential: `stackit beta alb observability-credentials add --displayname "abc" --username "abc" --password "abc"`
4. With some application load balancer observability credential present, verify the output of the credentials list command again:
    - `stackit beta alb observability-credentials list` -> Expected output: Table showing the available credentials
    - `stackit beta alb observability-credentials list --output-format json` -> expected valid JSON output
    - `stackit beta alb observability-credentials list --output-format yaml` -> expected valid YAML output
5. Verify the output of the plans list command:
    - `stackit beta alb plans` -> Expected output: Table showing the available plans
    - `stackit beta alb plans --output-format json` -> expected valid JSON output
    - `stackit beta alb plans --output-format YAML` -> expected valid YAML output
6. Cleanup:
    - Delete the observability credential: `stackit beta alb observability-credentials delete credentials-xxxx`

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
