### PR TITLE
fix: refresh token flow uses x-www-form encoding

### DIFF
--- a/internal/pkg/auth/user_token_flow.go
+++ b/internal/pkg/auth/user_token_flow.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -166,21 +167,21 @@ func buildRequestToRefreshTokens(utf *userTokenFlow) (*http.Request, error) {
 		return nil, err
 	}
 
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", idpClientID)
+	form.Set("refresh_token", utf.refreshToken)
+
 	req, err := http.NewRequest(
 		http.MethodPost,
 		utf.tokenEndpoint,
-		http.NoBody,
+		strings.NewReader(form.Encode()),
 	)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
 	if err != nil {
 		return nil, err
 	}
-	reqQuery := url.Values{}
-	reqQuery.Set("grant_type", "refresh_token")
-	reqQuery.Set("client_id", idpClientID)
-	reqQuery.Set("refresh_token", utf.refreshToken)
-	reqQuery.Set("token_format", "jwt")
-	req.URL.RawQuery = reqQuery.Encode()
-
 	return req, nil
 }
 


### PR DESCRIPTION
## Description

We have seen that during refresh_token grant type, the parameters are sent in query string and are logged by our monitoring systems. For token requests (specially over internet) x-www-form encoding should be used and currently it's used for code grant type too.

This PR updates the refresh_token grant type to use x-www-form 

## Checklist

- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
