### PR TITLE
chore(deps): bump github.com/stackitcloud/stackit-sdk-go/services/serverbackup from v1.3.4 to v1.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.18.2
 	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.3.3
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.0
-	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.4
+	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.5
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.3
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.11.3
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.3.3 h1:ShK5AFExNRA
 github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.3.3/go.mod h1:P1uhYJpSvhUXTnTGSEZqWf97J2+1Z6VuVwmUOlnhiwI=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.0 h1:8cFo0UG2r9kWwUAHRBTAG5wEt4G80+wkWdjQW6DhU6Y=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.0/go.mod h1:dMBt/b/LXfXTDLQTCW6PRhBlbl41q7XS+5mAyBezSJk=
-github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.4 h1:lOlg8zYL2nwMi1JxDYW2p8LL4cSB3eoOjlqPHioDWU0=
-github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.4/go.mod h1:MBlzqmewliF1LKeOBdOuT+aQrtc3y7p1Kd1fWkjecKQ=
+github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.5 h1:pAoqz4K17ZWcLusu7Dxkx3HGQAIYCk7SmZeAu9HHUrQ=
+github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.5/go.mod h1:MBlzqmewliF1LKeOBdOuT+aQrtc3y7p1Kd1fWkjecKQ=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.3 h1:1gLKXD91qOYUpackMuu0PdRwrm2Z8vFK+k8H7SF0xbg=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.3/go.mod h1:V34YusCRsq/3bJ/HxUk0wslLjVWWE/QVe70AZ+XrDPE=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.11.3 h1:XV3pPXpdvQjR5Z90FFutU4iqCHfejDYQAL840Y4ztLM=

--- a/internal/pkg/services/serverbackup/utils/utils_test.go
+++ b/internal/pkg/services/serverbackup/utils/utils_test.go
@@ -88,7 +88,7 @@ func TestCanDisableBackupService(t *testing.T) {
 						LastRestoredAt: utils.Ptr("test timestamp"),
 						Name:           utils.Ptr("test name"),
 						Size:           utils.Ptr(int64(5)),
-						Status:         serverbackup.BACKUPSTATUS_BACKING_UP.Ptr(),
+						Status:         serverbackup.BACKUPSTATUS_IN_PROGRESS.Ptr(),
 						VolumeBackups:  nil,
 					},
 				},


### PR DESCRIPTION
## Description

relates to STACKITCLI-304 and #1202

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
