### PR TITLE
fix: log browser url to stderr instead of stdout

### DIFF
--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -245,8 +245,8 @@ func AuthorizeUser(p *print.Printer, isReauthentication bool) error {
 	}
 
 	// Print the link
-	p.Outputln("Your browser has been opened to visit:\n")
-	p.Outputf("%s\n\n", authorizationURL)
+	p.Info("Your browser has been opened to visit:\n\n")
+	p.Info("%s\n\n", authorizationURL)
 
 	// Start the blocking web server loop
 	// It will exit when the handlers get fired and call server.Close()


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1125

## Testing instructions
1. Checkout the branch of this PR and run `$ make build`
1. Set the session limit to 1s, to simulate an expired session
  `$ ./bin/stackit config set --session-time-limit 1s`
1. Authenticate with your user account
  `$ ./bin/stackit auth login`
1. Run a command with output format json, e.g.:
   `$ ./bin/stackit network list -o json | jq`
   -> should work
1. Checkout the main branch and rerun the previous command
   `$ ./bin/stackit network list -o json | jq`
   -> should fail

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
