### PR TITLE
feat: Document scoop as installation option for Windows

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -188,7 +188,22 @@ Alternatively, you can install via [Homebrew](https://brew.sh/) or refer to one 
 
 ### Windows
 
-> We are currently working on distributing the CLI on a package manager for Windows. For the moment, please refer to one of the installation methods below.
+#### Scoop
+
+The STACKIT CLI can be installed through the [Scoop](https://scoop.sh/) package manager.
+
+1. Install Scoop (if not already installed):
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+```
+
+2. Install the CLI:
+
+```powershell
+scoop install stackit
+```
 
 ## Manual installation
 


### PR DESCRIPTION
## Description

Document how to install the cli using [Scoop](https://scoop.sh/) on Windows

relates to https://github.com/stackitcloud/stackit-cli/issues/291

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
