### PR TITLE
feat(logs): improve output for server logs

### DIFF
--- a/internal/cmd/server/log/log_test.go
+++ b/internal/cmd/server/log/log_test.go
@@ -184,9 +184,8 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		serverLabel  string
-		log          string
+		serverLabel string
+		logLines    []string
 	}
 	tests := []struct {
 		name    string
@@ -203,7 +202,7 @@ func TestOutputResult(t *testing.T) {
 	p.Cmd = NewCmd(&types.CmdParams{Printer: p})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(p, tt.args.outputFormat, tt.args.serverLabel, tt.args.log); (err != nil) != tt.wantErr {
+			if err := outputResult(p, tt.args.serverLabel, tt.args.logLines); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

This PR improves the output of server logs to make it more human readable. The screenshot shows old and new output

<img width="1512" height="831" alt="Screenshot 2025-10-23 at 09 41 36" src="https://github.com/user-attachments/assets/4c444266-8ceb-47f3-bce8-e78bd49d5526" />

## Checklist
- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
