### PR TITLE
feat(intake): port to v1betaapi

### DIFF
--- a/docs/stackit_beta_intake_runner_create.md
+++ b/docs/stackit_beta_intake_runner_create.md
@@ -23,12 +23,12 @@ stackit beta intake runner create [flags]
 ### Options
 
 ```
-      --description string          Description
-      --display-name string         Display name
-  -h, --help                        Help for "stackit beta intake runner create"
-      --labels stringToString       Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2" (default [])
-      --max-message-size-kib int    Maximum message size in KiB
-      --max-messages-per-hour int   Maximum number of messages per hour
+      --description string            Description
+      --display-name string           Display name
+  -h, --help                          Help for "stackit beta intake runner create"
+      --labels stringToString         Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2" (default [])
+      --max-message-size-kib int32    Maximum message size in KiB
+      --max-messages-per-hour int32   Maximum number of messages per hour
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_beta_intake_runner_update.md
+++ b/docs/stackit_beta_intake_runner_update.md
@@ -23,12 +23,12 @@ stackit beta intake runner update RUNNER_ID [flags]
 ### Options
 
 ```
-      --description string          Description
-      --display-name string         Display name
-  -h, --help                        Help for "stackit beta intake runner update"
-      --labels stringToString       Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2". (default [])
-      --max-message-size-kib int    Maximum message size in KiB. Note: Overall message capacity cannot be decreased.
-      --max-messages-per-hour int   Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.
+      --description string            Description
+      --display-name string           Display name
+  -h, --help                          Help for "stackit beta intake runner update"
+      --labels stringToString         Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2". (default [])
+      --max-message-size-kib int32    Maximum message size in KiB. Note: Overall message capacity cannot be decreased.
+      --max-messages-per-hour int32   Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3
 	github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.5
-	github.com/stackitcloud/stackit-sdk-go/services/intake v0.4.4
+	github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1
 	github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3 h1:VIjkSofZz9utOOkBd
 github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3/go.mod h1:EJk1Ss9GTel2NPIu/w3+x9XcQcEd2k3ibea5aQDzVhQ=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.5 h1:W57+XRa8wTLsi5CV9Tqa7mGgt/PvlRM//RurXSmvII8=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.5/go.mod h1:lTWjW57eAq1bwfM6nsNinhoBr3MHFW/GaFasdAsYfDM=
-github.com/stackitcloud/stackit-sdk-go/services/intake v0.4.4 h1:cbXM7jUBCL7A5zxJKFWolRIDl45sdJMMMAzeumeIEOA=
-github.com/stackitcloud/stackit-sdk-go/services/intake v0.4.4/go.mod h1:z+7KKZf0uHXU/Kb4CRs/oaBrXRJ01LpiD0OH11MXLOk=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1 h1:7ZSrwps/zI41rl+xYkG4osld8cyAwssyl/UZ/Iu/F2g=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1/go.mod h1:ZIvwBZwEMFO+YfJLCNXqabslI0Fp9zxV7ZBwlZjk7uE=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2 h1:2ulSL2IkIAKND59eAjbEhVkOoBMyvm48ojwz1a3t0U0=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2/go.mod h1:cuIaMMiHeHQsbvy7BOFMutoV3QtN+ZBx7Tg3GmYUw7s=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0 h1:DxrN85V738CRLynu6MULQHO+OXyYnkhVPgoZKULfFIs=

--- a/go.sum
+++ b/go.sum
@@ -612,8 +612,8 @@ github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3 h1:VIjkSofZz9utOOkBd
 github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3/go.mod h1:EJk1Ss9GTel2NPIu/w3+x9XcQcEd2k3ibea5aQDzVhQ=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.5 h1:W57+XRa8wTLsi5CV9Tqa7mGgt/PvlRM//RurXSmvII8=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.5/go.mod h1:lTWjW57eAq1bwfM6nsNinhoBr3MHFW/GaFasdAsYfDM=
-github.com/stackitcloud/stackit-sdk-go/services/intake v0.4.4 h1:cbXM7jUBCL7A5zxJKFWolRIDl45sdJMMMAzeumeIEOA=
-github.com/stackitcloud/stackit-sdk-go/services/intake v0.4.4/go.mod h1:z+7KKZf0uHXU/Kb4CRs/oaBrXRJ01LpiD0OH11MXLOk=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1 h1:7ZSrwps/zI41rl+xYkG4osld8cyAwssyl/UZ/Iu/F2g=
+github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1/go.mod h1:ZIvwBZwEMFO+YfJLCNXqabslI0Fp9zxV7ZBwlZjk7uE=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2 h1:2ulSL2IkIAKND59eAjbEhVkOoBMyvm48ojwz1a3t0U0=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2/go.mod h1:cuIaMMiHeHQsbvy7BOFMutoV3QtN+ZBx7Tg3GmYUw7s=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0 h1:DxrN85V738CRLynu6MULQHO+OXyYnkhVPgoZKULfFIs=

--- a/internal/cmd/beta/intake/create/create.go
+++ b/internal/cmd/beta/intake/create/create.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,8 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/create/create.go
+++ b/internal/cmd/beta/intake/create/create.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -19,6 +16,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -113,7 +112,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Creating STACKIT Intake instance", func() error {
-					_, err = wait.CreateOrUpdateIntakeWaitHandler(ctx, apiClient, model.ProjectId, model.Region, resp.GetId()).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, resp.GetId()).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -185,19 +184,19 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiCreateIntakeRequest {
-	req := apiClient.CreateIntake(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.CreateIntake(ctx, model.ProjectId, model.Region)
 
 	// Build catalog authentication
 	var catalogAuth *intake.CatalogAuth
 	if model.CatalogAuthType != nil {
 		authType := intake.CatalogAuthType(*model.CatalogAuthType)
 		catalogAuth = &intake.CatalogAuth{
-			Type: &authType,
+			Type: authType,
 		}
 		if *model.CatalogAuthType == "dremio" {
 			catalogAuth.Dremio = &intake.DremioAuth{
-				TokenEndpoint:       model.DremioTokenEndpoint,
-				PersonalAccessToken: model.DremioToken,
+				TokenEndpoint:       utils.PtrString(model.DremioTokenEndpoint),
+				PersonalAccessToken: utils.PtrString(model.DremioToken),
 			}
 		}
 	}
@@ -209,22 +208,22 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIC
 
 	// Build catalog
 	catalogPayload := intake.IntakeCatalog{
-		Uri:          model.CatalogURI,
-		Warehouse:    model.CatalogWarehouse,
+		Uri:          utils.PtrString(model.CatalogURI),
+		Warehouse:    utils.PtrString(model.CatalogWarehouse),
 		Namespace:    model.CatalogNamespace,
 		TableName:    model.CatalogTableName,
 		Partitioning: partitioning,
-		PartitionBy:  model.CatalogPartitionBy,
+		PartitionBy:  utils.PtrValue(model.CatalogPartitionBy),
 		Auth:         catalogAuth,
 	}
 
 	// Build main payload
 	payload := intake.CreateIntakePayload{
-		DisplayName:    model.DisplayName,
-		IntakeRunnerId: model.RunnerId,
+		DisplayName:    utils.PtrString(model.DisplayName),
+		IntakeRunnerId: utils.PtrString(model.RunnerId),
 		Description:    model.Description,
-		Labels:         model.Labels,
-		Catalog:        &catalogPayload,
+		Labels:         utils.PtrValue(model.Labels),
+		Catalog:        catalogPayload,
 	}
 	req = req.CreateIntakePayload(payload)
 
@@ -242,7 +241,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s Intake for project %q. Intake ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake for project %q. Intake ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/create/create_test.go
+++ b/internal/cmd/beta/intake/create/create_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/create/create_test.go
+++ b/internal/cmd/beta/intake/create/create_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/create/create_test.go
+++ b/internal/cmd/beta/intake/create/create_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -41,7 +40,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 
@@ -107,22 +108,22 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakePayload)) int
 	authType := intake.CatalogAuthType(testCatalogAuthType)
 	testPartitioningType := intake.PartitioningType(testCatalogPartitioning)
 	payload := intake.CreateIntakePayload{
-		DisplayName:    utils.Ptr(testDisplayName),
-		IntakeRunnerId: utils.Ptr(testRunnerId),
+		DisplayName:    testDisplayName,
+		IntakeRunnerId: testRunnerId,
 		Description:    utils.Ptr(testDescription),
-		Labels:         utils.Ptr(testLabels),
-		Catalog: &intake.IntakeCatalog{
-			Uri:          utils.Ptr(testCatalogURI),
-			Warehouse:    utils.Ptr(testCatalogWarehouse),
+		Labels:         testLabels,
+		Catalog: intake.IntakeCatalog{
+			Uri:          testCatalogURI,
+			Warehouse:    testCatalogWarehouse,
 			Namespace:    utils.Ptr(testCatalogNamespace),
 			TableName:    utils.Ptr(testCatalogTableName),
 			Partitioning: &testPartitioningType,
-			PartitionBy:  utils.Ptr(testCatalogPartitionBy),
+			PartitionBy:  testCatalogPartitionBy,
 			Auth: &intake.CatalogAuth{
-				Type: &authType,
+				Type: authType,
 				Dremio: &intake.DremioAuth{
-					TokenEndpoint:       utils.Ptr(testDremioTokenEndpoint),
-					PersonalAccessToken: utils.Ptr(testDremioToken),
+					TokenEndpoint:       testDremioTokenEndpoint,
+					PersonalAccessToken: testDremioToken,
 				},
 			},
 		},
@@ -135,7 +136,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakePayload)) int
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeRequest)) intake.ApiCreateIntakeRequest {
-	request := testClient.CreateIntake(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateIntake(testCtx, testProjectId, testRegion)
 	request = request.CreateIntakePayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -269,7 +270,7 @@ func TestBuildRequest(t *testing.T) {
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRequest) {
 				*request = (*request).CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
 					authType := intake.CatalogAuthType("none")
-					payload.Catalog.Auth.Type = &authType
+					payload.Catalog.Auth.Type = authType
 					payload.Catalog.Auth.Dremio = nil
 				}))
 			}),
@@ -282,6 +283,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -306,7 +308,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp:         &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},
@@ -317,7 +319,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp:         &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},
@@ -327,7 +329,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp: &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/create/create_test.go
+++ b/internal/cmd/beta/intake/create/create_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -41,7 +40,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 
@@ -107,22 +108,22 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakePayload)) int
 	authType := intake.CatalogAuthType(testCatalogAuthType)
 	testPartitioningType := intake.PartitioningType(testCatalogPartitioning)
 	payload := intake.CreateIntakePayload{
-		DisplayName:    utils.Ptr(testDisplayName),
-		IntakeRunnerId: utils.Ptr(testRunnerId),
+		DisplayName:    testDisplayName,
+		IntakeRunnerId: testRunnerId,
 		Description:    utils.Ptr(testDescription),
-		Labels:         utils.Ptr(testLabels),
-		Catalog: &intake.IntakeCatalog{
-			Uri:          utils.Ptr(testCatalogURI),
-			Warehouse:    utils.Ptr(testCatalogWarehouse),
+		Labels:         testLabels,
+		Catalog: intake.IntakeCatalog{
+			Uri:          testCatalogURI,
+			Warehouse:    testCatalogWarehouse,
 			Namespace:    utils.Ptr(testCatalogNamespace),
 			TableName:    utils.Ptr(testCatalogTableName),
 			Partitioning: &testPartitioningType,
-			PartitionBy:  utils.Ptr(testCatalogPartitionBy),
+			PartitionBy:  testCatalogPartitionBy,
 			Auth: &intake.CatalogAuth{
-				Type: &authType,
+				Type: authType,
 				Dremio: &intake.DremioAuth{
-					TokenEndpoint:       utils.Ptr(testDremioTokenEndpoint),
-					PersonalAccessToken: utils.Ptr(testDremioToken),
+					TokenEndpoint:       testDremioTokenEndpoint,
+					PersonalAccessToken: testDremioToken,
 				},
 			},
 		},
@@ -135,7 +136,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakePayload)) int
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeRequest)) intake.ApiCreateIntakeRequest {
-	request := testClient.CreateIntake(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateIntake(testCtx, testProjectId, testRegion)
 	request = request.CreateIntakePayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -269,7 +270,7 @@ func TestBuildRequest(t *testing.T) {
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRequest) {
 				*request = (*request).CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
 					authType := intake.CatalogAuthType("none")
-					payload.Catalog.Auth.Type = &authType
+					payload.Catalog.Auth.Type = authType
 					payload.Catalog.Auth.Dremio = nil
 				}))
 			}),
@@ -282,6 +283,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -306,7 +308,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp:         &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},
@@ -317,7 +319,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp:         &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},
@@ -327,7 +329,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")},
+				resp: &intake.IntakeResponse{Id: "intake-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/create/create_test.go
+++ b/internal/cmd/beta/intake/create/create_test.go
@@ -249,7 +249,7 @@ func TestBuildRequest(t *testing.T) {
 				model.DremioToken = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRequest) {
-				*request = (*request).CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
+				*request = request.CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
 					payload.Description = nil
 					payload.Labels = nil
 					payload.Catalog.Namespace = nil
@@ -268,7 +268,7 @@ func TestBuildRequest(t *testing.T) {
 				model.DremioToken = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRequest) {
-				*request = (*request).CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
+				*request = request.CreateIntakePayload(fixtureCreatePayload(func(payload *intake.CreateIntakePayload) {
 					authType := intake.CatalogAuthType("none")
 					payload.Catalog.Auth.Type = authType
 					payload.Catalog.Auth.Dremio = nil

--- a/internal/cmd/beta/intake/delete/delete.go
+++ b/internal/cmd/beta/intake/delete/delete.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (

--- a/internal/cmd/beta/intake/delete/delete.go
+++ b/internal/cmd/beta/intake/delete/delete.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,6 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (
@@ -70,7 +69,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Deleting STACKIT Intake instance", func() error {
-					_, err = wait.DeleteIntakeWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.IntakeId).WaitWithContext(ctx)
+					_, err = wait.DeleteIntakeWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.IntakeId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -110,6 +109,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 // buildRequest creates the API request to delete an Intake
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeRequest {
-	req := apiClient.DeleteIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
+	req := apiClient.DefaultAPI.DeleteIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
 	return req
 }

--- a/internal/cmd/beta/intake/delete/delete_test.go
+++ b/internal/cmd/beta/intake/delete/delete_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/delete/delete_test.go
+++ b/internal/cmd/beta/intake/delete/delete_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -24,7 +23,9 @@ var (
 	// testCtx is a dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient is a mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 )
@@ -70,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiDeleteIntakeRequest)) intake.ApiDeleteIntakeRequest {
-	request := testClient.DeleteIntake(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.DeleteIntake(testCtx, testProjectId, testRegion, testIntakeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -147,6 +148,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/describe/describe.go
+++ b/internal/cmd/beta/intake/describe/describe.go
@@ -131,7 +131,7 @@ func outputResult(p *print.Printer, outputFormat string, intk *intake.IntakeResp
 			table.AddRow("Catalog Table Name", tableName)
 		}
 		table.AddRow("Catalog Partitioning", catalog.GetPartitioning())
-		if partitionBy := catalog.GetPartitionBy(); partitionBy != nil && len(partitionBy) > 0 {
+		if partitionBy := catalog.GetPartitionBy(); len(partitionBy) > 0 {
 			table.AddRow("Catalog Partition By", strings.Join(partitionBy, ", "))
 		}
 

--- a/internal/cmd/beta/intake/describe/describe.go
+++ b/internal/cmd/beta/intake/describe/describe.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -86,7 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiGetIntakeRequest {
-	req := apiClient.GetIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
+	req := apiClient.DefaultAPI.GetIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
 	return req
 }
 
@@ -131,8 +131,8 @@ func outputResult(p *print.Printer, outputFormat string, intk *intake.IntakeResp
 			table.AddRow("Catalog Table Name", tableName)
 		}
 		table.AddRow("Catalog Partitioning", catalog.GetPartitioning())
-		if partitionBy := catalog.GetPartitionBy(); partitionBy != nil && len(*partitionBy) > 0 {
-			table.AddRow("Catalog Partition By", strings.Join(*partitionBy, ", "))
+		if partitionBy := catalog.GetPartitionBy(); partitionBy != nil && len(partitionBy) > 0 {
+			table.AddRow("Catalog Partition By", strings.Join(partitionBy, ", "))
 		}
 
 		err := table.Display(p)

--- a/internal/cmd/beta/intake/describe/describe_test.go
+++ b/internal/cmd/beta/intake/describe/describe_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -22,8 +21,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 )
@@ -65,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeRequest)) intake.ApiGetIntakeRequest {
-	request := testClient.GetIntake(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.GetIntake(testCtx, testProjectId, testRegion, testIntakeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -142,6 +143,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -162,17 +164,17 @@ func TestOutputResult(t *testing.T) {
 	}{
 		{
 			name:    "default output",
-			args:    args{outputFormat: "default", intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: "default", intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: print.JSONOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{
 			name:    "yaml output",
-			args:    args{outputFormat: print.YAMLOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: print.YAMLOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/describe/describe_test.go
+++ b/internal/cmd/beta/intake/describe/describe_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +23,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 )
@@ -66,7 +68,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeRequest)) intake.ApiGetIntakeRequest {
-	request := testClient.GetIntake(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.GetIntake(testCtx, testProjectId, testRegion, testIntakeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -143,6 +145,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -163,17 +166,17 @@ func TestOutputResult(t *testing.T) {
 	}{
 		{
 			name:    "default output",
-			args:    args{outputFormat: "default", intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: "default", intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: print.JSONOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{
 			name:    "yaml output",
-			args:    args{outputFormat: print.YAMLOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: &intake.IntakeCatalog{}}},
+			args:    args{outputFormat: print.YAMLOutputFormat, intakeResp: &intake.IntakeResponse{Catalog: intake.IntakeCatalog{}}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/describe/describe_test.go
+++ b/internal/cmd/beta/intake/describe/describe_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/describe/describe_test.go
+++ b/internal/cmd/beta/intake/describe/describe_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/list/list.go
+++ b/internal/cmd/beta/intake/list/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -119,7 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 
 // buildRequest creates the API request to list Intakes
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiListIntakesRequest {
-	req := apiClient.ListIntakes(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.ListIntakes(ctx, model.ProjectId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/intake/list/list_test.go
+++ b/internal/cmd/beta/intake/list/list_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -25,8 +24,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testLimit     = int64(5)
 )
@@ -57,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakesRequest)) intake.ApiListIntakesRequest {
-	request := testClient.ListIntakes(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListIntakes(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -139,6 +140,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/list/list_test.go
+++ b/internal/cmd/beta/intake/list/list_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -25,8 +24,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testLimit     = int64(5)
 )
@@ -57,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakesRequest)) intake.ApiListIntakesRequest {
-	request := testClient.ListIntakes(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListIntakes(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -139,6 +140,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/list/list_test.go
+++ b/internal/cmd/beta/intake/list/list_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/list/list_test.go
+++ b/internal/cmd/beta/intake/list/list_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/create/create.go
+++ b/internal/cmd/beta/intake/runner/create/create.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -34,8 +34,8 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	DisplayName        *string
-	MaxMessageSizeKiB  *int64
-	MaxMessagesPerHour *int64
+	MaxMessageSizeKiB  *int32
+	MaxMessagesPerHour *int32
 	Description        *string
 	Labels             *map[string]string
 }
@@ -89,7 +89,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Creating STACKIT Intake Runner", func() error {
-					_, err = wait.CreateOrUpdateIntakeRunnerWaitHandler(ctx, apiClient, model.ProjectId, model.Region, resp.GetId()).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeRunnerWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, resp.GetId()).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -106,8 +106,8 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(displayNameFlag, "", "Display name")
-	cmd.Flags().Int64(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB")
-	cmd.Flags().Int64(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour")
+	cmd.Flags().Int32(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB")
+	cmd.Flags().Int32(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour")
 	cmd.Flags().String(descriptionFlag, "", "Description")
 	cmd.Flags().StringToString(labelFlag, nil, "Labels in key=value format, separated by commas. Example: --labels \"key1=value1,key2=value2\"")
 
@@ -124,8 +124,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	model := inputModel{
 		GlobalFlagModel:    globalFlags,
 		DisplayName:        flags.FlagToStringPointer(p, cmd, displayNameFlag),
-		MaxMessageSizeKiB:  flags.FlagToInt64Pointer(p, cmd, maxMessageSizeKiBFlag),
-		MaxMessagesPerHour: flags.FlagToInt64Pointer(p, cmd, maxMessagesPerHourFlag),
+		MaxMessageSizeKiB:  flags.FlagToInt32Pointer(p, cmd, maxMessageSizeKiBFlag),
+		MaxMessagesPerHour: flags.FlagToInt32Pointer(p, cmd, maxMessagesPerHourFlag),
 		Description:        flags.FlagToStringPointer(p, cmd, descriptionFlag),
 		Labels:             flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
@@ -136,15 +136,15 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiCreateIntakeRunnerRequest {
 	// Start building the request by calling the base method with path parameters
-	req := apiClient.CreateIntakeRunner(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.CreateIntakeRunner(ctx, model.ProjectId, model.Region)
 
 	// Create the payload struct with data from the input model
 	payload := intake.CreateIntakeRunnerPayload{
-		DisplayName:        model.DisplayName,
-		MaxMessageSizeKiB:  model.MaxMessageSizeKiB,
-		MaxMessagesPerHour: model.MaxMessagesPerHour,
+		DisplayName:        utils.PtrString(model.DisplayName),
+		MaxMessageSizeKiB:  utils.PtrValue(model.MaxMessageSizeKiB),
+		MaxMessagesPerHour: utils.PtrValue(model.MaxMessagesPerHour),
 		Description:        model.Description,
-		Labels:             model.Labels,
+		Labels:             utils.PtrValue(model.Labels),
 	}
 	// Attach the payload to the request builder
 	req = req.CreateIntakeRunnerPayload(payload)
@@ -163,7 +163,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s Intake Runner for project %q. Runner ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake Runner for project %q. Runner ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -24,8 +23,8 @@ type testCtxKey struct{}
 const (
 	testRegion             = "eu01"
 	testDisplayName        = "testrunner"
-	testMaxMessageSizeKiB  = int64(1024)
-	testMaxMessagesPerHour = int64(10000)
+	testMaxMessageSizeKiB  = int32(1024)
+	testMaxMessagesPerHour = int32(10000)
 	testDescription        = "This is a test runner"
 	testLabelsString       = "env=test,team=dev"
 )
@@ -34,7 +33,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 
 	testLabels = map[string]string{"env": "test", "team": "dev"}
@@ -80,11 +81,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 // fixtureCreatePayload generates a CreateIntakeRunnerPayload for tests
 func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeRunnerPayload)) intake.CreateIntakeRunnerPayload {
 	payload := intake.CreateIntakeRunnerPayload{
-		DisplayName:        utils.Ptr(testDisplayName),
-		MaxMessageSizeKiB:  utils.Ptr(testMaxMessageSizeKiB),
-		MaxMessagesPerHour: utils.Ptr(testMaxMessagesPerHour),
+		DisplayName:        testDisplayName,
+		MaxMessageSizeKiB:  testMaxMessageSizeKiB,
+		MaxMessagesPerHour: testMaxMessagesPerHour,
 		Description:        utils.Ptr(testDescription),
-		Labels:             utils.Ptr(testLabels),
+		Labels:             testLabels,
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -94,7 +95,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeRunnerPayload
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeRunnerRequest)) intake.ApiCreateIntakeRunnerRequest {
-	request := testClient.CreateIntakeRunner(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateIntakeRunner(testCtx, testProjectId, testRegion)
 	request = request.CreateIntakeRunnerPayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -215,6 +216,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -239,7 +241,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -250,7 +252,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -260,7 +262,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp: &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -23,8 +22,8 @@ type testCtxKey struct{}
 const (
 	testRegion             = "eu01"
 	testDisplayName        = "testrunner"
-	testMaxMessageSizeKiB  = int64(1024)
-	testMaxMessagesPerHour = int64(10000)
+	testMaxMessageSizeKiB  = int32(1024)
+	testMaxMessagesPerHour = int32(10000)
 	testDescription        = "This is a test runner"
 	testLabelsString       = "env=test,team=dev"
 )
@@ -33,7 +32,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 
 	testLabels = map[string]string{"env": "test", "team": "dev"}
@@ -79,11 +80,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 // fixtureCreatePayload generates a CreateIntakeRunnerPayload for tests
 func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeRunnerPayload)) intake.CreateIntakeRunnerPayload {
 	payload := intake.CreateIntakeRunnerPayload{
-		DisplayName:        utils.Ptr(testDisplayName),
-		MaxMessageSizeKiB:  utils.Ptr(testMaxMessageSizeKiB),
-		MaxMessagesPerHour: utils.Ptr(testMaxMessagesPerHour),
+		DisplayName:        testDisplayName,
+		MaxMessageSizeKiB:  testMaxMessageSizeKiB,
+		MaxMessagesPerHour: testMaxMessagesPerHour,
 		Description:        utils.Ptr(testDescription),
-		Labels:             utils.Ptr(testLabels),
+		Labels:             testLabels,
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -93,7 +94,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeRunnerPayload
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeRunnerRequest)) intake.ApiCreateIntakeRunnerRequest {
-	request := testClient.CreateIntakeRunner(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateIntakeRunner(testCtx, testProjectId, testRegion)
 	request = request.CreateIntakeRunnerPayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -214,6 +215,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -238,7 +240,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -249,7 +251,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -259,7 +261,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp: &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -202,7 +202,7 @@ func TestBuildRequest(t *testing.T) {
 				model.Labels = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRunnerRequest) {
-				*request = (*request).CreateIntakeRunnerPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeRunnerPayload) {
+				*request = request.CreateIntakeRunnerPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeRunnerPayload) {
 					payload.Description = nil
 					payload.Labels = nil
 				}))

--- a/internal/cmd/beta/intake/runner/create/create_test.go
+++ b/internal/cmd/beta/intake/runner/create/create_test.go
@@ -201,7 +201,7 @@ func TestBuildRequest(t *testing.T) {
 				model.Labels = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeRunnerRequest) {
-				*request = (*request).CreateIntakeRunnerPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeRunnerPayload) {
+				*request = request.CreateIntakeRunnerPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeRunnerPayload) {
 					payload.Description = nil
 					payload.Labels = nil
 				}))

--- a/internal/cmd/beta/intake/runner/delete/delete.go
+++ b/internal/cmd/beta/intake/runner/delete/delete.go
@@ -7,9 +7,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,6 +15,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -70,7 +69,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Deleting STACKIT Intake Runner", func() error {
-					_, err = wait.DeleteIntakeRunnerWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.RunnerId).WaitWithContext(ctx)
+					_, err = wait.DeleteIntakeRunnerWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.RunnerId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -110,6 +109,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 // buildRequest creates the API request to delete an Intake Runner
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeRunnerRequest {
-	req := apiClient.DeleteIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	req := apiClient.DefaultAPI.DeleteIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
 	return req
 }

--- a/internal/cmd/beta/intake/runner/delete/delete.go
+++ b/internal/cmd/beta/intake/runner/delete/delete.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,8 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/runner/delete/delete_test.go
+++ b/internal/cmd/beta/intake/runner/delete/delete_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -24,7 +23,9 @@ var (
 	// testCtx is a dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient is a mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 )
@@ -70,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiDeleteIntakeRunnerRequest)) intake.ApiDeleteIntakeRunnerRequest {
-	request := testClient.DeleteIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	request := testClient.DefaultAPI.DeleteIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -147,6 +148,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/runner/delete/delete_test.go
+++ b/internal/cmd/beta/intake/runner/delete/delete_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/runner/describe/describe.go
+++ b/internal/cmd/beta/intake/runner/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -87,7 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 // buildRequest creates the API request to get a single Intake Runner
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiGetIntakeRunnerRequest {
-	req := apiClient.GetIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	req := apiClient.DefaultAPI.GetIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
 	return req
 }
 

--- a/internal/cmd/beta/intake/runner/describe/describe_test.go
+++ b/internal/cmd/beta/intake/runner/describe/describe_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/describe/describe_test.go
+++ b/internal/cmd/beta/intake/runner/describe/describe_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/describe/describe_test.go
+++ b/internal/cmd/beta/intake/runner/describe/describe_test.go
@@ -9,11 +9,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +22,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 )
@@ -66,7 +67,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeRunnerRequest)) intake.ApiGetIntakeRunnerRequest {
-	request := testClient.GetIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	request := testClient.DefaultAPI.GetIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -143,6 +144,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/runner/describe/describe_test.go
+++ b/internal/cmd/beta/intake/runner/describe/describe_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -22,8 +21,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 )
@@ -65,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeRunnerRequest)) intake.ApiGetIntakeRunnerRequest {
-	request := testClient.GetIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	request := testClient.DefaultAPI.GetIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -142,6 +143,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/runner/list/list.go
+++ b/internal/cmd/beta/intake/runner/list/list.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,6 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (
@@ -120,7 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 
 // buildRequest creates the API request to list Intake Runners
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiListIntakeRunnersRequest {
-	req := apiClient.ListIntakeRunners(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.ListIntakeRunners(ctx, model.ProjectId, model.Region)
 	// Note: we do support API pagination, but for consistency with other services, we fetch all items and apply
 	// client-side limit.
 	// A more advanced implementation could use the --limit flag to set the API's PageSize.

--- a/internal/cmd/beta/intake/runner/list/list.go
+++ b/internal/cmd/beta/intake/runner/list/list.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (

--- a/internal/cmd/beta/intake/runner/list/list_test.go
+++ b/internal/cmd/beta/intake/runner/list/list_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -27,8 +26,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 )
 
@@ -58,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakeRunnersRequest)) intake.ApiListIntakeRunnersRequest {
-	request := testClient.ListIntakeRunners(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListIntakeRunners(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -141,6 +142,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/runner/list/list_test.go
+++ b/internal/cmd/beta/intake/runner/list/list_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -26,8 +25,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 )
 
@@ -57,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakeRunnersRequest)) intake.ApiListIntakeRunnersRequest {
-	request := testClient.ListIntakeRunners(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListIntakeRunners(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -140,6 +141,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/runner/list/list_test.go
+++ b/internal/cmd/beta/intake/runner/list/list_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/list/list_test.go
+++ b/internal/cmd/beta/intake/runner/list/list_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/update/update.go
+++ b/internal/cmd/beta/intake/runner/update/update.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -21,6 +18,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -39,8 +38,8 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 	RunnerId           string
 	DisplayName        *string
-	MaxMessageSizeKiB  *int64
-	MaxMessagesPerHour *int64
+	MaxMessageSizeKiB  *int32
+	MaxMessagesPerHour *int32
 	Description        *string
 	Labels             *map[string]string
 }
@@ -88,7 +87,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Updating STACKIT Intake Runner", func() error {
-					_, err = wait.CreateOrUpdateIntakeRunnerWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.RunnerId).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeRunnerWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.RunnerId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -105,8 +104,8 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(displayNameFlag, "", "Display name")
-	cmd.Flags().Int64(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB. Note: Overall message capacity cannot be decreased.")
-	cmd.Flags().Int64(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.")
+	cmd.Flags().Int32(maxMessageSizeKiBFlag, 0, "Maximum message size in KiB. Note: Overall message capacity cannot be decreased.")
+	cmd.Flags().Int32(maxMessagesPerHourFlag, 0, "Maximum number of messages per hour. Note: Overall message capacity cannot be decreased.")
 	cmd.Flags().String(descriptionFlag, "", "Description")
 	cmd.Flags().StringToString(labelFlag, nil, `Labels in key=value format, separated by commas. Example: --labels "key1=value1,key2=value2".`)
 }
@@ -123,8 +122,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		GlobalFlagModel:    globalFlags,
 		RunnerId:           runnerId,
 		DisplayName:        flags.FlagToStringPointer(p, cmd, displayNameFlag),
-		MaxMessageSizeKiB:  flags.FlagToInt64Pointer(p, cmd, maxMessageSizeKiBFlag),
-		MaxMessagesPerHour: flags.FlagToInt64Pointer(p, cmd, maxMessagesPerHourFlag),
+		MaxMessageSizeKiB:  flags.FlagToInt32Pointer(p, cmd, maxMessageSizeKiBFlag),
+		MaxMessagesPerHour: flags.FlagToInt32Pointer(p, cmd, maxMessagesPerHourFlag),
 		Description:        flags.FlagToStringPointer(p, cmd, descriptionFlag),
 		Labels:             flags.FlagToStringToStringPointer(p, cmd, labelFlag),
 	}
@@ -138,7 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiUpdateIntakeRunnerRequest {
-	req := apiClient.UpdateIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	req := apiClient.DefaultAPI.UpdateIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
 
 	payload := intake.UpdateIntakeRunnerPayload{}
 	if model.DisplayName != nil {
@@ -154,7 +153,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIC
 		payload.Description = model.Description
 	}
 	if model.Labels != nil {
-		payload.Labels = model.Labels
+		payload.Labels = utils.PtrValue(model.Labels)
 	}
 
 	req = req.UpdateIntakeRunnerPayload(payload)
@@ -172,7 +171,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered update of"
 		}
-		p.Outputf("%s Intake Runner for project %q. Runner ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake Runner for project %q. Runner ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/runner/update/update.go
+++ b/internal/cmd/beta/intake/runner/update/update.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,8 +21,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -24,8 +23,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 )
@@ -69,7 +70,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiUpdateIntakeRunnerRequest)) intake.ApiUpdateIntakeRunnerRequest {
-	request := testClient.UpdateIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	request := testClient.DefaultAPI.UpdateIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
 	payload := intake.UpdateIntakeRunnerPayload{
 		DisplayName: utils.Ptr("new-runner-name"),
 	}
@@ -115,8 +116,8 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.MaxMessageSizeKiB = utils.Ptr(int64(2048))
-				model.MaxMessagesPerHour = utils.Ptr(int64(10000))
+				model.MaxMessageSizeKiB = utils.Ptr(int32(2048))
+				model.MaxMessagesPerHour = utils.Ptr(int32(10000))
 				model.Description = utils.Ptr("new description")
 				model.Labels = utils.Ptr(map[string]string{"env": "prod", "team": "sre"})
 			}),
@@ -165,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
 				payload := intake.UpdateIntakeRunnerPayload{
 					Description: utils.Ptr("new-desc"),
-					Labels:      utils.Ptr(map[string]string{"key": "value"}),
+					Labels:      map[string]string{"key": "value"},
 				}
 				*request = (*request).UpdateIntakeRunnerPayload(payload)
 			}),
@@ -174,18 +175,18 @@ func TestBuildRequest(t *testing.T) {
 			description: "update all fields",
 			model: fixtureInputModel(func(model *inputModel) {
 				model.DisplayName = utils.Ptr("another-name")
-				model.MaxMessageSizeKiB = utils.Ptr(int64(4096))
-				model.MaxMessagesPerHour = utils.Ptr(int64(20000))
+				model.MaxMessageSizeKiB = utils.Ptr(int32(4096))
+				model.MaxMessagesPerHour = utils.Ptr(int32(20000))
 				model.Description = utils.Ptr("final-desc")
 				model.Labels = utils.Ptr(map[string]string{"a": "b"})
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
 				payload := intake.UpdateIntakeRunnerPayload{
 					DisplayName:        utils.Ptr("another-name"),
-					MaxMessageSizeKiB:  utils.Ptr(int64(4096)),
-					MaxMessagesPerHour: utils.Ptr(int64(20000)),
+					MaxMessageSizeKiB:  utils.Ptr(int32(4096)),
+					MaxMessagesPerHour: utils.Ptr(int32(20000)),
 					Description:        utils.Ptr("final-desc"),
-					Labels:             utils.Ptr(map[string]string{"a": "b"}),
+					Labels:             map[string]string{"a": "b"},
 				}
 				*request = (*request).UpdateIntakeRunnerPayload(payload)
 			}),
@@ -199,6 +200,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -223,7 +225,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -234,7 +236,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -244,7 +246,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp: &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +22,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testRunnerId  = uuid.NewString()
 )
@@ -68,7 +69,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiUpdateIntakeRunnerRequest)) intake.ApiUpdateIntakeRunnerRequest {
-	request := testClient.UpdateIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
+	request := testClient.DefaultAPI.UpdateIntakeRunner(testCtx, testProjectId, testRegion, testRunnerId)
 	payload := intake.UpdateIntakeRunnerPayload{
 		DisplayName: utils.Ptr("new-runner-name"),
 	}
@@ -114,8 +115,8 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.MaxMessageSizeKiB = utils.Ptr(int64(2048))
-				model.MaxMessagesPerHour = utils.Ptr(int64(10000))
+				model.MaxMessageSizeKiB = utils.Ptr(int32(2048))
+				model.MaxMessagesPerHour = utils.Ptr(int32(10000))
 				model.Description = utils.Ptr("new description")
 				model.Labels = utils.Ptr(map[string]string{"env": "prod", "team": "sre"})
 			}),
@@ -164,7 +165,7 @@ func TestBuildRequest(t *testing.T) {
 			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
 				payload := intake.UpdateIntakeRunnerPayload{
 					Description: utils.Ptr("new-desc"),
-					Labels:      utils.Ptr(map[string]string{"key": "value"}),
+					Labels:      map[string]string{"key": "value"},
 				}
 				*request = (*request).UpdateIntakeRunnerPayload(payload)
 			}),
@@ -173,18 +174,18 @@ func TestBuildRequest(t *testing.T) {
 			description: "update all fields",
 			model: fixtureInputModel(func(model *inputModel) {
 				model.DisplayName = utils.Ptr("another-name")
-				model.MaxMessageSizeKiB = utils.Ptr(int64(4096))
-				model.MaxMessagesPerHour = utils.Ptr(int64(20000))
+				model.MaxMessageSizeKiB = utils.Ptr(int32(4096))
+				model.MaxMessagesPerHour = utils.Ptr(int32(20000))
 				model.Description = utils.Ptr("final-desc")
 				model.Labels = utils.Ptr(map[string]string{"a": "b"})
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiUpdateIntakeRunnerRequest) {
 				payload := intake.UpdateIntakeRunnerPayload{
 					DisplayName:        utils.Ptr("another-name"),
-					MaxMessageSizeKiB:  utils.Ptr(int64(4096)),
-					MaxMessagesPerHour: utils.Ptr(int64(20000)),
+					MaxMessageSizeKiB:  utils.Ptr(int32(4096)),
+					MaxMessagesPerHour: utils.Ptr(int32(20000)),
 					Description:        utils.Ptr("final-desc"),
-					Labels:             utils.Ptr(map[string]string{"a": "b"}),
+					Labels:             map[string]string{"a": "b"},
 				}
 				*request = (*request).UpdateIntakeRunnerPayload(payload)
 			}),
@@ -198,6 +199,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -222,7 +224,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -233,7 +235,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp:         &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},
@@ -243,7 +245,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeRunnerResponse{Id: utils.Ptr("runner-id-123")},
+				resp: &intake.IntakeRunnerResponse{Id: "runner-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -167,7 +167,7 @@ func TestBuildRequest(t *testing.T) {
 					Description: utils.Ptr("new-desc"),
 					Labels:      map[string]string{"key": "value"},
 				}
-				*request = (*request).UpdateIntakeRunnerPayload(payload)
+				*request = request.UpdateIntakeRunnerPayload(payload)
 			}),
 		},
 		{
@@ -187,7 +187,7 @@ func TestBuildRequest(t *testing.T) {
 					Description:        utils.Ptr("final-desc"),
 					Labels:             map[string]string{"a": "b"},
 				}
-				*request = (*request).UpdateIntakeRunnerPayload(payload)
+				*request = request.UpdateIntakeRunnerPayload(payload)
 			}),
 		},
 	}

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/runner/update/update_test.go
+++ b/internal/cmd/beta/intake/runner/update/update_test.go
@@ -168,7 +168,7 @@ func TestBuildRequest(t *testing.T) {
 					Description: utils.Ptr("new-desc"),
 					Labels:      map[string]string{"key": "value"},
 				}
-				*request = (*request).UpdateIntakeRunnerPayload(payload)
+				*request = request.UpdateIntakeRunnerPayload(payload)
 			}),
 		},
 		{
@@ -188,7 +188,7 @@ func TestBuildRequest(t *testing.T) {
 					Description:        utils.Ptr("final-desc"),
 					Labels:             map[string]string{"a": "b"},
 				}
-				*request = (*request).UpdateIntakeRunnerPayload(payload)
+				*request = request.UpdateIntakeRunnerPayload(payload)
 			}),
 		},
 	}

--- a/internal/cmd/beta/intake/update/update.go
+++ b/internal/cmd/beta/intake/update/update.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -107,7 +107,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Updating STACKIT Intake Runner instance", func() error {
-					_, err = wait.CreateOrUpdateIntakeWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.IntakeId).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.IntakeId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -181,13 +181,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiUpdateIntakeRequest {
-	req := apiClient.UpdateIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
+	req := apiClient.DefaultAPI.UpdateIntake(ctx, model.ProjectId, model.Region, model.IntakeId)
 
 	payload := intake.UpdateIntakePayload{
-		IntakeRunnerId: model.RunnerId, // This is required by the API
+		IntakeRunnerId: utils.PtrString(model.RunnerId), // This is required by the API
 		DisplayName:    model.DisplayName,
 		Description:    model.Description,
-		Labels:         model.Labels,
+		Labels:         utils.PtrValue(model.Labels),
 	}
 
 	// Build catalog patch payload only if catalog-related flags are set
@@ -261,7 +261,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered update of"
 		}
-		p.Outputf("%s Intake for project %q. Intake ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake for project %q. Intake ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/update/update_test.go
+++ b/internal/cmd/beta/intake/update/update_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -24,8 +23,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testRunnerId  = uuid.NewString()
@@ -161,9 +162,9 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "base",
 			model:       fixtureInputModel(),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					DisplayName:    utils.Ptr("new-display-name"),
 				}),
 		},
@@ -174,9 +175,9 @@ func TestBuildRequest(t *testing.T) {
 				model.Description = utils.Ptr("new-desc")
 				model.CatalogURI = utils.Ptr("new-uri")
 			}),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					Description:    utils.Ptr("new-desc"),
 					Catalog: &intake.IntakeCatalogPatch{
 						Uri: utils.Ptr("new-uri"),
@@ -197,12 +198,12 @@ func TestBuildRequest(t *testing.T) {
 				model.DremioTokenEndpoint = utils.Ptr("final-endpoint")
 				model.DremioToken = utils.Ptr("final-token")
 			}),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					DisplayName:    utils.Ptr("another-name"),
 					Description:    utils.Ptr("final-desc"),
-					Labels:         utils.Ptr(map[string]string{"a": "b"}),
+					Labels:         map[string]string{"a": "b"},
 					Catalog: &intake.IntakeCatalogPatch{
 						Uri:       utils.Ptr("final-uri"),
 						Warehouse: utils.Ptr("final-warehouse"),
@@ -227,6 +228,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedReq, request,
 				cmp.AllowUnexported(request),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -254,12 +256,12 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")}},
+			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeResponse{Id: "intake-id-123"}},
 			wantErr: false,
 		},
 		{
 			name:    "yaml output",
-			args:    args{outputFormat: print.YAMLOutputFormat, resp: &intake.IntakeResponse{Id: utils.Ptr("runner-id-123")}},
+			args:    args{outputFormat: print.YAMLOutputFormat, resp: &intake.IntakeResponse{Id: "runner-id-123"}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/update/update_test.go
+++ b/internal/cmd/beta/intake/update/update_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/update/update_test.go
+++ b/internal/cmd/beta/intake/update/update_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +22,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testRunnerId  = uuid.NewString()
@@ -160,9 +161,9 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "base",
 			model:       fixtureInputModel(),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					DisplayName:    utils.Ptr("new-display-name"),
 				}),
 		},
@@ -173,9 +174,9 @@ func TestBuildRequest(t *testing.T) {
 				model.Description = utils.Ptr("new-desc")
 				model.CatalogURI = utils.Ptr("new-uri")
 			}),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					Description:    utils.Ptr("new-desc"),
 					Catalog: &intake.IntakeCatalogPatch{
 						Uri: utils.Ptr("new-uri"),
@@ -196,12 +197,12 @@ func TestBuildRequest(t *testing.T) {
 				model.DremioTokenEndpoint = utils.Ptr("final-endpoint")
 				model.DremioToken = utils.Ptr("final-token")
 			}),
-			expectedReq: testClient.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
+			expectedReq: testClient.DefaultAPI.UpdateIntake(testCtx, testProjectId, testRegion, testIntakeId).
 				UpdateIntakePayload(intake.UpdateIntakePayload{
-					IntakeRunnerId: utils.Ptr(testRunnerId),
+					IntakeRunnerId: testRunnerId,
 					DisplayName:    utils.Ptr("another-name"),
 					Description:    utils.Ptr("final-desc"),
-					Labels:         utils.Ptr(map[string]string{"a": "b"}),
+					Labels:         map[string]string{"a": "b"},
 					Catalog: &intake.IntakeCatalogPatch{
 						Uri:       utils.Ptr("final-uri"),
 						Warehouse: utils.Ptr("final-warehouse"),
@@ -226,6 +227,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedReq, request,
 				cmp.AllowUnexported(request),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -253,12 +255,12 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeResponse{Id: utils.Ptr("intake-id-123")}},
+			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeResponse{Id: "intake-id-123"}},
 			wantErr: false,
 		},
 		{
 			name:    "yaml output",
-			args:    args{outputFormat: print.YAMLOutputFormat, resp: &intake.IntakeResponse{Id: utils.Ptr("runner-id-123")}},
+			args:    args{outputFormat: print.YAMLOutputFormat, resp: &intake.IntakeResponse{Id: "runner-id-123"}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/update/update_test.go
+++ b/internal/cmd/beta/intake/update/update_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/create/create.go
+++ b/internal/cmd/beta/intake/user/create/create.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,8 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/user/create/create.go
+++ b/internal/cmd/beta/intake/user/create/create.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -19,6 +16,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -90,7 +89,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Creating STACKIT Intake User", func() error {
-					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient, model.ProjectId, model.Region, *model.IntakeId, resp.GetId()).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, *model.IntakeId, resp.GetId()).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -138,7 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiCreateIntakeUserRequest {
-	req := apiClient.CreateIntakeUser(ctx, model.ProjectId, model.Region, *model.IntakeId)
+	req := apiClient.DefaultAPI.CreateIntakeUser(ctx, model.ProjectId, model.Region, *model.IntakeId)
 
 	var userType *intake.UserType
 	if model.UserType != nil {
@@ -146,11 +145,11 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIC
 	}
 
 	payload := intake.CreateIntakeUserPayload{
-		DisplayName: model.DisplayName,
-		Password:    model.Password,
+		DisplayName: utils.PtrString(model.DisplayName),
+		Password:    utils.PtrString(model.Password),
 		Type:        userType,
 		Description: model.Description,
-		Labels:      model.Labels,
+		Labels:      utils.PtrValue(model.Labels),
 	}
 
 	req = req.CreateIntakeUserPayload(payload)
@@ -168,7 +167,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s Intake User for project %q. User ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake User for project %q. User ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/user/create/create.go
+++ b/internal/cmd/beta/intake/user/create/create.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -19,6 +16,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -90,7 +89,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Creating STACKIT Intake User", func() error {
-					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient, model.ProjectId, model.Region, *model.IntakeId, resp.GetId()).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, *model.IntakeId, resp.GetId()).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -139,7 +138,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiCreateIntakeUserRequest {
-	req := apiClient.CreateIntakeUser(ctx, model.ProjectId, model.Region, *model.IntakeId)
+	req := apiClient.DefaultAPI.CreateIntakeUser(ctx, model.ProjectId, model.Region, *model.IntakeId)
 
 	var userType *intake.UserType
 	if model.UserType != nil {
@@ -147,11 +146,11 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIC
 	}
 
 	payload := intake.CreateIntakeUserPayload{
-		DisplayName: model.DisplayName,
-		Password:    model.Password,
+		DisplayName: utils.PtrString(model.DisplayName),
+		Password:    utils.PtrString(model.Password),
 		Type:        userType,
 		Description: model.Description,
-		Labels:      model.Labels,
+		Labels:      utils.PtrValue(model.Labels),
 	}
 
 	req = req.CreateIntakeUserPayload(payload)
@@ -169,7 +168,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s Intake User for project %q. User ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake User for project %q. User ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -201,7 +201,7 @@ func TestBuildRequest(t *testing.T) {
 				model.UserType = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeUserRequest) {
-				*request = (*request).CreateIntakeUserPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeUserPayload) {
+				*request = request.CreateIntakeUserPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeUserPayload) {
 					payload.Description = nil
 					payload.Labels = nil
 					payload.Type = nil

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -33,7 +32,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 
@@ -83,11 +84,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeUserPayload)) intake.CreateIntakeUserPayload {
 	userType := intake.UserType(testUserType)
 	payload := intake.CreateIntakeUserPayload{
-		DisplayName: utils.Ptr(testDisplayName),
-		Password:    utils.Ptr(testPassword),
+		DisplayName: testDisplayName,
+		Password:    testPassword,
 		Type:        &userType,
 		Description: utils.Ptr(testDescription),
-		Labels:      utils.Ptr(testLabels),
+		Labels:      testLabels,
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -97,7 +98,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeUserPayload))
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeUserRequest)) intake.ApiCreateIntakeUserRequest {
-	request := testClient.CreateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.CreateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId)
 	request = request.CreateIntakeUserPayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -214,6 +215,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -238,7 +240,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp:         &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},
@@ -249,7 +251,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp:         &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},
@@ -259,7 +261,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp: &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -34,7 +33,9 @@ var (
 	// testCtx dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 
@@ -84,11 +85,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeUserPayload)) intake.CreateIntakeUserPayload {
 	userType := intake.UserType(testUserType)
 	payload := intake.CreateIntakeUserPayload{
-		DisplayName: utils.Ptr(testDisplayName),
-		Password:    utils.Ptr(testPassword),
+		DisplayName: testDisplayName,
+		Password:    testPassword,
 		Type:        &userType,
 		Description: utils.Ptr(testDescription),
-		Labels:      utils.Ptr(testLabels),
+		Labels:      testLabels,
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -98,7 +99,7 @@ func fixtureCreatePayload(mods ...func(payload *intake.CreateIntakeUserPayload))
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiCreateIntakeUserRequest)) intake.ApiCreateIntakeUserRequest {
-	request := testClient.CreateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.CreateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId)
 	request = request.CreateIntakeUserPayload(fixtureCreatePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -215,6 +216,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -239,7 +241,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				model:        fixtureInputModel(),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp:         &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},
@@ -250,7 +252,7 @@ func TestOutputResult(t *testing.T) {
 					model.Async = true
 				}),
 				projectLabel: "my-project",
-				resp:         &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp:         &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},
@@ -260,7 +262,7 @@ func TestOutputResult(t *testing.T) {
 				model: fixtureInputModel(func(model *inputModel) {
 					model.OutputFormat = print.JSONOutputFormat
 				}),
-				resp: &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")},
+				resp: &intake.IntakeUserResponse{Id: "user-id-123"},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/intake/user/create/create_test.go
+++ b/internal/cmd/beta/intake/user/create/create_test.go
@@ -200,7 +200,7 @@ func TestBuildRequest(t *testing.T) {
 				model.UserType = nil
 			}),
 			expectedRequest: fixtureRequest(func(request *intake.ApiCreateIntakeUserRequest) {
-				*request = (*request).CreateIntakeUserPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeUserPayload) {
+				*request = request.CreateIntakeUserPayload(fixtureCreatePayload(func(payload *intake.CreateIntakeUserPayload) {
 					payload.Description = nil
 					payload.Labels = nil
 					payload.Type = nil

--- a/internal/cmd/beta/intake/user/delete/delete.go
+++ b/internal/cmd/beta/intake/user/delete/delete.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,6 +15,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -72,7 +71,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Deleting STACKIT Intake User", func() error {
-					_, err = wait.DeleteIntakeUserWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
+					_, err = wait.DeleteIntakeUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -121,6 +120,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 // buildRequest creates the API request to delete an Intake User
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeUserRequest {
-	req := apiClient.DeleteIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
+	req := apiClient.DefaultAPI.DeleteIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
 	return req
 }

--- a/internal/cmd/beta/intake/user/delete/delete.go
+++ b/internal/cmd/beta/intake/user/delete/delete.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,8 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/user/delete/delete_test.go
+++ b/internal/cmd/beta/intake/user/delete/delete_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions

--- a/internal/cmd/beta/intake/user/delete/delete_test.go
+++ b/internal/cmd/beta/intake/user/delete/delete_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // Define a unique key for the context to avoid collisions
@@ -24,7 +23,9 @@ var (
 	// testCtx is a dummy context for testing purposes
 	testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 	// testClient is a mock API client
-	testClient    = &intake.APIClient{}
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testUserId    = uuid.NewString()
@@ -73,7 +74,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // fixtureRequest generates an API request for tests
 func fixtureRequest(mods ...func(request *intake.ApiDeleteIntakeUserRequest)) intake.ApiDeleteIntakeUserRequest {
-	request := testClient.DeleteIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
+	request := testClient.DefaultAPI.DeleteIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -166,6 +167,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/user/describe/describe.go
+++ b/internal/cmd/beta/intake/user/describe/describe.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (

--- a/internal/cmd/beta/intake/user/describe/describe.go
+++ b/internal/cmd/beta/intake/user/describe/describe.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -17,6 +15,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (
@@ -97,7 +96,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiGetIntakeUserRequest {
-	req := apiClient.GetIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
+	req := apiClient.DefaultAPI.GetIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
 	return req
 }
 
@@ -113,10 +112,7 @@ func outputResult(p *print.Printer, outputFormat string, user *intake.IntakeUser
 		table.AddRow("ID", user.GetId())
 		table.AddRow("Name", user.GetDisplayName())
 		table.AddRow("State", user.GetState())
-
-		if user.Type != nil {
-			table.AddRow("Type", *user.Type)
-		}
+		table.AddRow("Type", user.Type)
 
 		table.AddRow("Username", user.GetUser())
 		table.AddRow("Created", user.GetCreateTime())

--- a/internal/cmd/beta/intake/user/describe/describe_test.go
+++ b/internal/cmd/beta/intake/user/describe/describe_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +22,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testUserId    = uuid.NewString()
@@ -69,7 +70,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeUserRequest)) intake.ApiGetIntakeUserRequest {
-	request := testClient.GetIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
+	request := testClient.DefaultAPI.GetIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -162,6 +163,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/user/describe/describe_test.go
+++ b/internal/cmd/beta/intake/user/describe/describe_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/describe/describe_test.go
+++ b/internal/cmd/beta/intake/user/describe/describe_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/describe/describe_test.go
+++ b/internal/cmd/beta/intake/user/describe/describe_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -22,8 +21,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testUserId    = uuid.NewString()
@@ -68,7 +69,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiGetIntakeUserRequest)) intake.ApiGetIntakeUserRequest {
-	request := testClient.GetIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
+	request := testClient.DefaultAPI.GetIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -161,6 +162,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testClient.DefaultAPI),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/user/list/list.go
+++ b/internal/cmd/beta/intake/user/list/list.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -17,7 +15,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (
@@ -127,7 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 
 // buildRequest creates the API request to list Intake Users
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiListIntakeUsersRequest {
-	req := apiClient.ListIntakeUsers(ctx, model.ProjectId, model.Region, *model.IntakeId)
+	req := apiClient.DefaultAPI.ListIntakeUsers(ctx, model.ProjectId, model.Region, *model.IntakeId)
 	return req
 }
 
@@ -145,7 +143,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel, intakeId string,
 			table.AddRow(
 				user.GetId(),
 				user.GetDisplayName(),
-				utils.PtrString(user.Type),
+				user.Type,
 				user.GetState(),
 			)
 		}

--- a/internal/cmd/beta/intake/user/list/list.go
+++ b/internal/cmd/beta/intake/user/list/list.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/intake/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 const (

--- a/internal/cmd/beta/intake/user/list/list_test.go
+++ b/internal/cmd/beta/intake/user/list/list_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/list/list_test.go
+++ b/internal/cmd/beta/intake/user/list/list_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/list/list_test.go
+++ b/internal/cmd/beta/intake/user/list/list_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -25,8 +24,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testLimit     = int64(5)
@@ -60,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakeUsersRequest)) intake.ApiListIntakeUsersRequest {
-	request := testClient.ListIntakeUsers(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.ListIntakeUsers(testCtx, testProjectId, testRegion, testIntakeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -156,6 +157,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreUnexported(intake.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/user/list/list_test.go
+++ b/internal/cmd/beta/intake/user/list/list_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -26,8 +26,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testLimit     = int64(5)
@@ -61,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiListIntakeUsersRequest)) intake.ApiListIntakeUsersRequest {
-	request := testClient.ListIntakeUsers(testCtx, testProjectId, testRegion, testIntakeId)
+	request := testClient.DefaultAPI.ListIntakeUsers(testCtx, testProjectId, testRegion, testIntakeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -157,6 +159,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreUnexported(intake.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/intake/user/update/update.go
+++ b/internal/cmd/beta/intake/user/update/update.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,6 +15,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -79,7 +78,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Updating STACKIT Intake User", func() error {
-					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
 					return err
 				})
 
@@ -135,13 +134,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiUpdateIntakeUserRequest {
-	req := apiClient.UpdateIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
+	req := apiClient.DefaultAPI.UpdateIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
 
 	payload := intake.UpdateIntakeUserPayload{
 		DisplayName: model.DisplayName,
 		Description: model.Description,
 		Password:    model.Password,
-		Labels:      model.Labels,
+		Labels:      utils.PtrValue(model.Labels),
 	}
 
 	if model.UserType != nil {
@@ -164,7 +163,7 @@ func outputResult(p *print.Printer, model *inputModel, resp *intake.IntakeUserRe
 		if model.Async {
 			operationState = "Triggered update of"
 		}
-		p.Outputf("%s Intake User for intake %q. User ID: %s\n", operationState, model.IntakeId, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake User for intake %q. User ID: %s\n", operationState, model.IntakeId, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/user/update/update.go
+++ b/internal/cmd/beta/intake/user/update/update.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/wait"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -18,6 +15,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (
@@ -79,7 +78,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(p.Printer, "Updating STACKIT Intake User", func() error {
-					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateIntakeUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.IntakeId, model.UserId).WaitWithContext(ctx)
 					return err
 				})
 
@@ -136,13 +135,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiUpdateIntakeUserRequest {
-	req := apiClient.UpdateIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
+	req := apiClient.DefaultAPI.UpdateIntakeUser(ctx, model.ProjectId, model.Region, model.IntakeId, model.UserId)
 
 	payload := intake.UpdateIntakeUserPayload{
 		DisplayName: model.DisplayName,
 		Description: model.Description,
 		Password:    model.Password,
-		Labels:      model.Labels,
+		Labels:      utils.PtrValue(model.Labels),
 	}
 
 	if model.UserType != nil {
@@ -165,7 +164,7 @@ func outputResult(p *print.Printer, model *inputModel, resp *intake.IntakeUserRe
 		if model.Async {
 			operationState = "Triggered update of"
 		}
-		p.Outputf("%s Intake User for intake %q. User ID: %s\n", operationState, model.IntakeId, utils.PtrString(resp.Id))
+		p.Outputf("%s Intake User for intake %q. User ID: %s\n", operationState, model.IntakeId, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/intake/user/update/update.go
+++ b/internal/cmd/beta/intake/user/update/update.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,8 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi/wait"
 )
 
 const (

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -24,8 +23,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testUserId    = uuid.NewString()
@@ -70,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiUpdateIntakeUserRequest)) intake.ApiUpdateIntakeUserRequest {
-	request := testClient.UpdateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
+	request := testClient.DefaultAPI.UpdateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
 	payload := intake.UpdateIntakeUserPayload{
 		DisplayName: utils.Ptr("new-display-name"),
 	}
@@ -192,7 +193,7 @@ func TestBuildRequest(t *testing.T) {
 				payload := intake.UpdateIntakeUserPayload{
 					DisplayName: utils.Ptr("another-name"),
 					Description: utils.Ptr("final-desc"),
-					Labels:      utils.Ptr(map[string]string{"a": "b"}),
+					Labels:      map[string]string{"a": "b"},
 					Type:        &userType,
 					Password:    utils.Ptr("Secret123!"),
 				}
@@ -208,6 +209,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedReq, request,
 				cmp.AllowUnexported(request),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreUnexported(intake.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -235,7 +237,7 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")}},
+			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeUserResponse{Id: "user-id-123"}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}
@@ -23,8 +22,10 @@ const (
 )
 
 var (
-	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &intake.APIClient{}
+	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
+	testClient = &intake.APIClient{
+		DefaultAPI: &intake.DefaultAPIService{},
+	}
 	testProjectId = uuid.NewString()
 	testIntakeId  = uuid.NewString()
 	testUserId    = uuid.NewString()
@@ -69,7 +70,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *intake.ApiUpdateIntakeUserRequest)) intake.ApiUpdateIntakeUserRequest {
-	request := testClient.UpdateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
+	request := testClient.DefaultAPI.UpdateIntakeUser(testCtx, testProjectId, testRegion, testIntakeId, testUserId)
 	payload := intake.UpdateIntakeUserPayload{
 		DisplayName: utils.Ptr("new-display-name"),
 	}
@@ -191,7 +192,7 @@ func TestBuildRequest(t *testing.T) {
 				payload := intake.UpdateIntakeUserPayload{
 					DisplayName: utils.Ptr("another-name"),
 					Description: utils.Ptr("final-desc"),
-					Labels:      utils.Ptr(map[string]string{"a": "b"}),
+					Labels:      map[string]string{"a": "b"},
 					Type:        &userType,
 					Password:    utils.Ptr("Secret123!"),
 				}
@@ -207,6 +208,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedReq, request,
 				cmp.AllowUnexported(request),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreUnexported(intake.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -234,7 +236,7 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			name:    "json output",
-			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeUserResponse{Id: utils.Ptr("user-id-123")}},
+			args:    args{outputFormat: print.JSONOutputFormat, resp: &intake.IntakeUserResponse{Id: "user-id-123"}},
 			wantErr: false,
 		},
 		{

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -175,7 +175,7 @@ func TestBuildRequest(t *testing.T) {
 				payload := intake.UpdateIntakeUserPayload{
 					Description: utils.Ptr("new-desc"),
 				}
-				*request = (*request).UpdateIntakeUserPayload(payload)
+				*request = request.UpdateIntakeUserPayload(payload)
 			}),
 		},
 		{
@@ -196,7 +196,7 @@ func TestBuildRequest(t *testing.T) {
 					Type:        &userType,
 					Password:    utils.Ptr("Secret123!"),
 				}
-				*request = (*request).UpdateIntakeUserPayload(payload)
+				*request = request.UpdateIntakeUserPayload(payload)
 			}),
 		},
 	}

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -176,7 +176,7 @@ func TestBuildRequest(t *testing.T) {
 				payload := intake.UpdateIntakeUserPayload{
 					Description: utils.Ptr("new-desc"),
 				}
-				*request = (*request).UpdateIntakeUserPayload(payload)
+				*request = request.UpdateIntakeUserPayload(payload)
 			}),
 		},
 		{
@@ -197,7 +197,7 @@ func TestBuildRequest(t *testing.T) {
 					Type:        &userType,
 					Password:    utils.Ptr("Secret123!"),
 				}
-				*request = (*request).UpdateIntakeUserPayload(payload)
+				*request = request.UpdateIntakeUserPayload(payload)
 			}),
 		},
 	}

--- a/internal/cmd/beta/intake/user/update/update_test.go
+++ b/internal/cmd/beta/intake/user/update/update_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 type testCtxKey struct{}

--- a/internal/pkg/services/intake/client/client.go
+++ b/internal/pkg/services/intake/client/client.go
@@ -2,11 +2,10 @@ package client
 
 import (
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/intake"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // ConfigureClient creates and configures a new Intake API client

--- a/internal/pkg/services/intake/client/client.go
+++ b/internal/pkg/services/intake/client/client.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"github.com/spf13/viper"
+	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	intake "github.com/stackitcloud/stackit-sdk-go/services/intake/v1betaapi"
 )
 
 // ConfigureClient creates and configures a new Intake API client


### PR DESCRIPTION
## Description

This PR migrates the current **STACKIT Intake** implementation to the new SDK hierarchy structure. In our case we must start using **v1betaapi**. 

In order to perform this port we had to: 

1. Update all SDK import paths of Intake to v1betaapi
2. Explicit use of `DefaultAPI` instead of using directly the client
3. Shift from pointers to values for required fields 
4. Fix `go-cmp` to ensure unexported private fields do not affect the test output 
5. Adjust some linting changes

## Checklist

- [x] Issue was linked above (not needed) 
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63)) (not needed)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
