### PR TITLE
fix(release): don't put license in root directory on apt installation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,7 +105,9 @@ nfpms:
     license: Apache 2.0
     contents:
       - src: LICENSE.md
-        dst: LICENSE.md
+        dst: /usr/share/doc/stackit/copyright
+        file_info:
+          mode: 0644
     formats:
       - deb
       - rpm


### PR DESCRIPTION
relates to STACKITCLI-324 and #1265

## Description

The license file was put in the root directory `/LICENSE.md`. Now it's placed under `/usr/share/doc/stackit/copyright` which seems to be common for APT packages.

## Testing instructions

I built a test environment for you with docker which allows you to check if the file is still located in `/LICENSE.md` or in `/usr/share/doc/stackit/copyright`. Read #1265 and the script, then you should understand roughly what happens and what's your job to test. 

To setup the test environment create a file named `Dockerfile` in the root of the repo and a file named `test.sh` with the following contents.

**Run this script (including your manual testing steps) once for the `main` branch and once with my bugfix branch to verify the old and the new behavior.**

Then run: `./test.sh`

```Dockerfile
FROM ubuntu:latest

USER root
COPY stackit.deb /stackit.deb
RUN dpkg -i /stackit.deb

CMD ["tail","-f","/dev/null"]
```

```bash
#!/usr/bin/env bash

echo "Building with goreleaser"
goreleaser release --snapshot --clean

DEB_FILE=$(find ./dist -maxdepth 1 -name "*amd64.deb" -print -quit)

if [ -z "$DEB_FILE" ]; then
    echo "Error: No amd64.deb file found!"
    exit 1
fi

echo "Targeting: $DEB_FILE"

cp $DEB_FILE ./stackit.deb

echo "Building test image"
docker build -t cr.stackit.cloud/stackit-cli:latest .

echo "Starting test container"
docker run -d --name stackit-cli cr.stackit.cloud/stackit-cli:latest

echo "Connecting to test container, exit by typing 'exit'"
echo "YOUR TURN: Check if the LICENSE.md file is present in the root directory (run 'ls /')"
docker exec -it -u root stackit-cli /bin/bash

echo "Removing test container"
docker rm -f stackit-cli
```

As I'm no MacOS user I had to adjust the goreleaser config a little bit (comment out the MacOS signing stuff and the snapcraft stuff). So it looks like this for the fixed version for me:

```yaml
version: 2

before:
  hooks:
    - go mod tidy

builds:
  - id: linux-builds
    env:
      - CGO_ENABLED=0
    goos:
      - linux
    binary: "stackit"

  - id: windows-builds
    env:
      - CGO_ENABLED=0
    goos:
      - windows
    binary: "stackit"

  - id: macos-builds
    env:
      - CGO_ENABLED=0
      - BUNDLE_ID=cloud.stackit.cli
      - "APPLE_APPLICATION_IDENTITY=Developer ID Application: Schwarz IT KG"
    goos:
      - darwin
    binary: "stackit"
    goarch:
      - arm64
      - amd64
    hooks:
      post:
        # Signing
        #- cmd: codesign -s "{{.Env.APPLE_APPLICATION_IDENTITY}}" -f -v --options=runtime "dist/macos-builds_{{.Target}}/{{.Name}}"
        #  output: true
        #- cmd: codesign -vvv --deep --strict "dist/macos-builds_{{.Target}}/{{.Name}}"
        #  output: true
        #- cmd: hdiutil create -volname "STACKIT-CLI" -srcfolder "dist/macos-builds_{{.Target}}/{{.Name}}" -ov -format UDZO "dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg"
        #  output: true
        #- cmd: codesign -s "{{.Env.APPLE_APPLICATION_IDENTITY}}" -f -v --options=runtime "dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg"
        #  output: true
        #- cmd: xcrun notarytool submit --keychain-profile "stackit-cli" --wait --progress dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg
        #  output: true
        #- cmd: xcrun stapler staple "dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg"
        #  output: true
        #- cmd: spctl -a -t open --context context:primary-signature -v dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.dmg
        #  output: true
        # Completion files
        - cmd: mkdir -p dist/completions
        - cmd: sh -c 'go run main.go completion zsh > ./dist/completions/stackit.zsh'
        - cmd: sh -c 'go run main.go completion bash > ./dist/completions/stackit.bash'
        - cmd: sh -c 'go run main.go completion fish > ./dist/completions/stackit.fish'

  - id: freebsd-builds
    env:
      - CGO_ENABLED=0
    goos:
      - freebsd
    goarch:
      - arm64
      - amd64
    binary: "stackit"

archives:
  - id: windows-archives
    ids:
      - windows-builds
    formats: [ 'zip' ]
  - ids:
      - linux-builds
      - macos-builds
      - freebsd-builds
    formats: [ 'tar.gz' ]
    files:
      - src: ./dist/completions/*
        dst: completions
      - LICENSE.md
      - README.md

release:
  # If set to auto, the GitHub release will be marked as "Pre-release"
  # if the tag has a prerelease indicator (e.g. v0.0.1-alpha1)
  prerelease: auto

changelog:
  use: github
  sort: asc
  filters:
    exclude:
      - "^docs:"
      - "^test:"

nfpms:
  - id: linux-packages
    # IDs of the builds for which to create packages for
    ids:
      - linux-builds
    package_name: stackit
    vendor: STACKIT
    homepage: https://github.com/stackitcloud/stackit-cli
    maintainer: STACKIT Developer Tools Team <developer-tools@stackit.cloud>
    description: A command-line interface to manage STACKIT resources.
    license: Apache 2.0
    contents:
      - src: LICENSE.md
        dst: /usr/share/doc/stackit/copyright
        file_info:
          mode: 0644
    formats:
      - deb
      - rpm

    rpm:
      # The package is signed if a key_file is set
      #signature:
      #  key_file: "{{ .Env.GPG_KEY_PATH }}"

homebrew_casks:
  - name: stackit
    directory: Casks
    repository:
      owner: stackitcloud
      name: homebrew-tap
    commit_author:
      name: CLI Release Bot
      email: noreply@stackit.de
    homepage: "https://github.com/stackitcloud/stackit-cli"
    description: "A command-line interface to manage STACKIT resources."
    license: "Apache-2.0"
    # If set to auto, the release will not be uploaded to the homebrew tap repo
    # if the tag has a prerelease indicator (e.g. v0.0.1-alpha1)
    skip_upload: auto
    completions:
      zsh: ./completions/stackit.zsh
      bash: ./completions/stackit.bash
      fish: ./completions/stackit.fish

#snapcrafts:
#  # IDs of the builds for which to create packages for
#  - ids:
#      - linux-builds
#    # The name of the snap
#    name: stackit
#    # The canonical title of the application, displayed in the software
#    # centre graphical frontends
#    title: STACKIT CLI
#    summary: A command-line interface to manage STACKIT resources.
#    description: "A command-line interface to manage STACKIT resources."
#    license: Apache-2.0
#    confinement: classic
#    # Grade "devel" will only release to `edge` and `beta` channels
#    # Grade "stable" will also release to the `candidate` and `stable` channels
#    grade: stable
#    # Whether to publish the Snap to the store
#    publish: true

winget:
  - name: stackit
    publisher: stackitcloud
    short_description: A command-line interface to manage STACKIT resources.
    license: Apache-2.0
    publisher_support_url: "https://github.com/stackitcloud/stackit-cli/issues"
    package_identifier: stackitcloud.stackit
    homepage: "https://github.com/stackitcloud/stackit-cli"
    # If set to auto, the release will not be uploaded to the homebrew tap repo
    # if the tag has a prerelease indicator (e.g. v0.0.1-alpha1)
    # Temporarily not skipping prereleases to test integration with Winget
    # skip_upload: auto
    repository:
      owner: stackitcloud
      name: winget-pkgs
      pull_request:
        enabled: true
        base:
          owner: microsoft
          name: winget-pkgs
          branch: master

```

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
