### PR TITLE
auth: login: explicit check for ipv6 port bindings

### DIFF
--- a/internal/pkg/auth/user_login.go
+++ b/internal/pkg/auth/user_login.go
@@ -85,6 +85,8 @@ func AuthorizeUser(p *print.Printer, authConfig UserAuthConfig) error {
 	var redirectURL string
 	var listener net.Listener
 	var listenerErr error
+	var ipv6Listener net.Listener
+	var ipv6ListenerErr error
 	var port int
 	startingPort := defaultPort
 	portRange := configuredPortRange
@@ -94,18 +96,27 @@ func AuthorizeUser(p *print.Printer, authConfig UserAuthConfig) error {
 	}
 	for i := range portRange {
 		port = startingPort + i
-		portString := fmt.Sprintf(":%s", strconv.Itoa(port))
+		ipv4addr := fmt.Sprintf("127.0.0.1:%d", port)
+		ipv6addr := fmt.Sprintf("[::1]:%d", port)
 		p.Debug(print.DebugLevel, "trying to bind port %d for login redirect", port)
-		listener, listenerErr = net.Listen("tcp", portString)
+		ipv6Listener, ipv6ListenerErr = net.Listen("tcp6", ipv6addr)
+		if ipv6ListenerErr != nil {
+			continue
+		}
+		listener, listenerErr = net.Listen("tcp4", ipv4addr)
 		if listenerErr == nil {
+			_ = ipv6Listener.Close()
 			redirectURL = fmt.Sprintf("http://localhost:%d", port)
 			p.Debug(print.DebugLevel, "bound port %d for login redirect", port)
 			break
 		}
 		p.Debug(print.DebugLevel, "unable to bind port %d for login redirect: %s", port, listenerErr)
 	}
+	if ipv6ListenerErr != nil {
+		return fmt.Errorf("unable to bind port for login redirect, tried from port %d to %d: %w", startingPort, port, ipv6ListenerErr)
+	}
 	if listenerErr != nil {
-		return fmt.Errorf("unable to bind port for login redirect, tried from port %d to %d: %w", defaultPort, port, listenerErr)
+		return fmt.Errorf("unable to bind port for login redirect, tried from port %d to %d: %w", startingPort, port, listenerErr)
 	}
 
 	conf := &oauth2.Config{


### PR DESCRIPTION
## Description

Fixes [1250](https://github.com/stackitcloud/stackit-cli/issues/1250) 

This PR tries to address the issue of the net.Listen() not being able to see that the requested port is already taken on MacOS.

This happens specifically on MacOS, when there is already a service bound to a port on the IPv6 localhost interface, but the port is free on the IPv4 localhost interface. The net.Listen() method sees that the port is open on the 127.0.0.1 interface, and binds to that one. When the user gets redirected to localhost in the browser, it can redirect to either one of the services using the same port on the different interfaces(seems like localhost resolving to the IPv6 is preferred).

## Testing

I tested by running the following python service locally, and executing `stackit auth login` after that which replicates the issue and can be observed.

```python
#!/usr/bin/env python3
from http.server import HTTPServer, SimpleHTTPRequestHandler
import socket

HOST = "::1"
PORT = 8000

class IPv6HTTPServer(HTTPServer):
    address_family = socket.AF_INET6

server = IPv6HTTPServer((HOST, PORT), SimpleHTTPRequestHandler)
print(f"Serving on http://[{HOST}]:{PORT}")
server.serve_forever()
```

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
