### PR TITLE
Support opening auth url on FreeBSD

### DIFF
--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -342,7 +342,7 @@ func cleanup(server *http.Server) {
 func openBrowser(pageUrl string) error {
 	var err error
 	switch runtime.GOOS {
-	case "linux":
+	case "freebsd", "linux":
 		// We need to use the windows way on WSL, otherwise we do not pass query
 		// parameters correctly. https://github.com/microsoft/WSL/issues/3832
 		if _, ok := os.LookupEnv("WSL_DISTRO_NAME"); !ok {


### PR DESCRIPTION
## Description

stackit-cli can be used with key flow, but cannot be used right now using `stackit auth login` on FreeBSD.
You will receive an 'unsupported platform' error when trying to open the browser URL to authenticate.

FreeBSD can be used similar to Linux, so I just added it next to Linux in `openBrowser`. I think the WSL_DISTRO_NAME lookup is not relevant for FreeBSD, but also doesn't hurt and didn't want to create a separate switch case. But let me know if you prefer a separate switch case.

## Checklist

- [ ] Issue was linked above
- [X] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
