### PR TITLE
feat(iaas): onboard network-area region commands

### DIFF
--- a/docs/stackit_network-area.md
+++ b/docs/stackit_network-area.md
@@ -35,6 +35,7 @@ stackit network-area [flags]
 * [stackit network-area describe](./stackit_network-area_describe.md)	 - Shows details of a STACKIT Network Area
 * [stackit network-area list](./stackit_network-area_list.md)	 - Lists all STACKIT Network Areas (SNA) of an organization
 * [stackit network-area network-range](./stackit_network-area_network-range.md)	 - Provides functionality for network ranges in STACKIT Network Areas
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
 * [stackit network-area route](./stackit_network-area_route.md)	 - Provides functionality for static routes in STACKIT Network Areas
 * [stackit network-area update](./stackit_network-area_update.md)	 - Updates a STACKIT Network Area (SNA)
 

--- a/docs/stackit_network-area_region.md
+++ b/docs/stackit_network-area_region.md
@@ -1,0 +1,38 @@
+## stackit network-area region
+
+Provides functionality for regional configuration of STACKIT Network Area (SNA)
+
+### Synopsis
+
+Provides functionality for regional configuration of STACKIT Network Area (SNA).
+
+```
+stackit network-area region [flags]
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit network-area region"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area](./stackit_network-area.md)	 - Provides functionality for STACKIT Network Area (SNA)
+* [stackit network-area region create](./stackit_network-area_region_create.md)	 - Creates a new regional configuration for a STACKIT Network Area (SNA)
+* [stackit network-area region delete](./stackit_network-area_region_delete.md)	 - Deletes a regional configuration for a STACKIT Network Area (SNA)
+* [stackit network-area region describe](./stackit_network-area_region_describe.md)	 - Describes a regional configuration for a STACKIT Network Area (SNA)
+* [stackit network-area region list](./stackit_network-area_region_list.md)	 - Lists all configured regions for a STACKIT Network Area (SNA)
+* [stackit network-area region update](./stackit_network-area_region_update.md)	 - Updates a existing regional configuration for a STACKIT Network Area (SNA)
+

--- a/docs/stackit_network-area_region_create.md
+++ b/docs/stackit_network-area_region_create.md
@@ -1,0 +1,58 @@
+## stackit network-area region create
+
+Creates a new regional configuration for a STACKIT Network Area (SNA)
+
+### Synopsis
+
+Creates a new regional configuration for a STACKIT Network Area (SNA).
+
+```
+stackit network-area region create [flags]
+```
+
+### Examples
+
+```
+  Create a new regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24" and ipv4 transfer network "192.168.1.0/24"
+  $ stackit network-area region create --network-area-id xxx --region eu02 --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24
+
+  Create a new regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config
+  $ stackit config set --region eu02
+  $ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24
+
+  Create a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"
+  $ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20
+
+  Create a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"
+  $ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20
+```
+
+### Options
+
+```
+  -h, --help                               Help for "stackit network-area region create"
+      --ipv4-default-nameservers strings   List of default DNS name server IPs
+      --ipv4-default-prefix-length int     The default prefix length for networks in the network area
+      --ipv4-max-prefix-length int         The maximum prefix length for networks in the network area
+      --ipv4-min-prefix-length int         The minimum prefix length for networks in the network area
+      --ipv4-network-ranges strings        Network range to create in CIDR notation (default [])
+      --ipv4-transfer-network string       Transfer network in CIDR notation
+      --network-area-id string             STACKIT Network Area (SNA) ID
+      --organization-id string             Organization ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
+

--- a/docs/stackit_network-area_region_delete.md
+++ b/docs/stackit_network-area_region_delete.md
@@ -1,0 +1,46 @@
+## stackit network-area region delete
+
+Deletes a regional configuration for a STACKIT Network Area (SNA)
+
+### Synopsis
+
+Deletes a regional configuration for a STACKIT Network Area (SNA).
+
+```
+stackit network-area region delete [flags]
+```
+
+### Examples
+
+```
+  Delete a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"
+  $ stackit network-area region delete --network-area-id xxx --region eu02 --organization-id yyy
+
+  Delete a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config
+  $ stackit config set --region eu02
+  $ stackit network-area region delete --network-area-id xxx --organization-id yyy
+```
+
+### Options
+
+```
+  -h, --help                     Help for "stackit network-area region delete"
+      --network-area-id string   STACKIT Network Area (SNA) ID
+      --organization-id string   Organization ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
+

--- a/docs/stackit_network-area_region_describe.md
+++ b/docs/stackit_network-area_region_describe.md
@@ -1,0 +1,46 @@
+## stackit network-area region describe
+
+Describes a regional configuration for a STACKIT Network Area (SNA)
+
+### Synopsis
+
+Describes a regional configuration for a STACKIT Network Area (SNA).
+
+```
+stackit network-area region describe [flags]
+```
+
+### Examples
+
+```
+  Describe a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"
+  $ stackit network-area region describe --network-area-id xxx --region eu02 --organization-id yyy
+
+  Describe a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config
+  $ stackit config set --region eu02
+  $ stackit network-area region describe --network-area-id xxx --organization-id yyy
+```
+
+### Options
+
+```
+  -h, --help                     Help for "stackit network-area region describe"
+      --network-area-id string   STACKIT Network Area (SNA) ID
+      --organization-id string   Organization ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
+

--- a/docs/stackit_network-area_region_list.md
+++ b/docs/stackit_network-area_region_list.md
@@ -1,0 +1,42 @@
+## stackit network-area region list
+
+Lists all configured regions for a STACKIT Network Area (SNA)
+
+### Synopsis
+
+Lists all configured regions for a STACKIT Network Area (SNA).
+
+```
+stackit network-area region list [flags]
+```
+
+### Examples
+
+```
+  List all configured region for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"
+  $ stackit network-area region list --network-area-id xxx --organization-id yyy
+```
+
+### Options
+
+```
+  -h, --help                     Help for "stackit network-area region list"
+      --network-area-id string   STACKIT Network Area (SNA) ID
+      --organization-id string   Organization ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
+

--- a/docs/stackit_network-area_region_update.md
+++ b/docs/stackit_network-area_region_update.md
@@ -1,0 +1,56 @@
+## stackit network-area region update
+
+Updates a existing regional configuration for a STACKIT Network Area (SNA)
+
+### Synopsis
+
+Updates a existing regional configuration for a STACKIT Network Area (SNA).
+
+```
+stackit network-area region update [flags]
+```
+
+### Examples
+
+```
+  Update a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy" with new ipv4-default-nameservers "8.8.8.8"
+  $ stackit network-area region update --network-area-id xxx --region eu02 --organization-id yyy --ipv4-default-nameservers 8.8.8.8
+
+  Update a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy" with new ipv4-default-nameservers "8.8.8.8", using the set region config
+  $ stackit config set --region eu02
+  $ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-default-nameservers 8.8.8.8
+
+  Update a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"
+  $ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20
+
+  Update a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"
+  $ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20
+```
+
+### Options
+
+```
+  -h, --help                               Help for "stackit network-area region update"
+      --ipv4-default-nameservers strings   List of default DNS name server IPs
+      --ipv4-default-prefix-length int     The default prefix length for networks in the network area
+      --ipv4-max-prefix-length int         The maximum prefix length for networks in the network area
+      --ipv4-min-prefix-length int         The minimum prefix length for networks in the network area
+      --network-area-id string             STACKIT Network Area (SNA) ID
+      --organization-id string             Organization ID
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit network-area region](./stackit_network-area_region.md)	 - Provides functionality for regional configuration of STACKIT Network Area (SNA)
+

--- a/internal/cmd/network-area/network_area.go
+++ b/internal/cmd/network-area/network_area.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/describe"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/list"
 	networkrange "github.com/stackitcloud/stackit-cli/internal/cmd/network-area/network-range"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/route"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/update"
 	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
@@ -33,6 +34,7 @@ func addSubcommands(cmd *cobra.Command, params *params.CmdParams) {
 	cmd.AddCommand(describe.NewCmd(params))
 	cmd.AddCommand(list.NewCmd(params))
 	cmd.AddCommand(networkrange.NewCmd(params))
+	cmd.AddCommand(region.NewCmd(params))
 	cmd.AddCommand(route.NewCmd(params))
 	cmd.AddCommand(update.NewCmd(params))
 }

--- a/internal/cmd/network-area/region/create/create.go
+++ b/internal/cmd/network-area/region/create/create.go
@@ -1,0 +1,195 @@
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+const (
+	networkAreaIdFlag           = "network-area-id"
+	organizationIdFlag          = "organization-id"
+	ipv4DefaultNameservers      = "ipv4-default-nameservers"
+	ipv4DefaultPrefixLengthFlag = "ipv4-default-prefix-length"
+	ipv4MaxPrefixLengthFlag     = "ipv4-max-prefix-length"
+	ipv4MinPrefixLengthFlag     = "ipv4-min-prefix-length"
+	ipv4NetworkRangesFlag       = "ipv4-network-ranges"
+	ipv4TransferNetworkFlag     = "ipv4-transfer-network"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	OrganizationId string
+	NetworkAreaId  string
+
+	IPv4DefaultNameservers  *[]string
+	IPv4DefaultPrefixLength *int64
+	IPv4MaxPrefixLength     *int64
+	IPv4MinPrefixLength     *int64
+	IPv4NetworkRanges       []string
+	IPv4TransferNetwork     string
+}
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates a new regional configuration for a STACKIT Network Area (SNA)",
+		Long:  "Creates a new regional configuration for a STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`Create a new regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24" and ipv4 transfer network "192.168.1.0/24"`,
+				`$ stackit network-area region create --network-area-id xxx --region eu02 --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24`,
+			),
+			examples.NewExample(
+				`Create a new regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config`,
+				`$ stackit config set --region eu02`,
+				`$ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24`,
+			),
+			examples.NewExample(
+				`Create a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"`,
+				`$ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20`,
+			),
+			examples.NewExample(
+				`Create a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"`,
+				`$ stackit network-area region create --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20`,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			// Get network area label
+			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				networkAreaLabel = model.NetworkAreaId
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to create the regional configuration %q for STACKIT Network Area (SNA) %q?", model.Region, networkAreaLabel)
+				err = params.Printer.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("create network area region: %w", err)
+			}
+
+			if resp == nil || resp.Ipv4 == nil {
+				return fmt.Errorf("empty response from API")
+			}
+
+			if !model.Async {
+				s := spinner.New(params.Printer)
+				s.Start("Create network area region")
+				_, err = wait.CreateNetworkAreaRegionWaitHandler(ctx, apiClient, model.OrganizationId, model.NetworkAreaId, model.Region).WaitWithContext(ctx)
+				if err != nil {
+					return fmt.Errorf("wait for network area region creation: %w", err)
+				}
+				s.Stop()
+			}
+
+			return outputResult(params.Printer, model.OutputFormat, model.Region, networkAreaLabel, *resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(flags.UUIDFlag(), networkAreaIdFlag, "STACKIT Network Area (SNA) ID")
+	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
+	cmd.Flags().Var(flags.CIDRSliceFlag(), ipv4NetworkRangesFlag, "Network range to create in CIDR notation")
+	cmd.Flags().Var(flags.CIDRFlag(), ipv4TransferNetworkFlag, "Transfer network in CIDR notation")
+	cmd.Flags().StringSlice(ipv4DefaultNameservers, nil, "List of default DNS name server IPs")
+	cmd.Flags().Int64(ipv4DefaultPrefixLengthFlag, 0, "The default prefix length for networks in the network area")
+	cmd.Flags().Int64(ipv4MaxPrefixLengthFlag, 0, "The maximum prefix length for networks in the network area")
+	cmd.Flags().Int64(ipv4MinPrefixLengthFlag, 0, "The minimum prefix length for networks in the network area")
+
+	err := flags.MarkFlagsRequired(cmd, networkAreaIdFlag, organizationIdFlag, ipv4NetworkRangesFlag, ipv4TransferNetworkFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.Region == "" {
+		return nil, &errors.RegionError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel:         globalFlags,
+		NetworkAreaId:           flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
+		OrganizationId:          flags.FlagToStringValue(p, cmd, organizationIdFlag),
+		IPv4DefaultNameservers:  flags.FlagToStringSlicePointer(p, cmd, ipv4DefaultNameservers),
+		IPv4DefaultPrefixLength: flags.FlagToInt64Pointer(p, cmd, ipv4DefaultPrefixLengthFlag),
+		IPv4MaxPrefixLength:     flags.FlagToInt64Pointer(p, cmd, ipv4MaxPrefixLengthFlag),
+		IPv4MinPrefixLength:     flags.FlagToInt64Pointer(p, cmd, ipv4MinPrefixLengthFlag),
+		IPv4NetworkRanges:       flags.FlagToStringSliceValue(p, cmd, ipv4NetworkRangesFlag),
+		IPv4TransferNetwork:     flags.FlagToStringValue(p, cmd, ipv4TransferNetworkFlag),
+	}
+
+	p.DebugInputModel(model)
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiCreateNetworkAreaRegionRequest {
+	req := apiClient.CreateNetworkAreaRegion(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
+
+	var networkRange []iaas.NetworkRange
+	if len(model.IPv4NetworkRanges) > 0 {
+		networkRange = make([]iaas.NetworkRange, len(model.IPv4NetworkRanges))
+		for i := range model.IPv4NetworkRanges {
+			networkRange[i] = iaas.NetworkRange{
+				Prefix: utils.Ptr(model.IPv4NetworkRanges[i]),
+			}
+		}
+	}
+
+	payload := iaas.CreateNetworkAreaRegionPayload{
+		Ipv4: &iaas.RegionalAreaIPv4{
+			DefaultNameservers: model.IPv4DefaultNameservers,
+			DefaultPrefixLen:   model.IPv4DefaultPrefixLength,
+			MaxPrefixLen:       model.IPv4MaxPrefixLength,
+			MinPrefixLen:       model.IPv4MinPrefixLength,
+			NetworkRanges:      utils.Ptr(networkRange),
+			TransferNetwork:    utils.Ptr(model.IPv4TransferNetwork),
+		},
+	}
+	return req.CreateNetworkAreaRegionPayload(payload)
+}
+
+func outputResult(p *print.Printer, outputFormat, region, networkAreaLabel string, regionalArea iaas.RegionalArea) error {
+	return p.OutputResult(outputFormat, regionalArea, func() error {
+		p.Outputf("Create region configuration for SNA %q.\nRegion: %s\n", networkAreaLabel, region)
+		return nil
+	})
+}

--- a/internal/cmd/network-area/region/create/create_test.go
+++ b/internal/cmd/network-area/region/create/create_test.go
@@ -1,0 +1,307 @@
+package create
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	testRegion                    = "eu01"
+	testDefaultPrefixLength int64 = 25
+	testMaxPrefixLength     int64 = 29
+	testMinPrefixLength     int64 = 24
+	testTransferNetwork           = "192.168.2.0/24"
+)
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &iaas.APIClient{}
+
+var (
+	testAreaId             = uuid.NewString()
+	testOrgId              = uuid.NewString()
+	testDefaultNameservers = []string{"8.8.8.8", "8.8.4.4"}
+	testNetworkRanges      = []string{"192.168.0.0/24", "10.0.0.0/24"}
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.RegionFlag: testRegion,
+
+		networkAreaIdFlag:           testAreaId,
+		organizationIdFlag:          testOrgId,
+		ipv4DefaultNameservers:      strings.Join(testDefaultNameservers, ","),
+		ipv4DefaultPrefixLengthFlag: strconv.FormatInt(testDefaultPrefixLength, 10),
+		ipv4MaxPrefixLengthFlag:     strconv.FormatInt(testMaxPrefixLength, 10),
+		ipv4MinPrefixLengthFlag:     strconv.FormatInt(testMinPrefixLength, 10),
+		ipv4NetworkRangesFlag:       strings.Join(testNetworkRanges, ","),
+		ipv4TransferNetworkFlag:     testTransferNetwork,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		OrganizationId:          testOrgId,
+		NetworkAreaId:           testAreaId,
+		IPv4DefaultNameservers:  utils.Ptr(testDefaultNameservers),
+		IPv4DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
+		IPv4MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
+		IPv4MinPrefixLength:     utils.Ptr(testMinPrefixLength),
+		IPv4NetworkRanges:       testNetworkRanges,
+		IPv4TransferNetwork:     testTransferNetwork,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *iaas.ApiCreateNetworkAreaRegionRequest)) iaas.ApiCreateNetworkAreaRegionRequest {
+	request := testClient.CreateNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
+	request = request.CreateNetworkAreaRegionPayload(fixturePayload())
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func fixturePayload(mods ...func(payload *iaas.CreateNetworkAreaRegionPayload)) iaas.CreateNetworkAreaRegionPayload {
+	var networkRange []iaas.NetworkRange
+	if len(testNetworkRanges) > 0 {
+		networkRange = make([]iaas.NetworkRange, len(testNetworkRanges))
+		for i := range testNetworkRanges {
+			networkRange[i] = iaas.NetworkRange{
+				Prefix: utils.Ptr(testNetworkRanges[i]),
+			}
+		}
+	}
+
+	payload := iaas.CreateNetworkAreaRegionPayload{
+		Ipv4: &iaas.RegionalAreaIPv4{
+			DefaultNameservers: utils.Ptr(testDefaultNameservers),
+			DefaultPrefixLen:   utils.Ptr(testDefaultPrefixLength),
+			MaxPrefixLen:       utils.Ptr(testMaxPrefixLength),
+			MinPrefixLen:       utils.Ptr(testMinPrefixLength),
+			NetworkRanges:      utils.Ptr(networkRange),
+			TransferNetwork:    utils.Ptr(testTransferNetwork),
+		},
+	}
+	for _, mod := range mods {
+		mod(&payload)
+	}
+	return payload
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "area id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, networkAreaIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, organizationIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "network range missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, ipv4NetworkRangesFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "multiple network ranges",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[ipv4NetworkRangesFlag] = "192.168.2.0/24,10.0.0.0/24"
+			}),
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.IPv4NetworkRanges = []string{"192.168.2.0/24", "10.0.0.0/24"}
+			}),
+			isValid: true,
+		},
+		{
+			description: "network range invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[ipv4NetworkRangesFlag] = "invalid-cidr"
+			}),
+			isValid: false,
+		},
+		{
+			description: "transfer network missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, ipv4TransferNetworkFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "transfer network invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[ipv4TransferNetworkFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "transfer network invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[ipv4TransferNetworkFlag] = "invalid-cidr"
+			}),
+			isValid: false,
+		},
+		{
+			description: "region empty",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[globalflags.RegionFlag] = ""
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest iaas.ApiCreateNetworkAreaRegionRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_outputResult(t *testing.T) {
+	type args struct {
+		outputFormat     string
+		region           string
+		networkAreaLabel string
+		regionalArea     iaas.RegionalArea
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{},
+			wantErr: false,
+		},
+		{
+			name: "set empty regional area",
+			args: args{
+				regionalArea: iaas.RegionalArea{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "output json",
+			args: args{
+				outputFormat: print.JSONOutputFormat,
+				regionalArea: iaas.RegionalArea{},
+			},
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.region, tt.args.networkAreaLabel, tt.args.regionalArea); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/network-area/region/delete/delete.go
+++ b/internal/cmd/network-area/region/delete/delete.go
@@ -1,0 +1,129 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+const (
+	networkAreaIdFlag  = "network-area-id"
+	organizationIdFlag = "organization-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	OrganizationId string
+	NetworkAreaId  string
+}
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Deletes a regional configuration for a STACKIT Network Area (SNA)",
+		Long:  "Deletes a regional configuration for a STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`Delete a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"`,
+				`$ stackit network-area region delete --network-area-id xxx --region eu02 --organization-id yyy`,
+			),
+			examples.NewExample(
+				`Delete a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config`,
+				`$ stackit config set --region eu02`,
+				`$ stackit network-area region delete --network-area-id xxx --organization-id yyy`,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			// Get network area label
+			networkAreaName, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				networkAreaName = model.NetworkAreaId
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to delete the regional configuration %q for STACKIT Network Area (SNA) %q?", model.Region, networkAreaName)
+				err = params.Printer.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			err = req.Execute()
+			if err != nil {
+				return fmt.Errorf("delete network area region: %w", err)
+			}
+
+			if !model.Async {
+				s := spinner.New(params.Printer)
+				s.Start("Delete network area region")
+				_, err = wait.DeleteNetworkAreaRegionWaitHandler(ctx, apiClient, model.OrganizationId, model.NetworkAreaId, model.Region).WaitWithContext(ctx)
+				if err != nil {
+					return fmt.Errorf("wait for network area region deletion: %w", err)
+				}
+				s.Stop()
+			}
+
+			params.Printer.Outputf("Delete regional network area %q for %q\n", model.Region, networkAreaName)
+			return nil
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(flags.UUIDFlag(), networkAreaIdFlag, "STACKIT Network Area (SNA) ID")
+	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
+
+	err := flags.MarkFlagsRequired(cmd, networkAreaIdFlag, organizationIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.Region == "" {
+		return nil, &errors.RegionError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		NetworkAreaId:   flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+	}
+
+	p.DebugInputModel(model)
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiDeleteNetworkAreaRegionRequest {
+	return apiClient.DeleteNetworkAreaRegion(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
+}

--- a/internal/cmd/network-area/region/delete/delete_test.go
+++ b/internal/cmd/network-area/region/delete/delete_test.go
@@ -1,0 +1,168 @@
+package delete
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	testRegion = "eu01"
+)
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &iaas.APIClient{}
+
+var (
+	testAreaId = uuid.NewString()
+	testOrgId  = uuid.NewString()
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.RegionFlag: testRegion,
+
+		networkAreaIdFlag:  testAreaId,
+		organizationIdFlag: testOrgId,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		OrganizationId: testOrgId,
+		NetworkAreaId:  testAreaId,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *iaas.ApiDeleteNetworkAreaRegionRequest)) iaas.ApiDeleteNetworkAreaRegionRequest {
+	request := testClient.DeleteNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "area id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, networkAreaIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, organizationIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "region empty",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[globalflags.RegionFlag] = ""
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest iaas.ApiDeleteNetworkAreaRegionRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/cmd/network-area/region/describe/describe.go
+++ b/internal/cmd/network-area/region/describe/describe.go
@@ -1,0 +1,169 @@
+package describe
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	networkAreaIdFlag  = "network-area-id"
+	organizationIdFlag = "organization-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	OrganizationId string
+	NetworkAreaId  string
+}
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Describes a regional configuration for a STACKIT Network Area (SNA)",
+		Long:  "Describes a regional configuration for a STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`Describe a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"`,
+				`$ stackit network-area region describe --network-area-id xxx --region eu02 --organization-id yyy`,
+			),
+			examples.NewExample(
+				`Describe a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", using the set region config`,
+				`$ stackit config set --region eu02`,
+				`$ stackit network-area region describe --network-area-id xxx --organization-id yyy`,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			// Get network area label
+			networkAreaName, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				// Set explicit the networkAreaName to empty string and not to the ID, because this is used for the table output
+				networkAreaName = ""
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("describe network area region: %w", err)
+			}
+
+			if resp == nil || resp.Ipv4 == nil {
+				return fmt.Errorf("empty response from API")
+			}
+
+			return outputResult(params.Printer, model.OutputFormat, model.Region, model.NetworkAreaId, networkAreaName, *resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(flags.UUIDFlag(), networkAreaIdFlag, "STACKIT Network Area (SNA) ID")
+	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
+
+	err := flags.MarkFlagsRequired(cmd, networkAreaIdFlag, organizationIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.Region == "" {
+		return nil, &errors.RegionError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		NetworkAreaId:   flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+	}
+
+	p.DebugInputModel(model)
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiGetNetworkAreaRegionRequest {
+	return apiClient.GetNetworkAreaRegion(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
+}
+
+func outputResult(p *print.Printer, outputFormat, region, areaId, areaName string, regionalArea iaas.RegionalArea) error {
+	return p.OutputResult(outputFormat, regionalArea, func() error {
+		table := tables.NewTable()
+		table.AddRow("ID", areaId)
+		table.AddSeparator()
+		if areaName != "" {
+			table.AddRow("NAME", areaName)
+			table.AddSeparator()
+		}
+		table.AddRow("REGION", region)
+		table.AddSeparator()
+		table.AddRow("STATUS", utils.PtrString(regionalArea.Status))
+		table.AddSeparator()
+		if ipv4 := regionalArea.Ipv4; ipv4 != nil {
+			if ipv4.NetworkRanges != nil {
+				var networkRanges []string
+				for _, networkRange := range *ipv4.NetworkRanges {
+					if networkRange.Prefix != nil {
+						networkRanges = append(networkRanges, *networkRange.Prefix)
+					}
+				}
+				table.AddRow("NETWORK RANGES", strings.Join(networkRanges, ","))
+				table.AddSeparator()
+			}
+			if transferNetwork := ipv4.TransferNetwork; transferNetwork != nil {
+				table.AddRow("TRANSFER RANGE", utils.PtrString(transferNetwork))
+				table.AddSeparator()
+			}
+			if defaultNameserver := ipv4.DefaultNameservers; defaultNameserver != nil && len(*defaultNameserver) > 0 {
+				table.AddRow("DNS NAME SERVERS", strings.Join(*defaultNameserver, ","))
+				table.AddSeparator()
+			}
+			if defaultPrefixLength := ipv4.DefaultPrefixLen; defaultPrefixLength != nil {
+				table.AddRow("DEFAULT PREFIX LENGTH", utils.PtrString(defaultPrefixLength))
+				table.AddSeparator()
+			}
+			if maxPrefixLength := ipv4.MaxPrefixLen; maxPrefixLength != nil {
+				table.AddRow("MAX PREFIX LENGTH", utils.PtrString(maxPrefixLength))
+				table.AddSeparator()
+			}
+			if minPrefixLen := ipv4.MinPrefixLen; minPrefixLen != nil {
+				table.AddRow("MIN PREFIX LENGTH", utils.PtrString(minPrefixLen))
+				table.AddSeparator()
+			}
+		}
+
+		if err := table.Display(p); err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/cmd/network-area/region/describe/describe_test.go
+++ b/internal/cmd/network-area/region/describe/describe_test.go
@@ -1,0 +1,214 @@
+package describe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	testRegion = "eu01"
+)
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &iaas.APIClient{}
+
+var (
+	testAreaId = uuid.NewString()
+	testOrgId  = uuid.NewString()
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.RegionFlag: testRegion,
+
+		networkAreaIdFlag:  testAreaId,
+		organizationIdFlag: testOrgId,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		OrganizationId: testOrgId,
+		NetworkAreaId:  testAreaId,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *iaas.ApiGetNetworkAreaRegionRequest)) iaas.ApiGetNetworkAreaRegionRequest {
+	request := testClient.GetNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "org id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, organizationIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, networkAreaIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "region empty",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[globalflags.RegionFlag] = ""
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest iaas.ApiGetNetworkAreaRegionRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_outputResult(t *testing.T) {
+	type args struct {
+		outputFormat     string
+		areaId           string
+		region           string
+		networkAreaLabel string
+		regionalArea     iaas.RegionalArea
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{},
+			wantErr: false,
+		},
+		{
+			name: "set empty regional area",
+			args: args{
+				regionalArea: iaas.RegionalArea{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "output json",
+			args: args{
+				outputFormat: print.JSONOutputFormat,
+				regionalArea: iaas.RegionalArea{},
+			},
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.region, tt.args.areaId, tt.args.networkAreaLabel, tt.args.regionalArea); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/network-area/region/list/list.go
+++ b/internal/cmd/network-area/region/list/list.go
@@ -1,0 +1,153 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	networkAreaIdFlag  = "network-area-id"
+	organizationIdFlag = "organization-id"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	OrganizationId string
+	NetworkAreaId  string
+}
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all configured regions for a STACKIT Network Area (SNA)",
+		Long:  "Lists all configured regions for a STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`List all configured region for a STACKIT Network Area with ID "xxx" in organization with ID "yyy"`,
+				`$ stackit network-area region list --network-area-id xxx --organization-id yyy`,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			// Get network area label
+			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				networkAreaLabel = model.NetworkAreaId
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("list network area region: %w", err)
+			}
+
+			if resp == nil {
+				return fmt.Errorf("empty response from API")
+			}
+
+			return outputResult(params.Printer, model.OutputFormat, networkAreaLabel, *resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(flags.UUIDFlag(), networkAreaIdFlag, "STACKIT Network Area (SNA) ID")
+	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
+
+	err := flags.MarkFlagsRequired(cmd, networkAreaIdFlag, organizationIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+
+	model := inputModel{
+		GlobalFlagModel: globalFlags,
+		NetworkAreaId:   flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+	}
+
+	p.DebugInputModel(model)
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiListNetworkAreaRegionsRequest {
+	return apiClient.ListNetworkAreaRegions(ctx, model.OrganizationId, model.NetworkAreaId)
+}
+
+func outputResult(p *print.Printer, outputFormat, areaLabel string, regionalArea iaas.RegionalAreaListResponse) error {
+	return p.OutputResult(outputFormat, regionalArea, func() error {
+		if regionalArea.Regions == nil || len(*regionalArea.Regions) == 0 {
+			p.Outputf("No regions found for network area %q\n", areaLabel)
+			return nil
+		}
+
+		table := tables.NewTable()
+		table.SetHeader("REGION", "STATUS", "DNS NAME SERVERS", "NETWORK RANGES", "TRANSFER NETWORK")
+		for region, regionConfig := range *regionalArea.Regions {
+			var dnsNames string
+			var networkRanges []string
+			var transferNetwork string
+
+			if ipv4 := regionConfig.Ipv4; ipv4 != nil {
+				// Set dnsNames
+				dnsNames = utils.JoinStringPtr(ipv4.DefaultNameservers, ",")
+
+				// Set networkRanges
+				if ipv4.NetworkRanges != nil && len(*ipv4.NetworkRanges) > 0 {
+					for _, networkRange := range *ipv4.NetworkRanges {
+						if networkRange.Prefix != nil {
+							networkRanges = append(networkRanges, *networkRange.Prefix)
+						}
+					}
+				}
+
+				// Set transferNetwork
+				transferNetwork = utils.PtrString(ipv4.TransferNetwork)
+			}
+
+			table.AddRow(
+				region,
+				utils.PtrString(regionConfig.Status),
+				dnsNames,
+				strings.Join(networkRanges, ","),
+				transferNetwork,
+			)
+		}
+
+		if err := table.Display(p); err != nil {
+			return fmt.Errorf("render table: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/cmd/network-area/region/list/list_test.go
+++ b/internal/cmd/network-area/region/list/list_test.go
@@ -1,0 +1,221 @@
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &iaas.APIClient{}
+
+var (
+	testAreaId = uuid.NewString()
+	testOrgId  = uuid.NewString()
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		networkAreaIdFlag:  testAreaId,
+		organizationIdFlag: testOrgId,
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		OrganizationId: testOrgId,
+		NetworkAreaId:  testAreaId,
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *iaas.ApiListNetworkAreaRegionsRequest)) iaas.ApiListNetworkAreaRegionsRequest {
+	request := testClient.ListNetworkAreaRegions(testCtx, testOrgId, testAreaId)
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "org id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, organizationIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, networkAreaIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest iaas.ApiListNetworkAreaRegionsRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_outputResult(t *testing.T) {
+	type args struct {
+		outputFormat     string
+		networkAreaLabel string
+		regionalArea     iaas.RegionalAreaListResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{},
+			wantErr: false,
+		},
+		{
+			name: "set empty response",
+			args: args{
+				regionalArea: iaas.RegionalAreaListResponse{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set nil for regions map in response",
+			args: args{
+				regionalArea: iaas.RegionalAreaListResponse{
+					Regions: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set empty map for regions map in response",
+			args: args{
+				regionalArea: iaas.RegionalAreaListResponse{
+					Regions: utils.Ptr(map[string]iaas.RegionalArea{}),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set empty region in response",
+			args: args{
+				regionalArea: iaas.RegionalAreaListResponse{
+					Regions: utils.Ptr(map[string]iaas.RegionalArea{
+						"eu01": {},
+					}),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.networkAreaLabel, tt.args.regionalArea); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmd/network-area/region/region.go
+++ b/internal/cmd/network-area/region/region.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region/create"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region/delete"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region/describe"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region/list"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/network-area/region/update"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "region",
+		Short: "Provides functionality for regional configuration of STACKIT Network Area (SNA)",
+		Long:  "Provides functionality for regional configuration of STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Run:   utils.CmdHelp,
+	}
+	addSubcommands(cmd, params)
+	return cmd
+}
+
+func addSubcommands(cmd *cobra.Command, params *params.CmdParams) {
+	cmd.AddCommand(create.NewCmd(params))
+	cmd.AddCommand(describe.NewCmd(params))
+	cmd.AddCommand(delete.NewCmd(params))
+	cmd.AddCommand(update.NewCmd(params))
+	cmd.AddCommand(list.NewCmd(params))
+}

--- a/internal/cmd/network-area/region/update/update.go
+++ b/internal/cmd/network-area/region/update/update.go
@@ -1,0 +1,165 @@
+package update
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
+	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	networkAreaIdFlag           = "network-area-id"
+	organizationIdFlag          = "organization-id"
+	ipv4DefaultNameservers      = "ipv4-default-nameservers"
+	ipv4DefaultPrefixLengthFlag = "ipv4-default-prefix-length"
+	ipv4MaxPrefixLengthFlag     = "ipv4-max-prefix-length"
+	ipv4MinPrefixLengthFlag     = "ipv4-min-prefix-length"
+)
+
+type inputModel struct {
+	*globalflags.GlobalFlagModel
+	OrganizationId string
+	NetworkAreaId  string
+
+	IPv4DefaultNameservers  *[]string
+	IPv4DefaultPrefixLength *int64
+	IPv4MaxPrefixLength     *int64
+	IPv4MinPrefixLength     *int64
+}
+
+func NewCmd(params *params.CmdParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Updates a existing regional configuration for a STACKIT Network Area (SNA)",
+		Long:  "Updates a existing regional configuration for a STACKIT Network Area (SNA).",
+		Args:  args.NoArgs,
+		Example: examples.Build(
+			examples.NewExample(
+				`Update a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy" with new ipv4-default-nameservers "8.8.8.8"`,
+				`$ stackit network-area region update --network-area-id xxx --region eu02 --organization-id yyy --ipv4-default-nameservers 8.8.8.8`,
+			),
+			examples.NewExample(
+				`Update a regional configuration "eu02" for a STACKIT Network Area with ID "xxx" in organization with ID "yyy" with new ipv4-default-nameservers "8.8.8.8", using the set region config`,
+				`$ stackit config set --region eu02`,
+				`$ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-default-nameservers 8.8.8.8`,
+			),
+			examples.NewExample(
+				`Update a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"`,
+				`$ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20`,
+			),
+			examples.NewExample(
+				`Update a new regional configuration for a STACKIT Network Area with ID "xxx" in organization with ID "yyy", ipv4 network range "192.168.0.0/24", ipv4 transfer network "192.168.1.0/24", default prefix length "24", max prefix length "25" and min prefix length "20"`,
+				`$ stackit network-area region update --network-area-id xxx --organization-id yyy --ipv4-network-ranges 192.168.0.0/24 --ipv4-transfer-network 192.168.1.0/24 --region "eu02" --ipv4-default-prefix-length 24 --ipv4-max-prefix-length 25 --ipv4-min-prefix-length 20`,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			model, err := parseInput(params.Printer, cmd, args)
+			if err != nil {
+				return err
+			}
+
+			// Configure API client
+			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			// Get network area label
+			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				networkAreaLabel = model.NetworkAreaId
+			}
+
+			if !model.AssumeYes {
+				prompt := fmt.Sprintf("Are you sure you want to update the regional configuration %q for STACKIT Network Area (SNA) %q?", model.Region, networkAreaLabel)
+				err = params.Printer.PromptForConfirmation(prompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Call API
+			req := buildRequest(ctx, model, apiClient)
+			resp, err := req.Execute()
+			if err != nil {
+				return fmt.Errorf("update network area region: %w", err)
+			}
+
+			if resp == nil || resp.Ipv4 == nil {
+				return fmt.Errorf("empty response from API")
+			}
+
+			return outputResult(params.Printer, model.OutputFormat, model.Region, networkAreaLabel, *resp)
+		},
+	}
+	configureFlags(cmd)
+	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(flags.UUIDFlag(), networkAreaIdFlag, "STACKIT Network Area (SNA) ID")
+	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
+	cmd.Flags().StringSlice(ipv4DefaultNameservers, nil, "List of default DNS name server IPs")
+	cmd.Flags().Int64(ipv4DefaultPrefixLengthFlag, 0, "The default prefix length for networks in the network area")
+	cmd.Flags().Int64(ipv4MaxPrefixLengthFlag, 0, "The maximum prefix length for networks in the network area")
+	cmd.Flags().Int64(ipv4MinPrefixLengthFlag, 0, "The minimum prefix length for networks in the network area")
+
+	// At least one of the flags is required, otherwise there is nothing to update
+	cmd.MarkFlagsOneRequired(ipv4DefaultNameservers, ipv4MaxPrefixLengthFlag, ipv4MinPrefixLengthFlag, ipv4DefaultPrefixLengthFlag)
+
+	err := flags.MarkFlagsRequired(cmd, networkAreaIdFlag, organizationIdFlag)
+	cobra.CheckErr(err)
+}
+
+func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
+	globalFlags := globalflags.Parse(p, cmd)
+	if globalFlags.Region == "" {
+		return nil, &errors.RegionError{}
+	}
+
+	model := inputModel{
+		GlobalFlagModel:         globalFlags,
+		NetworkAreaId:           flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
+		OrganizationId:          flags.FlagToStringValue(p, cmd, organizationIdFlag),
+		IPv4DefaultNameservers:  flags.FlagToStringSlicePointer(p, cmd, ipv4DefaultNameservers),
+		IPv4DefaultPrefixLength: flags.FlagToInt64Pointer(p, cmd, ipv4DefaultPrefixLengthFlag),
+		IPv4MaxPrefixLength:     flags.FlagToInt64Pointer(p, cmd, ipv4MaxPrefixLengthFlag),
+		IPv4MinPrefixLength:     flags.FlagToInt64Pointer(p, cmd, ipv4MinPrefixLengthFlag),
+	}
+
+	p.DebugInputModel(model)
+	return &model, nil
+}
+
+func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiUpdateNetworkAreaRegionRequest {
+	req := apiClient.UpdateNetworkAreaRegion(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
+
+	payload := iaas.UpdateNetworkAreaRegionPayload{
+		Ipv4: &iaas.UpdateRegionalAreaIPv4{
+			DefaultNameservers: model.IPv4DefaultNameservers,
+			DefaultPrefixLen:   model.IPv4DefaultPrefixLength,
+			MaxPrefixLen:       model.IPv4MaxPrefixLength,
+			MinPrefixLen:       model.IPv4MinPrefixLength,
+		},
+	}
+	return req.UpdateNetworkAreaRegionPayload(payload)
+}
+
+func outputResult(p *print.Printer, outputFormat, region, networkAreaLabel string, regionalArea iaas.RegionalArea) error {
+	return p.OutputResult(outputFormat, regionalArea, func() error {
+		p.Outputf("Updated region configuration for SNA %q.\nRegion: %s\n", networkAreaLabel, region)
+		return nil
+	})
+}

--- a/internal/cmd/network-area/region/update/update_test.go
+++ b/internal/cmd/network-area/region/update/update_test.go
@@ -1,0 +1,265 @@
+package update
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/stackitcloud/stackit-cli/internal/cmd/params"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+const (
+	testRegion                    = "eu01"
+	testDefaultPrefixLength int64 = 25
+	testMaxPrefixLength     int64 = 29
+	testMinPrefixLength     int64 = 24
+)
+
+type testCtxKey struct{}
+
+var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
+var testClient = &iaas.APIClient{}
+
+var (
+	testAreaId             = uuid.NewString()
+	testOrgId              = uuid.NewString()
+	testDefaultNameservers = []string{"8.8.8.8", "8.8.4.4"}
+	testNetworkRanges      = []string{"192.168.0.0/24", "10.0.0.0/24"}
+)
+
+func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
+	flagValues := map[string]string{
+		globalflags.RegionFlag: testRegion,
+
+		networkAreaIdFlag:           testAreaId,
+		organizationIdFlag:          testOrgId,
+		ipv4DefaultNameservers:      strings.Join(testDefaultNameservers, ","),
+		ipv4DefaultPrefixLengthFlag: strconv.FormatInt(testDefaultPrefixLength, 10),
+		ipv4MaxPrefixLengthFlag:     strconv.FormatInt(testMaxPrefixLength, 10),
+		ipv4MinPrefixLengthFlag:     strconv.FormatInt(testMinPrefixLength, 10),
+	}
+	for _, mod := range mods {
+		mod(flagValues)
+	}
+	return flagValues
+}
+
+func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
+	model := &inputModel{
+		GlobalFlagModel: &globalflags.GlobalFlagModel{
+			Region:    testRegion,
+			Verbosity: globalflags.VerbosityDefault,
+		},
+		OrganizationId:          testOrgId,
+		NetworkAreaId:           testAreaId,
+		IPv4DefaultNameservers:  utils.Ptr(testDefaultNameservers),
+		IPv4DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
+		IPv4MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
+		IPv4MinPrefixLength:     utils.Ptr(testMinPrefixLength),
+	}
+	for _, mod := range mods {
+		mod(model)
+	}
+	return model
+}
+
+func fixtureRequest(mods ...func(request *iaas.ApiUpdateNetworkAreaRegionRequest)) iaas.ApiUpdateNetworkAreaRegionRequest {
+	request := testClient.UpdateNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
+	request = request.UpdateNetworkAreaRegionPayload(fixturePayload())
+	for _, mod := range mods {
+		mod(&request)
+	}
+	return request
+}
+
+func fixturePayload(mods ...func(payload *iaas.UpdateNetworkAreaRegionPayload)) iaas.UpdateNetworkAreaRegionPayload {
+	var networkRange []iaas.NetworkRange
+	if len(testNetworkRanges) > 0 {
+		networkRange = make([]iaas.NetworkRange, len(testNetworkRanges))
+		for i := range testNetworkRanges {
+			networkRange[i] = iaas.NetworkRange{
+				Prefix: utils.Ptr(testNetworkRanges[i]),
+			}
+		}
+	}
+
+	payload := iaas.UpdateNetworkAreaRegionPayload{
+		Ipv4: &iaas.UpdateRegionalAreaIPv4{
+			DefaultNameservers: utils.Ptr(testDefaultNameservers),
+			DefaultPrefixLen:   utils.Ptr(testDefaultPrefixLength),
+			MaxPrefixLen:       utils.Ptr(testMaxPrefixLength),
+			MinPrefixLen:       utils.Ptr(testMinPrefixLength),
+		},
+	}
+	for _, mod := range mods {
+		mod(&payload)
+	}
+	return payload
+}
+
+func TestParseInput(t *testing.T) {
+	tests := []struct {
+		description   string
+		argValues     []string
+		flagValues    map[string]string
+		isValid       bool
+		expectedModel *inputModel
+	}{
+		{
+			description:   "base",
+			flagValues:    fixtureFlagValues(),
+			isValid:       true,
+			expectedModel: fixtureInputModel(),
+		},
+		{
+			description: "no values",
+			flagValues:  map[string]string{},
+			isValid:     false,
+		},
+		{
+			description: "org id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, organizationIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "org id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[organizationIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, networkAreaIdFlag)
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 1",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = ""
+			}),
+			isValid: false,
+		},
+		{
+			description: "area id invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[networkAreaIdFlag] = "invalid-uuid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "no update data is set",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, ipv4DefaultPrefixLengthFlag)
+				delete(flagValues, ipv4MaxPrefixLengthFlag)
+				delete(flagValues, ipv4MinPrefixLengthFlag)
+				delete(flagValues, ipv4DefaultNameservers)
+			}),
+			isValid: false,
+		},
+		{
+			description: "region empty",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[globalflags.RegionFlag] = ""
+			}),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		description     string
+		model           *inputModel
+		expectedRequest iaas.ApiUpdateNetworkAreaRegionRequest
+	}{
+		{
+			description:     "base",
+			model:           fixtureInputModel(),
+			expectedRequest: fixtureRequest(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			request := buildRequest(testCtx, tt.model, testClient)
+
+			diff := cmp.Diff(request, tt.expectedRequest,
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
+			)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_outputResult(t *testing.T) {
+	type args struct {
+		outputFormat     string
+		region           string
+		networkAreaLabel string
+		regionalArea     iaas.RegionalArea
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{},
+			wantErr: false,
+		},
+		{
+			name: "set empty regional area",
+			args: args{
+				regionalArea: iaas.RegionalArea{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "output json",
+			args: args{
+				outputFormat: print.JSONOutputFormat,
+				regionalArea: iaas.RegionalArea{},
+			},
+		},
+	}
+	p := print.NewPrinter()
+	p.Cmd = NewCmd(&params.CmdParams{Printer: p})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := outputResult(p, tt.args.outputFormat, tt.args.region, tt.args.networkAreaLabel, tt.args.regionalArea); (err != nil) != tt.wantErr {
+				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -18,6 +18,16 @@ You can configure it for all commands by running:
 	
 or you can also set it through the environment variable [STACKIT_PROJECT_ID]`
 
+	MISSING_REGION = `the region is not currently set.
+	
+It can be set on the command level by re-running your command with the --region flag.
+	
+You can configure it for all commands by running:
+	
+  $ stackit config set --region xxx
+	
+or you can also set it through the environment variable [STACKIT_REGION]`
+
 	EMPTY_UPDATE = `please specify at least one field to update.
 	
 Get details on the available flags by re-running your command with the --help flag.`
@@ -238,6 +248,12 @@ type ProjectIdError struct{}
 
 func (e *ProjectIdError) Error() string {
 	return MISSING_PROJECT_ID
+}
+
+type RegionError struct{}
+
+func (e *RegionError) Error() string {
+	return MISSING_REGION
 }
 
 type EmptyUpdateError struct{}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-227

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
