### PR TITLE
chore(client): Refactor ConfigureClient() function to use a generic f…

### DIFF
--- a/.github/docs/contribution-guide/client.go
+++ b/.github/docs/contribution-guide/client.go
@@ -2,46 +2,12 @@ package client
 
 import (
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/foo"
 	// (...)
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*foo.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		return nil, &errors.AuthError{}
-	}
-
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region), // Configuring region is needed if "foo" is a regional API
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.fooCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := foo.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.fooCustomEndpointKey), false, genericclient.CreateApiClient[*foo.APIClient](foo.NewAPIClient))
 }

--- a/internal/cmd/git/flavor/list/list.go
+++ b/internal/cmd/git/flavor/list/list.go
@@ -49,7 +49,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/git/instance/create/create.go
+++ b/internal/cmd/git/instance/create/create.go
@@ -61,7 +61,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/git/instance/delete/delete.go
+++ b/internal/cmd/git/instance/delete/delete.go
@@ -46,7 +46,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/git/instance/describe/describe.go
+++ b/internal/cmd/git/instance/describe/describe.go
@@ -42,7 +42,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/git/instance/list/list.go
+++ b/internal/cmd/git/instance/list/list.go
@@ -50,7 +50,7 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer)
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -23,6 +23,7 @@ const (
 	AllowedUrlDomainKey                             = "allowed_url_domain"
 
 	AuthorizationCustomEndpointKey     = "authorization_custom_endpoint"
+	AlbCustomEndpoint                  = "alb_custom _endpoint"
 	DNSCustomEndpointKey               = "dns_custom_endpoint"
 	LoadBalancerCustomEndpointKey      = "load_balancer_custom_endpoint"
 	LogMeCustomEndpointKey             = "logme_custom_endpoint"
@@ -107,6 +108,7 @@ var ConfigKeys = []string{
 	IaaSCustomEndpointKey,
 	TokenCustomEndpointKey,
 	GitCustomEndpointKey,
+	AlbCustomEndpoint,
 }
 
 var defaultConfigFolderPath string
@@ -193,6 +195,7 @@ func setConfigDefaults() {
 	viper.SetDefault(IaaSCustomEndpointKey, "")
 	viper.SetDefault(TokenCustomEndpointKey, "")
 	viper.SetDefault(GitCustomEndpointKey, "")
+	viper.SetDefault(AlbCustomEndpoint, "")
 }
 
 func getConfigFilePath(configFolder string) string {

--- a/internal/pkg/generic-client/generic_client.go
+++ b/internal/pkg/generic-client/generic_client.go
@@ -1,0 +1,50 @@
+package genericclient
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
+)
+
+type CreateApiClient[T any] func(opts ...sdkConfig.ConfigurationOption) (T, error)
+
+// ConfigureClientGeneric contains the generic code which needs to be executed in order to configure the api client.
+func ConfigureClientGeneric[T any](p *print.Printer, cliVersion, customEndpoint string, useRegion bool, createApiClient CreateApiClient[T]) (T, error) {
+	// return value if an error happens
+	var zero T
+	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
+	if err != nil {
+		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
+		return zero, &errors.AuthError{}
+	}
+	cfgOptions := []sdkConfig.ConfigurationOption{
+		utils.UserAgentConfigOption(cliVersion),
+		authCfgOption,
+	}
+
+	if customEndpoint != "" {
+		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
+	}
+
+	if useRegion {
+		cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(viper.GetString(config.RegionKey)))
+	}
+
+	if p.IsVerbosityDebug() {
+		cfgOptions = append(cfgOptions,
+			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
+		)
+	}
+
+	apiClient, err := createApiClient(cfgOptions...)
+	if err != nil {
+		p.Debug(print.ErrorLevel, "create new API client: %v", err)
+		return zero, &errors.AuthError{}
+	}
+
+	return apiClient, nil
+}

--- a/internal/pkg/services/alb/client/client.go
+++ b/internal/pkg/services/alb/client/client.go
@@ -1,44 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*alb.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.IaaSCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := alb.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.AlbCustomEndpoint), true, genericclient.CreateApiClient[*alb.APIClient](alb.NewAPIClient))
 }

--- a/internal/pkg/services/authorization/client/client.go
+++ b/internal/pkg/services/authorization/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*authorization.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.AuthorizationCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := authorization.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.AuthorizationCustomEndpointKey), false, genericclient.CreateApiClient[*authorization.APIClient](authorization.NewAPIClient))
 }

--- a/internal/pkg/services/dns/client/client.go
+++ b/internal/pkg/services/dns/client/client.go
@@ -1,46 +1,15 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*dns.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.DNSCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := dns.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.DNSCustomEndpointKey), false, genericclient.CreateApiClient[*dns.APIClient](dns.NewAPIClient))
 }

--- a/internal/pkg/services/git/client/client.go
+++ b/internal/pkg/services/git/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/git"
 )
 
-func ConfigureClient(p *print.Printer) (*git.APIClient, error) {
-	var err error
-	var apiClient *git.APIClient
-	var cfgOptions []sdkConfig.ConfigurationOption
-
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions = append(cfgOptions, authCfgOption)
-
-	customEndpoint := viper.GetString(config.GitCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err = git.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+func ConfigureClient(p *print.Printer, cliVersion string) (*git.APIClient, error) {
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.GitCustomEndpointKey), false, genericclient.CreateApiClient[*git.APIClient](git.NewAPIClient))
 }

--- a/internal/pkg/services/iaas/client/client.go
+++ b/internal/pkg/services/iaas/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*iaas.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.IaaSCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		region := viper.GetString(config.RegionKey)
-		cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := iaas.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.IaaSCustomEndpointKey), true, genericclient.CreateApiClient[*iaas.APIClient](iaas.NewAPIClient))
 }

--- a/internal/pkg/services/kms/client/client.go
+++ b/internal/pkg/services/kms/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/kms"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*kms.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.KMSCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := kms.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.KMSCustomEndpointKey), false, genericclient.CreateApiClient[*kms.APIClient](kms.NewAPIClient))
 }

--- a/internal/pkg/services/load-balancer/client/client.go
+++ b/internal/pkg/services/load-balancer/client/client.go
@@ -1,44 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*loadbalancer.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.LoadBalancerCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := loadbalancer.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.LoadBalancerCustomEndpointKey), false, genericclient.CreateApiClient[*loadbalancer.APIClient](loadbalancer.NewAPIClient))
 }

--- a/internal/pkg/services/logme/client/client.go
+++ b/internal/pkg/services/logme/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/logme"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*logme.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.LogMeCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := logme.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.LogMeCustomEndpointKey), true, genericclient.CreateApiClient[*logme.APIClient](logme.NewAPIClient))
 }

--- a/internal/pkg/services/mariadb/client/client.go
+++ b/internal/pkg/services/mariadb/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*mariadb.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.MariaDBCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := mariadb.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.MariaDBCustomEndpointKey), true, genericclient.CreateApiClient[*mariadb.APIClient](mariadb.NewAPIClient))
 }

--- a/internal/pkg/services/mongodbflex/client/client.go
+++ b/internal/pkg/services/mongodbflex/client/client.go
@@ -1,44 +1,13 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*mongodbflex.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.MongoDBFlexCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := mongodbflex.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.MongoDBFlexCustomEndpointKey), false, genericclient.CreateApiClient[*mongodbflex.APIClient](mongodbflex.NewAPIClient))
 }

--- a/internal/pkg/services/object-storage/client/client.go
+++ b/internal/pkg/services/object-storage/client/client.go
@@ -1,48 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*objectstorage.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ObjectStorageCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := objectstorage.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ObjectStorageCustomEndpointKey), true, genericclient.CreateApiClient[*objectstorage.APIClient](objectstorage.NewAPIClient))
 }

--- a/internal/pkg/services/observability/client/client.go
+++ b/internal/pkg/services/observability/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/observability"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*observability.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ObservabilityCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := observability.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ObservabilityCustomEndpointKey), true, genericclient.CreateApiClient[*observability.APIClient](observability.NewAPIClient))
 }

--- a/internal/pkg/services/opensearch/client/client.go
+++ b/internal/pkg/services/opensearch/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/opensearch"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*opensearch.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.OpenSearchCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := opensearch.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.OpenSearchCustomEndpointKey), true, genericclient.CreateApiClient[*opensearch.APIClient](opensearch.NewAPIClient))
 }

--- a/internal/pkg/services/postgresflex/client/client.go
+++ b/internal/pkg/services/postgresflex/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*postgresflex.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.PostgresFlexCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := postgresflex.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.PostgresFlexCustomEndpointKey), true, genericclient.CreateApiClient[*postgresflex.APIClient](postgresflex.NewAPIClient))
 }

--- a/internal/pkg/services/rabbitmq/client/client.go
+++ b/internal/pkg/services/rabbitmq/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*rabbitmq.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.RabbitMQCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := rabbitmq.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.RabbitMQCustomEndpointKey), true, genericclient.CreateApiClient[*rabbitmq.APIClient](rabbitmq.NewAPIClient))
 }

--- a/internal/pkg/services/redis/client/client.go
+++ b/internal/pkg/services/redis/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/redis"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*redis.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.RedisCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := redis.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.RedisCustomEndpointKey), true, genericclient.CreateApiClient[*redis.APIClient](redis.NewAPIClient))
 }

--- a/internal/pkg/services/resourcemanager/client/client.go
+++ b/internal/pkg/services/resourcemanager/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*resourcemanager.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ResourceManagerEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := resourcemanager.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ResourceManagerEndpointKey), false, genericclient.CreateApiClient[*resourcemanager.APIClient](resourcemanager.NewAPIClient))
 }

--- a/internal/pkg/services/runcommand/client/client.go
+++ b/internal/pkg/services/runcommand/client/client.go
@@ -1,46 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*runcommand.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.RunCommandCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		cfgOptions = append(cfgOptions, authCfgOption)
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := runcommand.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.RunCommandCustomEndpointKey), false, genericclient.CreateApiClient[*runcommand.APIClient](runcommand.NewAPIClient))
 }

--- a/internal/pkg/services/secrets-manager/client/client.go
+++ b/internal/pkg/services/secrets-manager/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*secretsmanager.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	region := viper.GetString(config.RegionKey)
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		sdkConfig.WithRegion(region),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.SecretsManagerCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := secretsmanager.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.SecretsManagerCustomEndpointKey), true, genericclient.CreateApiClient[*secretsmanager.APIClient](secretsmanager.NewAPIClient))
 }

--- a/internal/pkg/services/serverbackup/client/client.go
+++ b/internal/pkg/services/serverbackup/client/client.go
@@ -1,47 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serverbackup.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ServerBackupCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		region := viper.GetString(config.RegionKey)
-		cfgOptions = append(cfgOptions, authCfgOption, sdkConfig.WithRegion(region))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := serverbackup.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServerBackupCustomEndpointKey), true, genericclient.CreateApiClient[*serverbackup.APIClient](serverbackup.NewAPIClient))
 }

--- a/internal/pkg/services/serverosupdate/client/client.go
+++ b/internal/pkg/services/serverosupdate/client/client.go
@@ -1,46 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serverupdate.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ServerOsUpdateCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		cfgOptions = append(cfgOptions, authCfgOption)
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := serverupdate.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServerOsUpdateCustomEndpointKey), false, genericclient.CreateApiClient[*serverupdate.APIClient](serverupdate.NewAPIClient))
 }

--- a/internal/pkg/services/service-account/client/client.go
+++ b/internal/pkg/services/service-account/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serviceaccount.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ServiceAccountCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := serviceaccount.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServiceAccountCustomEndpointKey), false, genericclient.CreateApiClient[*serviceaccount.APIClient](serviceaccount.NewAPIClient))
 }

--- a/internal/pkg/services/service-enablement/client/client.go
+++ b/internal/pkg/services/service-enablement/client/client.go
@@ -2,46 +2,13 @@ package client
 
 import (
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serviceenablement.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.ServiceEnablementCustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		region := viper.GetString(config.RegionKey)
-		cfgOptions = append(cfgOptions, sdkConfig.WithRegion(region))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := serviceenablement.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServiceEnablementCustomEndpointKey), true, genericclient.CreateApiClient[*serviceenablement.APIClient](serviceenablement.NewAPIClient))
 }

--- a/internal/pkg/services/ske/client/client.go
+++ b/internal/pkg/services/ske/client/client.go
@@ -1,46 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*ske.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.SKECustomEndpointKey)
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	} else {
-		cfgOptions = append(cfgOptions, authCfgOption)
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := ske.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.SKECustomEndpointKey), false, genericclient.CreateApiClient[*ske.APIClient](ske.NewAPIClient))
 }

--- a/internal/pkg/services/sqlserverflex/client/client.go
+++ b/internal/pkg/services/sqlserverflex/client/client.go
@@ -1,45 +1,14 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/viper"
-	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*sqlserverflex.APIClient, error) {
-	authCfgOption, err := auth.AuthenticationConfig(p, auth.AuthorizeUser)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "configure authentication: %v", err)
-		return nil, &errors.AuthError{}
-	}
-	cfgOptions := []sdkConfig.ConfigurationOption{
-		utils.UserAgentConfigOption(cliVersion),
-		authCfgOption,
-	}
-
-	customEndpoint := viper.GetString(config.SQLServerFlexCustomEndpointKey)
-
-	if customEndpoint != "" {
-		cfgOptions = append(cfgOptions, sdkConfig.WithEndpoint(customEndpoint))
-	}
-
-	if p.IsVerbosityDebug() {
-		cfgOptions = append(cfgOptions,
-			sdkConfig.WithMiddleware(print.RequestResponseCapturer(p, nil)),
-		)
-	}
-
-	apiClient, err := sqlserverflex.NewAPIClient(cfgOptions...)
-	if err != nil {
-		p.Debug(print.ErrorLevel, "create new API client: %v", err)
-		return nil, &errors.AuthError{}
-	}
-
-	return apiClient, nil
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.SQLServerFlexCustomEndpointKey), false, genericclient.CreateApiClient[*sqlserverflex.APIClient](sqlserverflex.NewAPIClient))
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

The ConfigureClient() method was implemented for all clients with almost the same code. In order to reduce this code duplication a generic method was defined. The ConfigureClient() method is still present but is only a wrapper which means that the normal code does not need to be changed at all. This generic function still uses the region as parameter for some clients. This will be adjusted when all services have implemented the region adjustment.

For testing just execute the list command for every service (except the git service).

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
