### PR TITLE
chore: disable temporary snapcraft release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,24 +137,25 @@ homebrew_casks:
       bash: ./completions/stackit.bash
       fish: ./completions/stackit.fish
 
-snapcrafts:
-  # IDs of the builds for which to create packages for
-  - ids:
-      - linux-builds
-    # The name of the snap
-    name: stackit
-    # The canonical title of the application, displayed in the software
-    # centre graphical frontends
-    title: STACKIT CLI
-    summary: A command-line interface to manage STACKIT resources.
-    description: "A command-line interface to manage STACKIT resources."
-    license: Apache-2.0
-    confinement: classic
-    # Grade "devel" will only release to `edge` and `beta` channels
-    # Grade "stable" will also release to the `candidate` and `stable` channels
-    grade: stable
-    # Whether to publish the Snap to the store
-    publish: true
+# Temporary disable snap release, see https://jira.schwarz/browse/STACKITCLI-330
+# snapcrafts:
+#   # IDs of the builds for which to create packages for
+#   - ids:
+#       - linux-builds
+#     # The name of the snap
+#     name: stackit
+#     # The canonical title of the application, displayed in the software
+#     # centre graphical frontends
+#     title: STACKIT CLI
+#     summary: A command-line interface to manage STACKIT resources.
+#     description: "A command-line interface to manage STACKIT resources."
+#     license: Apache-2.0
+#     confinement: classic
+#     # Grade "devel" will only release to `edge` and `beta` channels
+#     # Grade "stable" will also release to the `candidate` and `stable` channels
+#     grade: stable
+#     # Whether to publish the Snap to the store
+#     publish: true
 
 winget:
   - name: stackit


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

disable snapcraft release temporary until token is updated to unblock [release pipeline](https://github.com/stackitcloud/stackit-cli/actions/runs/22094651571/job/63848417504#step:8:204)

follow up ticket STACKITCLI-330

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
