### PR TITLE
add readAnyDatabase and stackitAdmin roles for MongoDB users

### DIFF
--- a/docs/stackit_mongodbflex_user_create.md
+++ b/docs/stackit_mongodbflex_user_create.md
@@ -29,7 +29,7 @@ stackit mongodbflex user create [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user create"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, possible values are ["read" "readWrite" "readAnyDatabase" "readWriteAnyDatabase" "stackitAdmin"] (default [read])
+      --role strings         Roles of the user, possible values are ["read" "readWrite" "readAnyDatabase" "readWriteAnyDatabase" "stackitAdmin"]. The "readAnyDatabase", "readWriteAnyDatabase" and "stackitAdmin" roles will always be created in the admin database. (default [read])
       --username string      Username of the user. If not specified, a random username will be assigned
 ```
 

--- a/docs/stackit_mongodbflex_user_update.md
+++ b/docs/stackit_mongodbflex_user_update.md
@@ -23,7 +23,7 @@ stackit mongodbflex user update USER_ID [flags]
       --database string      The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it
   -h, --help                 Help for "stackit mongodbflex user update"
       --instance-id string   ID of the instance
-      --role strings         Roles of the user, possible values are ["read" "readWrite" "readAnyDatabase" "readWriteAnyDatabase" "stackitAdmin"] (default [])
+      --role strings         Roles of the user, possible values are ["read" "readWrite" "readAnyDatabase" "readWriteAnyDatabase" "stackitAdmin"]. The "readAnyDatabase", "readWriteAnyDatabase" and "stackitAdmin" roles will always be created in the admin database. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -106,7 +106,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(usernameFlag, "", "Username of the user. If not specified, a random username will be assigned")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, rolesDefault, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q. The \"readAnyDatabase\", \"readWriteAnyDatabase\" and \"stackitAdmin\" roles will always be created in the admin database.", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, databaseFlag)
 	cobra.CheckErr(err)

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -101,7 +101,7 @@ func configureFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the instance")
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
-	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q", roleOptions))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, nil, roleOptions...), roleFlag, fmt.Sprintf("Roles of the user, possible values are %q. The \"readAnyDatabase\", \"readWriteAnyDatabase\" and \"stackitAdmin\" roles will always be created in the admin database.", roleOptions))
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)


### PR DESCRIPTION
## Description

Adding additional roles for MongoDB users. Taken from the [API Docs](https://docs.api.stackit.cloud/documentation/mongodb-flex-service/version/v2#tag/user/paths/~1v2~1projects~1%7BprojectId%7D~1regions~1%7Bregion%7D~1instances~1%7BinstanceId%7D~1users/post).

## Checklist

- [ ] ~Issue was linked above~
- [x] Code format was applied: `make fmt`
- [ ] ~Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))~
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] ~Unit tests got implemented or updated~
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
