### PR TITLE
escape html encoding to marshal json output completely

### DIFF
--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -262,10 +262,10 @@ func (p *Printer) OutputResult(outputFormat string, output any, prettyOutputFunc
 		encoder.SetEscapeHTML(false)
 		encoder.SetIndent("", "  ")
 		err := encoder.Encode(output)
-		details := buffer.Bytes()
 		if err != nil {
 			return fmt.Errorf("marshal json: %w", err)
 		}
+		details := buffer.Bytes()
 		p.Outputln(string(details))
 
 		return nil


### PR DESCRIPTION
## Description

In the json output format, the used marshal function will escape some characters and replace with the unicode. 
This was causing some issues in the output of some commands like mongodbflex user creation uri. 

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
