### PR TITLE
fix(auth): hide misleading parameters in get access token cmd

### DIFF
--- a/internal/cmd/auth/get-access-token/get_access_token.go
+++ b/internal/cmd/auth/get-access-token/get_access_token.go
@@ -67,6 +67,13 @@ func NewCmd(params *params.CmdParams) *cobra.Command {
 			}
 		},
 	}
+
+	// hide project id flag from help command because it could mislead users
+	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		_ = command.Flags().MarkHidden(globalflags.ProjectIdFlag) // nolint:errcheck // there's no chance to handle the error here
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	return cmd
 }
 


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1001 / STACKITCLI-282

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
