### PR TITLE
fix(print): use os.Stdin.Fd instead of syscall.Stdin in PromptForPassword

### DIFF
--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -6,14 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"syscall"
-
-	"github.com/goccy/go-yaml"
-
 	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/goccy/go-yaml"
 
 	"github.com/fatih/color"
 	"github.com/lmittmann/tint"
@@ -182,13 +180,16 @@ func (p *Printer) PromptForEnter(prompt string) error {
 func (p *Printer) PromptForPassword(prompt string) (string, error) {
 	p.Cmd.PrintErr(prompt)
 	defer p.Outputln("")
-	if term.IsTerminal(syscall.Stdin) {
-		bytePassword, err := term.ReadPassword(syscall.Stdin)
+
+	fd := int(os.Stdin.Fd())
+	if term.IsTerminal(fd) {
+		bytePassword, err := term.ReadPassword(fd)
 		if err != nil {
 			return "", fmt.Errorf("read password: %w", err)
 		}
 		return string(bytePassword), nil
 	}
+
 	// Fallback for non-terminal environments
 	reader := bufio.NewReader(p.Cmd.InOrStdin())
 	pw, err := reader.ReadString('\n')


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-315

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
