### PR TITLE
fix(ske/login): add profile email to cacheKey

### DIFF
--- a/internal/cmd/ske/kubeconfig/login/login.go
+++ b/internal/cmd/ske/kubeconfig/login/login.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/ske/client"
@@ -158,12 +157,12 @@ func parseClusterConfig(p *print.Printer, cmd *cobra.Command) (*clusterConfig, e
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 
-	profile, err := config.GetProfile()
+	authEmail, err := auth.GetAuthEmail()
 	if err != nil {
-		return nil, fmt.Errorf("error getting profile: %w", err)
+		return nil, fmt.Errorf("error getting auth email: %w", err)
 	}
 
-	clusterConfig.cacheKey = fmt.Sprintf("ske-login-%x", sha256.Sum256([]byte(execCredential.Spec.Cluster.Server+auth.GetProfileEmail(profile))))
+	clusterConfig.cacheKey = fmt.Sprintf("ske-login-%x", sha256.Sum256([]byte(execCredential.Spec.Cluster.Server+"\x00"+authEmail)))
 
 	// NOTE: Fallback if region is not set in the kubeconfig (this was the case in the past)
 	if clusterConfig.Region == "" {


### PR DESCRIPTION


## Description

Adds the profile email as additional info to the calculated hash cachekey.

This solves an issue where the user doesn't directly see that their current credentials are unable to access the cluster, when they have a cached and still valid kubeconfig that was retrieved with different/working credentials earlier.

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
