### PR TITLE
display projects correctly by using resource manager tree

### DIFF
--- a/docs/stackit_project_list.md
+++ b/docs/stackit_project_list.md
@@ -31,6 +31,7 @@ stackit project list [flags]
 ```
       --creation-time-after string   Filter by creation timestamp, in a date-time with the RFC3339 layout format, e.g. 2023-01-01T00:00:00Z. The list of projects that were created after the given timestamp will be shown
   -h, --help                         Help for "stackit project list"
+      --lifecycle-state string       Filter by lifecycle state (default "active")
       --limit int                    Maximum number of entries to list
       --member string                Filter by member. The list of projects of which the member is part of will be shown
       --page-size int                Number of items fetched in each API call. Does not affect the number of items in the command output (default 50)

--- a/internal/cmd/project/list/errors.go
+++ b/internal/cmd/project/list/errors.go
@@ -1,0 +1,19 @@
+package list
+
+import (
+	"errors"
+	"net/http"
+
+	oapiError "github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+)
+
+func isForbiddenError(err error) bool {
+	var oAPIError *oapiError.GenericOpenAPIError
+	if ok := errors.As(err, &oAPIError); !ok {
+		return false
+	}
+	if oAPIError.StatusCode != http.StatusForbidden {
+		return false
+	}
+	return true
+}

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -156,6 +156,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 type project struct {
 	Name         string
 	ID           string
+	Labels       map[string]string
+	State        resourcemanager.LifecycleState
 	Organization string
 	Folder       []string
 }
@@ -181,6 +183,8 @@ func getProjects(ctx context.Context, parent *node, org string, projChan chan<- 
 			}
 			projChan <- project{
 				Name:         child.name,
+				State:        child.lifecycleState,
+				Labels:       child.labels,
 				ID:           child.resourceID,
 				Organization: org,
 				Folder:       folderName,
@@ -236,7 +240,7 @@ func fetchProjects(ctx context.Context, model *inputModel, resourceClient *resou
 func outputResult(p *print.Printer, outputFormat string, projects []project) error {
 	return p.OutputResult(outputFormat, projects, func() error {
 		table := tables.NewTable()
-		table.SetHeader("ORGANIZATION", "FOLDER", "NAME", "ID")
+		table.SetHeader("ORGANIZATION", "FOLDER", "NAME", "ID", "STATE")
 		for i := range projects {
 			p := projects[i]
 			table.AddRow(
@@ -244,6 +248,7 @@ func outputResult(p *print.Printer, outputFormat string, projects []project) err
 				p.FolderPath(),
 				p.Name,
 				p.ID,
+				p.State,
 			)
 		}
 

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -62,14 +62,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				`List all STACKIT projects that the authenticated user or service account is a member of`,
 				"$ stackit project list"),
 			examples.NewExample(
-				`List all STACKIT projects that are children of a specific parent`,
-				"$ stackit project list --parent-id xxx"),
-			examples.NewExample(
-				`List all STACKIT projects that match the given project IDs, located under the same parent resource`,
-				"$ stackit project list --project-id-like xxx,yyy,zzz"),
-			examples.NewExample(
 				`List all STACKIT projects that a certain user is a member of`,
 				"$ stackit project list --member example@email.com"),
+			examples.NewExample(
+				`List all STACKIT projects without regards to the lifecycle status`,
+				"$ stackit project list --lifecycle-state=\"\""),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			model, err := parseInput(params.Printer, cmd, args)

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	parentIdFlag          = "parent-id"
+	lifecycleStateFlag    = "lifecycle-state"
 	projectIdLikeFlag     = "project-id-like"
 	memberFlag            = "member"
 	creationTimeAfterFlag = "creation-time-after"
@@ -47,6 +48,7 @@ type inputModel struct {
 	CreationTimeAfter *time.Time
 	Limit             *int64
 	PageSize          int64
+	LifecycleState    string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -104,6 +106,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().String(lifecycleStateFlag, "active", "Filter by lifecycle state")
 	cmd.Flags().String(parentIdFlag, "", "Filter by parent identifier")
 	cmd.Flags().Var(flags.UUIDSliceFlag(), projectIdLikeFlag, "Filter by project identifier. Multiple project IDs can be provided, but they need to belong to the same parent resource")
 	cmd.Flags().String(memberFlag, "", "Filter by member. The list of projects of which the member is part of will be shown")
@@ -147,6 +150,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		CreationTimeAfter: creationTimeAfter,
 		Limit:             limit,
 		PageSize:          pageSize,
+		LifecycleState:    flags.FlagWithDefaultToStringValue(p, cmd, lifecycleStateFlag),
 	}
 
 	p.DebugInputModel(model)

--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -1,23 +1,29 @@
 package list
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"path"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
+
+	authclient "github.com/stackitcloud/stackit-cli/internal/pkg/services/authorization/client"
+	resourceclient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
 	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 )
 
@@ -64,20 +70,24 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				"$ stackit project list --member example@email.com"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
 			model, err := parseInput(params.Printer, cmd, args)
 			if err != nil {
 				return err
 			}
 
 			// Configure API client
-			apiClient, err := client.ConfigureClient(params.Printer, params.CliVersion)
+			resourceClient, err := resourceclient.ConfigureClient(params.Printer, params.CliVersion)
+			if err != nil {
+				return err
+			}
+
+			authClient, err := authclient.ConfigureClient(params.Printer, params.CliVersion)
 			if err != nil {
 				return err
 			}
 
 			// Fetch projects
-			projects, err := fetchProjects(ctx, model, apiClient)
+			projects, err := fetchProjects(cmd.Context(), model, resourceClient, authClient)
 			if err != nil {
 				return err
 			}
@@ -143,90 +153,97 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient resourceManagerClient, offset int) (resourcemanager.ApiListProjectsRequest, error) {
-	req := apiClient.ListProjects(ctx)
-	if model.ParentId != nil {
-		req = req.ContainerParentId(*model.ParentId)
-	}
-	if model.ProjectIdLike != nil {
-		req = req.ContainerIds(model.ProjectIdLike)
-	}
-	if model.Member != nil {
-		req = req.Member(*model.Member)
-	}
-	if model.CreationTimeAfter != nil {
-		req = req.CreationTimeStart(*model.CreationTimeAfter)
-	}
+type project struct {
+	Name         string
+	ID           string
+	Organization string
+	Folder       []string
+}
 
-	if model.ParentId == nil && model.ProjectIdLike == nil && model.Member == nil {
-		email, err := auth.GetAuthEmail()
-		if err != nil {
-			return req, fmt.Errorf("get email of authenticated user: %w", err)
-		}
-		req = req.Member(email)
+func (p project) FolderPath() string {
+	return path.Join(p.Folder...)
+}
+
+func getProjects(ctx context.Context, parent *node, org string, projChan chan<- project) error {
+	g, ctx := errgroup.WithContext(ctx)
+	for _, child := range parent.children {
+		g.Go(func() error {
+			if child.typ != resourceTypeProject {
+				return getProjects(ctx, child, org, projChan)
+			}
+			parent := child.parent
+			folderName := []string{}
+			for parent != nil {
+				if parent.typ == resourceTypeFolder {
+					folderName = append([]string{parent.name}, folderName...)
+				}
+				parent = parent.parent
+			}
+			projChan <- project{
+				Name:         child.name,
+				ID:           child.resourceID,
+				Organization: org,
+				Folder:       folderName,
+			}
+			return nil
+		})
 	}
-	req = req.Limit(float32(model.PageSize))
-	req = req.Offset(float32(offset))
-	return req, nil
+	return g.Wait()
 }
 
 type resourceManagerClient interface {
 	ListProjects(ctx context.Context) resourcemanager.ApiListProjectsRequest
 }
 
-func fetchProjects(ctx context.Context, model *inputModel, apiClient resourceManagerClient) ([]resourcemanager.Project, error) {
-	if model.Limit != nil && *model.Limit < model.PageSize {
-		model.PageSize = *model.Limit
+func fetchProjects(ctx context.Context, model *inputModel, resourceClient *resourcemanager.APIClient, authClient *authorization.APIClient) ([]project, error) {
+	tree, err := newResourceTree(resourceClient, authClient, model)
+	if err != nil {
+		return nil, err
 	}
 
-	offset := 0
-	projects := []resourcemanager.Project{}
-	for {
-		// Call API
-		req, err := buildRequest(ctx, model, apiClient, offset)
-		if err != nil {
-			return nil, fmt.Errorf("build list projects request: %w", err)
-		}
-		resp, err := req.Execute()
-		if err != nil {
-			return nil, fmt.Errorf("get projects: %w", err)
-		}
-		respProjects := *resp.Items
-		if len(respProjects) == 0 {
-			break
-		}
-		projects = append(projects, respProjects...)
-		// Stop if no more pages
-		if len(respProjects) < int(model.PageSize) {
-			break
-		}
-
-		// Stop and truncate if limit is reached
-		if model.Limit != nil && len(projects) >= int(*model.Limit) {
-			projects = projects[:*model.Limit]
-			break
-		}
-		offset += int(model.PageSize)
+	if err := tree.Fill(ctx); err != nil {
+		return nil, err
 	}
-	return projects, nil
+
+	var projs []project
+	projChan := make(chan project)
+
+	var wg sync.WaitGroup
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		for p := range projChan {
+			i, _ := slices.BinarySearchFunc(projs, p, func(e project, target project) int {
+				if orgCmp := cmp.Compare(e.Organization, target.Organization); orgCmp != 0 {
+					return orgCmp
+				}
+				return cmp.Compare(e.FolderPath(), p.FolderPath())
+			})
+			projs = slices.Insert(projs, i, p)
+		}
+	}()
+
+	for _, root := range tree.roots {
+		if err := getProjects(ctx, root, root.name, projChan); err != nil {
+			return nil, err
+		}
+	}
+	close(projChan)
+	wg.Wait()
+	return projs, nil
 }
 
-func outputResult(p *print.Printer, outputFormat string, projects []resourcemanager.Project) error {
+func outputResult(p *print.Printer, outputFormat string, projects []project) error {
 	return p.OutputResult(outputFormat, projects, func() error {
 		table := tables.NewTable()
-		table.SetHeader("ID", "NAME", "STATE", "PARENT ID")
+		table.SetHeader("ORGANIZATION", "FOLDER", "NAME", "ID")
 		for i := range projects {
 			p := projects[i]
-
-			var parentId *string
-			if p.Parent != nil {
-				parentId = p.Parent.Id
-			}
 			table.AddRow(
-				utils.PtrString(p.ProjectId),
-				utils.PtrString(p.Name),
-				utils.PtrString(p.LifecycleState),
-				utils.PtrString(parentId),
+				p.Organization,
+				p.FolderPath(),
+				p.Name,
+				p.ID,
 			)
 		}
 

--- a/internal/cmd/project/list/tree.go
+++ b/internal/cmd/project/list/tree.go
@@ -1,0 +1,147 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/auth"
+
+	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
+)
+
+type node struct {
+	resourceID string
+	name       string
+
+	typ      resourceType
+	parent   *node
+	children []*node
+}
+
+type resourceType string
+
+const (
+	resourceTypeOrg     resourceType = "organization"
+	resourceTypeFolder  resourceType = "folder"
+	resourceTypeProject resourceType = "project"
+)
+
+type resourceTree struct {
+	mu sync.Mutex
+
+	authClient     *authorization.APIClient
+	resourceClient *resourcemanager.APIClient
+	member         string
+	roots          map[string]*node
+}
+
+func newResourceTree(resourceClient *resourcemanager.APIClient, authClient *authorization.APIClient, model *inputModel) (*resourceTree, error) {
+	var member string
+	if model.Member == nil {
+		var err error
+		member, err = auth.GetAuthEmail()
+		if err != nil {
+			return nil, fmt.Errorf("get email of authenticated user: %w", err)
+		}
+	} else {
+		member = *model.Member
+	}
+	tree := &resourceTree{
+		member:         member,
+		resourceClient: resourceClient,
+		authClient:     authClient,
+		roots:          map[string]*node{},
+	}
+	return tree, nil
+}
+
+func (r *resourceTree) Fill(ctx context.Context) error {
+	resp, err := r.authClient.ListUserMemberships(ctx, r.member).ResourceType("organization").Execute()
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, orgMembership := range resp.GetItems() {
+		g.Go(func() error {
+			org, err := r.resourceClient.GetOrganizationExecute(ctx, orgMembership.GetResourceId())
+			if err != nil {
+				return err
+			}
+			orgNode := &node{
+				resourceID: org.GetOrganizationId(),
+				name:       org.GetName(),
+				typ:        resourceTypeOrg,
+			}
+			r.mu.Lock()
+			r.roots[orgNode.resourceID] = orgNode
+			r.mu.Unlock()
+			if err := r.fillNode(ctx, orgNode); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+func (r *resourceTree) fillNode(ctx context.Context, parent *node) error {
+	if err := r.getNodeProjects(ctx, parent); err != nil {
+		return err
+	}
+	req := r.resourceClient.ListFolders(ctx).ContainerParentId(parent.resourceID)
+	resp, err := req.Execute()
+	if err != nil {
+		if !isForbiddenError(err) {
+			return err
+		}
+		// listing folder for parent was forbidden, trying with member
+		resp, err = req.Member(r.member).Execute()
+		if err != nil {
+			return err
+		}
+	}
+	g, ctx := errgroup.WithContext(ctx)
+	for _, folder := range resp.GetItems() {
+		g.Go(func() error {
+			newFolderNode := &node{
+				resourceID: folder.GetFolderId(),
+				parent:     parent,
+				typ:        resourceTypeFolder,
+				name:       folder.GetName(),
+			}
+			parent.children = append(parent.children, newFolderNode)
+			return r.fillNode(ctx, newFolderNode)
+		})
+	}
+	return g.Wait()
+}
+
+func (r *resourceTree) getNodeProjects(ctx context.Context, parent *node) error {
+	req := r.resourceClient.ListProjects(ctx).ContainerParentId(parent.resourceID)
+	resp, err := req.Execute()
+	if err != nil {
+		if !isForbiddenError(err) {
+			return err
+		}
+		// listing projects for parent was forbidden, trying with member
+		resp, err = req.Member(r.member).Execute()
+		if err != nil {
+			return err
+		}
+	}
+	for _, proj := range resp.GetItems() {
+		projNode := &node{
+			resourceID: proj.GetProjectId(),
+			typ:        resourceTypeProject,
+			name:       proj.GetName(),
+			parent:     parent,
+		}
+		parent.children = append(parent.children, projNode)
+	}
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -211,8 +213,9 @@ func Execute(version, date string) {
 	// PersistentPreRun is not called when the command is wrongly called
 	p.Cmd = cmd
 	p.Verbosity = print.InfoLevel
-
-	err := cmd.Execute()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		err := beautifyUnknownAndMissingCommandsError(cmd, err)
 		p.Debug(print.ErrorLevel, "execute command: %v", err)


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

The current implementation of the `project list` command does not return all projects a user has permission to see. It just returns the projects a user is directly a member of, not if he inherited the permissions from e.g. an organization or folder.

This PR uses the authorization and resourcemanager APIs to correctly query all projects a user has permission to see.
The implementation is a tree based data structure that uses recursion to view all projects of a folder, nested folders and projects directly under a organization.

For printing the Organization name, as well as the folder path is additionally printed. I decided against querying the resourcemanager API for project details as that returned in 500's from the API if queried to fast.

The existing flag filters do not apply as good anymore to the implementation, so they could be removed if the implementation itself is accepted.

Tests will be implemented once a first review has been done, as this also takes some time. I tested the change manually.

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
