### PR TITLE
Update to stackit-sdk-go/services/edge v0.3.0

### DIFF
--- a/internal/cmd/beta/edge/instance/create/create_test.go
+++ b/internal/cmd/beta/edge/instance/create/create_test.go
@@ -57,12 +57,12 @@ func (m *mockExecutable) Execute() (*edge.Instance, error) {
 
 // mockAPIClient is a mock for the client.APIClient interface
 type mockAPIClient struct {
-	postInstancesMock edge.ApiCreateInstanceRequest
+	createInstanceMock edge.ApiCreateInstanceRequest
 }
 
 func (m *mockAPIClient) CreateInstance(_ context.Context, _, _ string) edge.ApiCreateInstanceRequest {
-	if m.postInstancesMock != nil {
-		return m.postInstancesMock
+	if m.createInstanceMock != nil {
+		return m.createInstanceMock
 	}
 	return &mockExecutable{}
 }
@@ -285,7 +285,7 @@ func TestBuildRequest(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					postInstancesMock: &mockExecutable{},
+					createInstanceMock: &mockExecutable{},
 				},
 			},
 			want: &createRequestSpec{
@@ -331,7 +331,7 @@ func TestRun(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					postInstancesMock: &mockExecutable{
+					createInstanceMock: &mockExecutable{
 						resp: &edge.Instance{Id: &testInstanceId},
 					},
 				},
@@ -343,7 +343,7 @@ func TestRun(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					postInstancesMock: &mockExecutable{
+					createInstanceMock: &mockExecutable{
 						executeFails: true,
 					},
 				},

--- a/internal/cmd/beta/edge/instance/list/list_test.go
+++ b/internal/cmd/beta/edge/instance/list/list_test.go
@@ -52,12 +52,12 @@ func (m *mockExecutable) Execute() (*edge.InstanceList, error) {
 
 // mockAPIClient is a mock for the edge.APIClient interface
 type mockAPIClient struct {
-	getInstancesMock edge.ApiListInstancesRequest
+	listInstancesMock edge.ApiListInstancesRequest
 }
 
 func (m *mockAPIClient) ListInstances(_ context.Context, _, _ string) edge.ApiListInstancesRequest {
-	if m.getInstancesMock != nil {
-		return m.getInstancesMock
+	if m.listInstancesMock != nil {
+		return m.listInstancesMock
 	}
 	return &mockExecutable{}
 }
@@ -291,7 +291,7 @@ func TestRun(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					getInstancesMock: &mockExecutable{
+					listInstancesMock: &mockExecutable{
 						executeResp: &edge.InstanceList{Instances: &[]edge.Instance{}},
 					},
 				},
@@ -303,7 +303,7 @@ func TestRun(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					getInstancesMock: &mockExecutable{
+					listInstancesMock: &mockExecutable{
 						executeFails: true,
 					},
 				},
@@ -426,7 +426,7 @@ func TestBuildRequest(t *testing.T) {
 			args: args{
 				model: fixtureInputModel(),
 				client: &mockAPIClient{
-					getInstancesMock: &mockExecutable{},
+					listInstancesMock: &mockExecutable{},
 				},
 			},
 		},
@@ -442,7 +442,7 @@ func TestBuildRequest(t *testing.T) {
 					model.Limit = utils.Ptr(int64(10))
 				}),
 				client: &mockAPIClient{
-					getInstancesMock: &mockExecutable{},
+					listInstancesMock: &mockExecutable{},
 				},
 			},
 		},

--- a/internal/pkg/services/edge/client/client.go
+++ b/internal/pkg/services/edge/client/client.go
@@ -15,18 +15,18 @@ import (
 
 // APIClient is an interface that consolidates all client functionality to allow for mocking of the API client during testing.
 type APIClient interface {
-	CreateInstance(ctx context.Context, projectId, region string) edge.ApiCreateInstanceRequest
-	DeleteInstance(ctx context.Context, projectId, region, instanceId string) edge.ApiDeleteInstanceRequest
-	DeleteInstanceByName(ctx context.Context, projectId, region, instanceName string) edge.ApiDeleteInstanceByNameRequest
-	GetInstance(ctx context.Context, projectId, region, instanceId string) edge.ApiGetInstanceRequest
-	GetInstanceByName(ctx context.Context, projectId, region, instanceName string) edge.ApiGetInstanceByNameRequest
-	ListInstances(ctx context.Context, projectId, region string) edge.ApiListInstancesRequest
-	UpdateInstance(ctx context.Context, projectId, region, instanceId string) edge.ApiUpdateInstanceRequest
-	UpdateInstanceByName(ctx context.Context, projectId, region, instanceName string) edge.ApiUpdateInstanceByNameRequest
-	GetKubeconfigByInstanceId(ctx context.Context, projectId, region, instanceId string) edge.ApiGetKubeconfigByInstanceIdRequest
-	GetKubeconfigByInstanceName(ctx context.Context, projectId, region, instanceName string) edge.ApiGetKubeconfigByInstanceNameRequest
-	GetTokenByInstanceId(ctx context.Context, projectId, region, instanceId string) edge.ApiGetTokenByInstanceIdRequest
-	GetTokenByInstanceName(ctx context.Context, projectId, region, instanceName string) edge.ApiGetTokenByInstanceNameRequest
+	CreateInstance(ctx context.Context, projectId, regionId string) edge.ApiCreateInstanceRequest
+	DeleteInstance(ctx context.Context, projectId, regionId, instanceId string) edge.ApiDeleteInstanceRequest
+	DeleteInstanceByName(ctx context.Context, projectId, regionId, displayName string) edge.ApiDeleteInstanceByNameRequest
+	GetInstance(ctx context.Context, projectId, regionId, instanceId string) edge.ApiGetInstanceRequest
+	GetInstanceByName(ctx context.Context, projectId, regionId, displayName string) edge.ApiGetInstanceByNameRequest
+	ListInstances(ctx context.Context, projectId, regionId string) edge.ApiListInstancesRequest
+	UpdateInstance(ctx context.Context, projectId, regionId, instanceId string) edge.ApiUpdateInstanceRequest
+	UpdateInstanceByName(ctx context.Context, projectId, regionId, displayName string) edge.ApiUpdateInstanceByNameRequest
+	GetKubeconfigByInstanceId(ctx context.Context, projectId, regionId, instanceId string) edge.ApiGetKubeconfigByInstanceIdRequest
+	GetKubeconfigByInstanceName(ctx context.Context, projectId, regionId, displayName string) edge.ApiGetKubeconfigByInstanceNameRequest
+	GetTokenByInstanceId(ctx context.Context, projectId, regionId, instanceId string) edge.ApiGetTokenByInstanceIdRequest
+	GetTokenByInstanceName(ctx context.Context, projectId, regionId, displayName string) edge.ApiGetTokenByInstanceNameRequest
 	ListPlansProject(ctx context.Context, projectId string) edge.ApiListPlansProjectRequest
 }
 


### PR DESCRIPTION
## Description

This updates the methods names used in the unit tests of the edge-cloud service to be consistent with the changed method names of stackit-sdk-go/services/edge v0.3.0. Relates to #1230

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
