### PR TITLE
STACKITRCO-186 - Add flag: iaas API param agent

### DIFF
--- a/docs/stackit_server_create.md
+++ b/docs/stackit_server_create.md
@@ -39,12 +39,16 @@ stackit server create [flags]
 
   Create a server with user data (cloud-init)
   $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml
+
+  Create a server with provisioned agent
+  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-id yyy --agent-provisioning-policy ALWAYS
 ```
 
 ### Options
 
 ```
       --affinity-group string                  The affinity group the server is assigned to
+      --agent-provisioning-policy string       Whether to provision an agent on server creation, one of ["ALWAYS" "NEVER" "INHERIT"] (default "INHERIT")
       --availability-zone string               The availability zone of the server
       --boot-volume-delete-on-termination      Delete the volume during the termination of the server. Defaults to false
       --boot-volume-performance-class string   Boot volume performance class

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -28,6 +28,7 @@ const (
 	machineTypeFlag                   = "machine-type"
 	affinityGroupFlag                 = "affinity-group"
 	availabilityZoneFlag              = "availability-zone"
+	agentProvisioningPolicyFlag       = "agent-provisioning-policy"
 	bootVolumeSourceIdFlag            = "boot-volume-source-id"
 	bootVolumeSourceTypeFlag          = "boot-volume-source-type"
 	bootVolumeSizeFlag                = "boot-volume-size"
@@ -50,6 +51,7 @@ type inputModel struct {
 	MachineType                   *string
 	AffinityGroup                 *string
 	AvailabilityZone              *string
+	AgentProvisioningPolicy       *string
 	BootVolumeSourceId            *string
 	BootVolumeSourceType          *string
 	BootVolumeSize                *int64
@@ -109,6 +111,10 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				`Create a server with user data (cloud-init)`,
 				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml`,
 			),
+			examples.NewExample(
+				`Create a server with provisioned agent`,
+				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-id yyy --agent-provisioning-policy ALWAYS`,
+			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -162,6 +168,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
+	agentProvisioningPolicyOptions := []string{"ALWAYS", "NEVER", "INHERIT"}
+	cmd.Flags().Var(flags.EnumFlag(false, "INHERIT", agentProvisioningPolicyOptions...), agentProvisioningPolicyFlag, fmt.Sprintf("Whether to provision an agent on server creation, one of %q", agentProvisioningPolicyOptions))
 	cmd.Flags().StringP(nameFlag, "n", "", "Server name")
 	cmd.Flags().String(machineTypeFlag, "", "Name of the type of the machine for the server. Possible values are documented in https://docs.stackit.cloud/products/compute-engine/server/basics/machine-types/")
 	cmd.Flags().String(affinityGroupFlag, "", "The affinity group the server is assigned to")
@@ -250,6 +258,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		MachineType:                   flags.FlagToStringPointer(p, cmd, machineTypeFlag),
 		AffinityGroup:                 flags.FlagToStringPointer(p, cmd, affinityGroupFlag),
 		AvailabilityZone:              flags.FlagToStringPointer(p, cmd, availabilityZoneFlag),
+		AgentProvisioningPolicy:       flags.FlagToStringPointer(p, cmd, agentProvisioningPolicyFlag),
 		BootVolumeSourceId:            flags.FlagToStringPointer(p, cmd, bootVolumeSourceIdFlag),
 		BootVolumeSourceType:          flags.FlagToStringPointer(p, cmd, bootVolumeSourceTypeFlag),
 		BootVolumeSize:                flags.FlagToInt64Pointer(p, cmd, bootVolumeSizeFlag),
@@ -291,6 +300,15 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 		UserData:            userData,
 		Volumes:             model.Volumes,
 		Labels:              utils.ConvertStringMapToInterfaceMap(model.Labels),
+	}
+
+	if model.AgentProvisioningPolicy != nil {
+		switch *model.AgentProvisioningPolicy {
+		case "ALWAYS":
+			payload.Agent = &iaas.ServerAgent{Provisioned: utils.Ptr(true)}
+		case "NEVER":
+			payload.Agent = &iaas.ServerAgent{Provisioned: utils.Ptr(false)}
+		}
 	}
 
 	if model.BootVolumePerformanceClass != nil || model.BootVolumeSize != nil || model.BootVolumeDeleteOnTermination != nil || model.BootVolumeSourceId != nil || model.BootVolumeSourceType != nil {

--- a/internal/cmd/server/create/create_test.go
+++ b/internal/cmd/server/create/create_test.go
@@ -35,6 +35,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		globalflags.ProjectIdFlag: testProjectId,
 		globalflags.RegionFlag:    testRegion,
 
+		agentProvisioningPolicyFlag:       "INHERIT",
 		availabilityZoneFlag:              "eu01-1",
 		nameFlag:                          "test-server-name",
 		machineTypeFlag:                   "t1.1",
@@ -65,6 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
+		AgentProvisioningPolicy:       utils.Ptr("INHERIT"),
 		AvailabilityZone:              utils.Ptr("eu01-1"),
 		Name:                          utils.Ptr("test-server-name"),
 		MachineType:                   utils.Ptr("t1.1"),
@@ -164,6 +166,7 @@ func TestParseInput(t *testing.T) {
 			description: "required only",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, affinityGroupFlag)
+				delete(flagValues, agentProvisioningPolicyFlag)
 				delete(flagValues, availabilityZoneFlag)
 				delete(flagValues, labelFlag)
 				delete(flagValues, bootVolumeSourceIdFlag)
@@ -182,6 +185,7 @@ func TestParseInput(t *testing.T) {
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
 				model.AffinityGroup = nil
+				model.AgentProvisioningPolicy = nil
 				model.AvailabilityZone = nil
 				model.Labels = nil
 				model.BootVolumeSourceId = nil
@@ -327,6 +331,26 @@ func TestParseInput(t *testing.T) {
 				model.ImageId = nil
 			}),
 		},
+		{
+			description: "valid with agent-provisioned flag missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, agentProvisioningPolicyFlag)
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.AgentProvisioningPolicy = nil
+			}),
+		},
+		{
+			description: "agent-provisioned flag properly handled",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[agentProvisioningPolicyFlag] = "ALWAYS"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.AgentProvisioningPolicy = utils.Ptr("ALWAYS")
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -359,6 +383,19 @@ func TestBuildRequest(t *testing.T) {
 				Name:        utils.Ptr("test-server-name"),
 			},
 			expectedRequest: fixtureRequiredRequest(),
+		},
+		{
+			description: "with provisioned agent",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.AgentProvisioningPolicy = utils.Ptr("ALWAYS")
+			}),
+			expectedRequest: fixtureRequest(func(request *iaas.ApiCreateServerRequest) {
+				payload := fixturePayload()
+				payload.Agent = &iaas.ServerAgent{
+					Provisioned: utils.Ptr(true),
+				}
+				*request = (*request).CreateServerPayload(payload)
+			}),
 		},
 	}
 

--- a/internal/cmd/server/describe/describe.go
+++ b/internal/cmd/server/describe/describe.go
@@ -161,6 +161,11 @@ func outputResult(p *print.Printer, outputFormat string, server *iaas.Server) er
 			table.AddSeparator()
 		}
 
+		if server.Agent != nil && server.Agent.Provisioned != nil {
+			table.AddRow("AGENT", *server.Agent.Provisioned)
+			table.AddSeparator()
+		}
+
 		if server.MachineType != nil {
 			table.AddRow("MACHINE TYPE", *server.MachineType)
 			table.AddSeparator()

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -165,7 +165,7 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 		return nil
 	default:
 		table := tables.NewTable()
-		table.SetHeader("ID", "Name", "Status", "Machine Type", "Availability Zones", "Nic IPv4", "Public IPs")
+		table.SetHeader("ID", "Name", "Status", "Machine Type", "Availability Zones", "Nic IPv4", "Public IPs", "Agent")
 
 		for i := range servers {
 			server := servers[i]
@@ -186,6 +186,11 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 				}
 			}
 
+			agent := ""
+			if server.Agent != nil {
+				agent = utils.PtrString(server.Agent.Provisioned)
+			}
+
 			table.AddRow(
 				utils.PtrString(server.Id),
 				utils.PtrString(server.Name),
@@ -194,6 +199,7 @@ func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) 
 				utils.PtrString(server.AvailabilityZone),
 				nicIPv4,
 				publicIPs,
+				agent,
 			)
 		}
 

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -201,6 +201,7 @@ type Base64PatchedServer struct {
 	UpdatedAt           *time.Time              `json:"updatedAt,omitempty"`
 	UserData            *Base64Bytes            `json:"userData,omitempty"`
 	Volumes             *[]string               `json:"volumes,omitempty"`
+	Agent               *iaas.ServerAgent       `json:"agent,omitempty"`
 }
 
 // ConvertToBase64PatchedServer converts an iaas.Server to Base64PatchedServer
@@ -241,6 +242,7 @@ func ConvertToBase64PatchedServer(server *iaas.Server) *Base64PatchedServer {
 		UpdatedAt:           server.UpdatedAt,
 		UserData:            userData,
 		Volumes:             server.Volumes,
+		Agent:               server.Agent,
 	}
 }
 

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -349,6 +349,27 @@ func TestConvertToBase64PatchedServer(t *testing.T) {
 				UserData:         nil,
 			},
 		},
+		{
+			name: "server with agent",
+			input: &iaas.Server{
+				Id:               Ptr("server-456"),
+				Name:             Ptr("test-server-2"),
+				Status:           Ptr("STOPPED"),
+				AvailabilityZone: Ptr("eu01-2"),
+				MachineType:      Ptr("t1.2"),
+				UserData:         &emptyUserData,
+				Agent:            &iaas.ServerAgent{Provisioned: Ptr(true)},
+			},
+			expected: &Base64PatchedServer{
+				Id:               Ptr("server-456"),
+				Name:             Ptr("test-server-2"),
+				Status:           Ptr("STOPPED"),
+				AvailabilityZone: Ptr("eu01-2"),
+				MachineType:      Ptr("t1.2"),
+				UserData:         Ptr(Base64Bytes(emptyUserData)),
+				Agent:            Ptr(iaas.ServerAgent{Provisioned: Ptr(true)}),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds a cli flag for the iaas ( _create server_ ) API param: `"agent": {"provisioned": true}`

ref STACKITRCO-186

---

Tests:
* ran `make fmt`, `make generate-docs`

* unit tests
```
[~/stackit-cli] go test internal/cmd/server/create/*
ok      command-line-arguments  0.006s
[~/stackit-cli]
[~/stackit-cli] make test
>> Running tests for the CLI application
...
ok      github.com/stackitcloud/stackit-cli/internal/cmd/server/create  0.006s  coverage: 69.7% of statements
...
```

* ran without specifying the new flag (default is agent-provisioned=false) - no change, same behavior as before
```
[~/stackit-cli] stackit -y --project-id c904f41c-2f8c-4edb-b966-e87d65f10b64 server create   --name server1   --machine-type t1.1   --network-id 97c5dde4-cb9d-49b8-be55-9cdf0c3795e1   --boot-volume-source-type image   --boot-volume-source-id 21466190-b904-4267-8bf3-1be4323f4ffb   --boot-volume-size 20   --boot-volume-delete-on-termination=true
...
Server ID: 71785201-d749-4449-99b2-6dc23f406133

[~/stackit-cli] stackit -y server command create --server-id=71785201-d749-4449-99b2-6dc23f406133 --project-id=c904f41c-2f8c-4edb-b966-e87d65f10b64 --template-name=RunShellScript --params script='echo hello'
Error: create Server Command: 404 Not Found, status code 404, Body: {"status":"Not Found","message":"agent not found"}

[~/stackit-cli] stackit -y --project-id c904f41c-2f8c-4edb-b966-e87d65f10b64 server delete 71785201-d749-4449-99b2-6dc23f406133
Deleting server ✓
Deleted server "server1"
```

* ran with specifying flag agent-provisioned=true - the server was created with a provisioned agent, it was possible to set commands
```
[~/stackit-cli] stackit -y --project-id c904f41c-2f8c-4edb-b966-e87d65f10b64 server create   --name server1   --machine-type t1.1   --network-id 97c5dde4-cb9d-49b8-be55-9cdf0c3795e1   --boot-volume-source-type image   --boot-volume-source-id 21466190-b904-4267-8bf3-1be4323f4ffb   --boot-volume-size 20   --boot-volume-delete-on-termination=true --agent-provisioned=true
...
Server ID: ed3086ff-a1ef-44ec-b2f7-08775611dc4e

[~/stackit-cli] stackit -y server command create --server-id=ed3086ff-a1ef-44ec-b2f7-08775611dc4e --project-id=c904f41c-2f8c-4edb-b966-e87d65f10b64 --template-name=RunShellScript --params script='echo hello'
Created server command for server server1. Command ID: 263667

[~/stackit-cli] stackit -y --project-id c904f41c-2f8c-4edb-b966-e87d65f10b64 server delete ed3086ff-a1ef-44ec-b2f7-08775611dc4e
Deleting server ✓
Deleted server "server1"
```

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITRCO-186

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [ ] No linter issues: `make lint` (will be checked by CI) 
