### PR TITLE
fix(iaas): print valid JSON/YAML output for list cmds

### DIFF
--- a/docs/stackit_security-group_list.md
+++ b/docs/stackit_security-group_list.md
@@ -13,11 +13,17 @@ stackit security-group list [flags]
 ### Examples
 
 ```
-  List all groups
+  Lists all security groups
   $ stackit security-group list
 
-  List groups with labels
+  Lists security groups with labels
   $ stackit security-group list --label-selector label1=value1,label2=value2
+
+  Lists all security groups in JSON format
+  $ stackit security-group list --output-format json
+
+  Lists up to 10 security groups
+  $ stackit security-group list --limit 10
 ```
 
 ### Options
@@ -25,6 +31,7 @@ stackit security-group list [flags]
 ```
   -h, --help                    Help for "stackit security-group list"
       --label-selector string   Filter by label
+      --limit int               Maximum number of entries to list
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/affinity-groups/list/list.go
+++ b/internal/cmd/affinity-groups/list/list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 )
 
@@ -63,16 +64,19 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list affinity groups: %w", err)
 			}
+			items := result.GetItems()
 
-			if items := result.Items; items != nil {
-				if model.Limit != nil && len(*items) > int(*model.Limit) {
-					*items = (*items)[:*model.Limit]
-				}
-				return outputResult(params.Printer, *model, *items)
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
-			params.Printer.Outputln("No affinity groups found")
-			return nil
+			// Truncate Output
+			if model.Limit != nil && len(items) > int(*model.Limit) {
+				items = items[:*model.Limit]
+			}
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -110,13 +114,12 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func outputResult(p *print.Printer, model inputModel, items []iaas.AffinityGroup) error {
-	var outputFormat string
-	if model.GlobalFlagModel != nil {
-		outputFormat = model.OutputFormat
-	}
-
+func outputResult(p *print.Printer, outputFormat, projectLabel string, items []iaas.AffinityGroup) error {
 	return p.OutputResult(outputFormat, items, func() error {
+		if len(items) == 0 {
+			p.Outputf("No affinity groups found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "POLICY")
 		for _, item := range items {

--- a/internal/cmd/affinity-groups/list/list_test.go
+++ b/internal/cmd/affinity-groups/list/list_test.go
@@ -156,6 +156,20 @@ func TestOutputResult(t *testing.T) {
 			args:        args{},
 			isValid:     true,
 		},
+		{
+			description: "empty slice",
+			args: args{
+				instances: []iaas.AffinityGroup{},
+			},
+			isValid: true,
+		},
+		{
+			description: "empty affinity group in slice",
+			args: args{
+				instances: []iaas.AffinityGroup{{}},
+			},
+			isValid: true,
+		},
 	}
 	params := testparams.NewTestParams()
 	for _, tt := range tests {

--- a/internal/cmd/affinity-groups/list/list_test.go
+++ b/internal/cmd/affinity-groups/list/list_test.go
@@ -141,23 +141,26 @@ func TestBuildRequest(t *testing.T) {
 }
 
 func TestOutputResult(t *testing.T) {
+	type args struct {
+		outputFormat string
+		projectLabel string
+		instances    []iaas.AffinityGroup
+	}
 	tests := []struct {
 		description string
-		model       inputModel
-		response    []iaas.AffinityGroup
+		args        args
 		isValid     bool
 	}{
 		{
 			description: "empty",
-			model:       inputModel{},
-			response:    []iaas.AffinityGroup{},
+			args:        args{},
 			isValid:     true,
 		},
 	}
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			err := outputResult(params.Printer, tt.model, tt.response)
+			err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.instances)
 			if err != nil {
 				if !tt.isValid {
 					return

--- a/internal/cmd/image/list/list.go
+++ b/internal/cmd/image/list/list.go
@@ -81,21 +81,18 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Call API
 			request := buildRequest(ctx, model, apiClient)
-
 			response, err := request.Execute()
 			if err != nil {
 				return fmt.Errorf("list images: %w", err)
 			}
+			items := response.GetItems()
 
-			if items := response.GetItems(); len(items) == 0 {
-				params.Printer.Info("No images found for project %q", projectLabel)
-			} else {
-				if model.Limit != nil && len(items) > int(*model.Limit) {
-					items = (items)[:*model.Limit]
-				}
-				if err := outputResult(params.Printer, model.OutputFormat, items); err != nil {
-					return fmt.Errorf("output images: %w", err)
-				}
+			// Truncate output
+			if model.Limit != nil && len(items) > int(*model.Limit) {
+				items = (items)[:*model.Limit]
+			}
+			if err := outputResult(params.Printer, model.OutputFormat, projectLabel, items); err != nil {
+				return fmt.Errorf("output images: %w", err)
 			}
 
 			return nil
@@ -149,8 +146,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return request
 }
 
-func outputResult(p *print.Printer, outputFormat string, items []iaas.Image) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, items []iaas.Image) error {
 	return p.OutputResult(outputFormat, items, func() error {
+		if len(items) == 0 {
+			p.Outputf("No images found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "OS", "ARCHITECTURE", "DISTRIBUTION", "VERSION", "SCOPE", "OWNER", "LABELS")
 		for i := range items {

--- a/internal/cmd/image/list/list_test.go
+++ b/internal/cmd/image/list/list_test.go
@@ -188,6 +188,7 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		items        []iaas.Image
 	}
 	tests := []struct {
@@ -215,7 +216,7 @@ func Test_outputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.items); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.items); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -135,7 +135,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 func outputResult(p *print.Printer, outputFormat, projectLabel string, keyPairs []iaas.Keypair) error {
 	return p.OutputResult(outputFormat, keyPairs, func() error {
 		if len(keyPairs) == 0 {
-			p.Outputf("No key pairs found for project %q\n", projectLabel)
+			p.Outputf("No key pairs found\n")
 			return nil
 		}
 

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -70,6 +71,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				return fmt.Errorf("list key pairs: %w", err)
+			}
+
 			// Call API
 			req := buildRequest(ctx, model, apiClient)
 			resp, err := req.Execute()
@@ -77,17 +83,14 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list key pairs: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				params.Printer.Info("No key pairs found\n")
-				return nil
-			}
+			items := resp.GetItems()
 
-			items := *resp.Items
+			// Truncate output
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -128,8 +131,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, keyPairs []iaas.Keypair) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, keyPairs []iaas.Keypair) error {
 	return p.OutputResult(outputFormat, keyPairs, func() error {
+		if len(keyPairs) == 0 {
+			p.Outputf("No key pairs found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("KEY PAIR NAME", "LABELS", "FINGERPRINT", "CREATED AT", "UPDATED AT")
 

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -80,18 +79,12 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			items := resp.GetItems()
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				projectLabel = model.ProjectId
-			}
-
 			// Truncate output
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
+			return outputResult(params.Printer, model.OutputFormat, items)
 		},
 	}
 	configureFlags(cmd)
@@ -132,7 +125,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat, projectLabel string, keyPairs []iaas.Keypair) error {
+func outputResult(p *print.Printer, outputFormat string, keyPairs []iaas.Keypair) error {
 	return p.OutputResult(outputFormat, keyPairs, func() error {
 		if len(keyPairs) == 0 {
 			p.Outputf("No key pairs found\n")

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -71,12 +71,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				projectLabel = model.ProjectId
-			}
-
 			// Call API
 			req := buildRequest(ctx, model, apiClient)
 			resp, err := req.Execute()
@@ -85,6 +79,12 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			items := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
+			}
 
 			// Truncate output
 			if model.Limit != nil && len(items) > int(*model.Limit) {

--- a/internal/cmd/key-pair/list/list.go
+++ b/internal/cmd/key-pair/list/list.go
@@ -73,7 +73,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
-				return fmt.Errorf("list key pairs: %w", err)
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Call API

--- a/internal/cmd/key-pair/list/list_test.go
+++ b/internal/cmd/key-pair/list/list_test.go
@@ -153,6 +153,7 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		keyPairs     []iaas.Keypair
 	}
 	tests := []struct {
@@ -176,7 +177,7 @@ func Test_outputResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			params := testparams.NewTestParams()
 
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.keyPairs); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.keyPairs); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/key-pair/list/list_test.go
+++ b/internal/cmd/key-pair/list/list_test.go
@@ -153,7 +153,6 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
-		projectLabel string
 		keyPairs     []iaas.Keypair
 	}
 	tests := []struct {
@@ -177,7 +176,7 @@ func Test_outputResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			params := testparams.NewTestParams()
 
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.keyPairs); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.keyPairs); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -80,31 +80,30 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list network areas: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				var orgLabel string
-				rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
-				if err == nil {
-					orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
-					if err != nil {
-						params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
-						orgLabel = *model.OrganizationId
-					} else if orgLabel == "" {
-						orgLabel = *model.OrganizationId
-					}
-				} else {
-					params.Printer.Debug(print.ErrorLevel, "configure resource manager client: %v", err)
+			items := resp.GetItems()
+
+			var orgLabel string
+			rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
+			if err == nil {
+				orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
+				if err != nil {
+					params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
+					orgLabel = *model.OrganizationId
 				}
-				params.Printer.Info("No STACKIT Network Areas found for organization %q\n", orgLabel)
-				return nil
+			} else {
+				params.Printer.Debug(print.ErrorLevel, "configure resource manager client: %v", err)
+			}
+
+			if orgLabel == "" {
+				orgLabel = *model.OrganizationId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, orgLabel, model.OutputFormat, items)
 		},
 	}
 	configureFlags(cmd)
@@ -149,8 +148,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, networkAreas []iaas.NetworkArea) error {
+func outputResult(p *print.Printer, orgLabel, outputFormat string, networkAreas []iaas.NetworkArea) error {
 	return p.OutputResult(outputFormat, networkAreas, func() error {
+		if len(networkAreas) == 0 {
+			p.Outputf("No STACKIT Network Areas found for organization %q\n", orgLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "Name", "# Attached Projects")
 

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -103,7 +103,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, orgLabel, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, orgLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -148,7 +148,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, orgLabel, outputFormat string, networkAreas []iaas.NetworkArea) error {
+func outputResult(p *print.Printer, outputFormat, orgLabel string, networkAreas []iaas.NetworkArea) error {
 	return p.OutputResult(outputFormat, networkAreas, func() error {
 		if len(networkAreas) == 0 {
 			p.Outputf("No STACKIT Network Areas found for organization %q\n", orgLabel)

--- a/internal/cmd/network-area/list/list.go
+++ b/internal/cmd/network-area/list/list.go
@@ -32,7 +32,7 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	Limit          *int64
-	OrganizationId *string
+	OrganizationId string
 	LabelSelector  *string
 }
 
@@ -85,17 +85,17 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			var orgLabel string
 			rmApiClient, err := rmClient.ConfigureClient(params.Printer, params.CliVersion)
 			if err == nil {
-				orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, *model.OrganizationId)
+				orgLabel, err = rmUtils.GetOrganizationName(ctx, rmApiClient, model.OrganizationId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
-					orgLabel = *model.OrganizationId
+					orgLabel = model.OrganizationId
 				}
 			} else {
 				params.Printer.Debug(print.ErrorLevel, "configure resource manager client: %v", err)
 			}
 
 			if orgLabel == "" {
-				orgLabel = *model.OrganizationId
+				orgLabel = model.OrganizationId
 			}
 
 			// Truncate output
@@ -132,7 +132,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		Limit:           limit,
-		OrganizationId:  flags.FlagToStringPointer(p, cmd, organizationIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
 	}
 
@@ -141,7 +141,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiListNetworkAreasRequest {
-	req := apiClient.ListNetworkAreas(ctx, *model.OrganizationId)
+	req := apiClient.ListNetworkAreas(ctx, model.OrganizationId)
 	if model.LabelSelector != nil {
 		req = req.LabelSelector(*model.LabelSelector)
 	}

--- a/internal/cmd/network-area/list/list_test.go
+++ b/internal/cmd/network-area/list/list_test.go
@@ -39,7 +39,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		GlobalFlagModel: &globalflags.GlobalFlagModel{
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		OrganizationId: &testOrganizationId,
+		OrganizationId: testOrganizationId,
 		Limit:          utils.Ptr(int64(10)),
 		LabelSelector:  utils.Ptr(testLabelSelector),
 	}

--- a/internal/cmd/network-area/list/list_test.go
+++ b/internal/cmd/network-area/list/list_test.go
@@ -167,6 +167,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		orgLabel     string
 		networkAreas []iaas.NetworkArea
 	}
 	tests := []struct {
@@ -197,7 +198,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.networkAreas); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.orgLabel, tt.args.networkAreas); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -75,24 +75,21 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list network ranges: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				var networkAreaLabel string
-				networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
-					networkAreaLabel = *model.NetworkAreaId
-				}
-				params.Printer.Info("No network ranges found for SNA %q\n", networkAreaLabel)
-				return nil
+			items := resp.GetItems()
+
+			var networkAreaLabel string
+			networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
+				networkAreaLabel = *model.NetworkAreaId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, networkAreaLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -133,8 +130,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return apiClient.ListNetworkAreaRanges(ctx, *model.OrganizationId, *model.NetworkAreaId, model.Region)
 }
 
-func outputResult(p *print.Printer, outputFormat string, networkRanges []iaas.NetworkRange) error {
+func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, networkRanges []iaas.NetworkRange) error {
 	return p.OutputResult(outputFormat, networkRanges, func() error {
+		if len(networkRanges) == 0 {
+			p.Outputf("No network ranges found for SNA %q\n", networkAreaLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "Network Range")
 

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -132,7 +132,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, networkRanges []iaas.NetworkRange) error {
 	return p.OutputResult(outputFormat, networkRanges, func() error {
 		if len(networkRanges) == 0 {
-			p.Outputf("No network ranges found for SNA %q\n", networkAreaLabel)
+			p.Outputf("No network ranges found for STACKIT network area %q\n", networkAreaLabel)
 			return nil
 		}
 		table := tables.NewTable()

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -77,8 +77,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			items := resp.GetItems()
 
-			var networkAreaLabel string
-			networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
+			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
 				networkAreaLabel = *model.NetworkAreaId

--- a/internal/cmd/network-area/network-range/list/list.go
+++ b/internal/cmd/network-area/network-range/list/list.go
@@ -31,8 +31,8 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	Limit          *int64
-	OrganizationId *string
-	NetworkAreaId  *string
+	OrganizationId string
+	NetworkAreaId  string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -77,10 +77,10 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			items := resp.GetItems()
 
-			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
+			networkAreaLabel, err := iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get organization name: %v", err)
-				networkAreaLabel = *model.NetworkAreaId
+				networkAreaLabel = model.NetworkAreaId
 			}
 
 			// Truncate output
@@ -117,8 +117,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		Limit:           limit,
-		OrganizationId:  flags.FlagToStringPointer(p, cmd, organizationIdFlag),
-		NetworkAreaId:   flags.FlagToStringPointer(p, cmd, networkAreaIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+		NetworkAreaId:   flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -126,7 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiListNetworkAreaRangesRequest {
-	return apiClient.ListNetworkAreaRanges(ctx, *model.OrganizationId, *model.NetworkAreaId, model.Region)
+	return apiClient.ListNetworkAreaRanges(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
 }
 
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, networkRanges []iaas.NetworkRange) error {

--- a/internal/cmd/network-area/network-range/list/list_test.go
+++ b/internal/cmd/network-area/network-range/list/list_test.go
@@ -46,8 +46,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		OrganizationId: &testOrganizationId,
-		NetworkAreaId:  &testNetworkAreaId,
+		OrganizationId: testOrganizationId,
+		NetworkAreaId:  testNetworkAreaId,
 		Limit:          utils.Ptr(int64(10)),
 	}
 	for _, mod := range mods {

--- a/internal/cmd/network-area/network-range/list/list_test.go
+++ b/internal/cmd/network-area/network-range/list/list_test.go
@@ -183,8 +183,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat  string
-		networkRanges []iaas.NetworkRange
+		outputFormat     string
+		networkAreaLabel string
+		networkRanges    []iaas.NetworkRange
 	}
 	tests := []struct {
 		name    string
@@ -214,7 +215,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.networkRanges); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.networkAreaLabel, tt.args.networkRanges); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -30,8 +30,8 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	Limit          *int64
-	OrganizationId *string
-	NetworkAreaId  *string
+	OrganizationId string
+	NetworkAreaId  string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -77,10 +77,10 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			items := resp.GetItems()
 
 			var networkAreaLabel string
-			networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
+			networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, model.OrganizationId, model.NetworkAreaId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
-				networkAreaLabel = *model.NetworkAreaId
+				networkAreaLabel = model.NetworkAreaId
 			}
 
 			// Truncate output
@@ -117,8 +117,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		Limit:           limit,
-		OrganizationId:  flags.FlagToStringPointer(p, cmd, organizationIdFlag),
-		NetworkAreaId:   flags.FlagToStringPointer(p, cmd, networkAreaIdFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+		NetworkAreaId:   flags.FlagToStringValue(p, cmd, networkAreaIdFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -126,7 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiListNetworkAreaRoutesRequest {
-	return apiClient.ListNetworkAreaRoutes(ctx, *model.OrganizationId, *model.NetworkAreaId, model.Region)
+	return apiClient.ListNetworkAreaRoutes(ctx, model.OrganizationId, model.NetworkAreaId, model.Region)
 }
 
 func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, routes []iaas.Route) error {

--- a/internal/cmd/network-area/route/list/list.go
+++ b/internal/cmd/network-area/route/list/list.go
@@ -74,24 +74,21 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list static routes: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				var networkAreaLabel string
-				networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
-					networkAreaLabel = *model.NetworkAreaId
-				}
-				params.Printer.Info("No static routes found for STACKIT Network Area %q\n", networkAreaLabel)
-				return nil
+			items := resp.GetItems()
+
+			var networkAreaLabel string
+			networkAreaLabel, err = iaasUtils.GetNetworkAreaName(ctx, apiClient, *model.OrganizationId, *model.NetworkAreaId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get network area name: %v", err)
+				networkAreaLabel = *model.NetworkAreaId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, networkAreaLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -132,8 +129,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return apiClient.ListNetworkAreaRoutes(ctx, *model.OrganizationId, *model.NetworkAreaId, model.Region)
 }
 
-func outputResult(p *print.Printer, outputFormat string, routes []iaas.Route) error {
+func outputResult(p *print.Printer, outputFormat, networkAreaLabel string, routes []iaas.Route) error {
 	return p.OutputResult(outputFormat, routes, func() error {
+		if len(routes) == 0 {
+			p.Outputf("No static routes found for STACKIT Network Area %q\n", networkAreaLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("Static Route ID", "Next Hop", "Next Hop Type", "Destination")
 

--- a/internal/cmd/network-area/route/list/list_test.go
+++ b/internal/cmd/network-area/route/list/list_test.go
@@ -46,8 +46,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 			Region:    testRegion,
 		},
-		OrganizationId: &testOrganizationId,
-		NetworkAreaId:  &testNetworkAreaId,
+		OrganizationId: testOrganizationId,
+		NetworkAreaId:  testNetworkAreaId,
 		Limit:          utils.Ptr(int64(10)),
 	}
 	for _, mod := range mods {

--- a/internal/cmd/network-area/route/list/list_test.go
+++ b/internal/cmd/network-area/route/list/list_test.go
@@ -183,8 +183,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		routes       []iaas.Route
+		outputFormat     string
+		networkAreaLabel string
+		routes           []iaas.Route
 	}
 	tests := []struct {
 		name    string
@@ -232,7 +233,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.routes); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.networkAreaLabel, tt.args.routes); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/network/list/list.go
+++ b/internal/cmd/network/list/list.go
@@ -83,8 +83,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId
-			} else if projectLabel == "" {
-				projectLabel = model.ProjectId
 			}
 
 			// Truncate output

--- a/internal/cmd/network/list/list.go
+++ b/internal/cmd/network/list/list.go
@@ -77,25 +77,22 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list networks: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				} else if projectLabel == "" {
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No networks found for project %q\n", projectLabel)
-				return nil
+			items := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
+			} else if projectLabel == "" {
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -139,8 +136,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, networks []iaas.Network) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, networks []iaas.Network) error {
 	return p.OutputResult(outputFormat, networks, func() error {
+		if len(networks) == 0 {
+			p.Outputf("No networks found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATUS", "PUBLIC IP", "PREFIXES", "ROUTED", "ROUTING TABLE ID")
 

--- a/internal/cmd/network/list/list_test.go
+++ b/internal/cmd/network/list/list_test.go
@@ -174,6 +174,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		networks     []iaas.Network
 	}
 	tests := []struct {
@@ -199,7 +200,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.networks); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.networks); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -83,8 +83,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId
-			} else if projectLabel == "" {
-				projectLabel = model.ProjectId
 			}
 
 			// Truncate output

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -83,6 +83,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
 				projectLabel = model.ProjectId
+			} else if projectLabel == "" {
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output

--- a/internal/cmd/public-ip/list/list.go
+++ b/internal/cmd/public-ip/list/list.go
@@ -77,25 +77,22 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list public IPs: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				} else if projectLabel == "" {
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No public IPs found for project %q\n", projectLabel)
-				return nil
+			items := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
+			} else if projectLabel == "" {
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -140,8 +137,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, publicIps []iaas.PublicIp) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, publicIps []iaas.PublicIp) error {
 	return p.OutputResult(outputFormat, publicIps, func() error {
+		if len(publicIps) == 0 {
+			p.Outputf("No public IPs found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "IP ADDRESS", "USED BY")
 

--- a/internal/cmd/public-ip/list/list_test.go
+++ b/internal/cmd/public-ip/list/list_test.go
@@ -174,6 +174,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		publicIps    []iaas.PublicIp
 	}
 	tests := []struct {
@@ -190,7 +191,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.publicIps); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.publicIps); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/quota/list/list.go
+++ b/internal/cmd/quota/list/list.go
@@ -64,7 +64,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list quotas: %w", err)
 			}
-
+			response.Quotas = nil
 			if items := response.Quotas; items == nil {
 				params.Printer.Info("No quotas found for project %q", projectLabel)
 			} else {

--- a/internal/cmd/quota/list/list.go
+++ b/internal/cmd/quota/list/list.go
@@ -64,16 +64,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list quotas: %w", err)
 			}
-			response.Quotas = nil
-			if items := response.Quotas; items == nil {
-				params.Printer.Info("No quotas found for project %q", projectLabel)
-			} else {
-				if err := outputResult(params.Printer, model.OutputFormat, items); err != nil {
-					return fmt.Errorf("output quotas: %w", err)
-				}
-			}
 
-			return nil
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, response.Quotas)
 		},
 	}
 
@@ -100,11 +92,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return request
 }
 
-func outputResult(p *print.Printer, outputFormat string, quotas *iaas.QuotaList) error {
-	if quotas == nil {
-		return fmt.Errorf("quotas is nil")
-	}
+func outputResult(p *print.Printer, outputFormat, projectLabel string, quotas *iaas.QuotaList) error {
 	return p.OutputResult(outputFormat, quotas, func() error {
+		if quotas == nil {
+			p.Outputf("No quotas found for project %q", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("NAME", "LIMIT", "CURRENT USAGE", "PERCENT")
 		if val := quotas.BackupGigabytes; val != nil {

--- a/internal/cmd/quota/list/list_test.go
+++ b/internal/cmd/quota/list/list_test.go
@@ -138,6 +138,7 @@ func TestBuildRequest(t *testing.T) {
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		quotas       *iaas.QuotaList
 	}
 	tests := []struct {
@@ -148,7 +149,7 @@ func Test_outputResult(t *testing.T) {
 		{
 			name:    "empty",
 			args:    args{},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "set quota empty",
@@ -161,7 +162,7 @@ func Test_outputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.quotas); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.quotas); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -25,10 +25,12 @@ import (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	LabelSelector *string
+	Limit         *int64
 }
 
 const (
 	labelSelectorFlag = "label-selector"
+	limitFlag         = "limit"
 )
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -38,8 +40,16 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Long:  "Lists security groups by its internal ID.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
-			examples.NewExample(`List all groups`, `$ stackit security-group list`),
-			examples.NewExample(`List groups with labels`, `$ stackit security-group list --label-selector label1=value1,label2=value2`),
+			examples.NewExample(`Lists all security groups`, `$ stackit security-group list`),
+			examples.NewExample(`Lists security groups with labels`, `$ stackit security-group list --label-selector label1=value1,label2=value2`),
+			examples.NewExample(
+				`Lists all security groups in JSON format`,
+				"$ stackit security-group list --output-format json",
+			),
+			examples.NewExample(
+				`Lists up to 10 security groups`,
+				"$ stackit security-group list --limit 10",
+			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -70,6 +80,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				projectLabel = model.ProjectId
 			}
 
+			// Truncate output
+			if model.Limit != nil && len(items) > int(*model.Limit) {
+				items = items[:*model.Limit]
+			}
+
 			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 
 		},
@@ -81,6 +96,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(labelSelectorFlag, "", "Filter by label")
+	cmd.Flags().Int64(limitFlag, 0, "Maximum number of entries to list")
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
@@ -89,9 +105,18 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		return nil, &errors.ProjectIdError{}
 	}
 
+	limit := flags.FlagToInt64Pointer(p, cmd, limitFlag)
+	if limit != nil && *limit < 1 {
+		return nil, &errors.FlagValidationError{
+			Flag:    limitFlag,
+			Details: "must be greater than 0",
+		}
+	}
+
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		LabelSelector:   flags.FlagToStringPointer(p, cmd, labelSelectorFlag),
+		Limit:           limit,
 	}
 
 	p.DebugInputModel(model)

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -54,12 +54,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-				projectLabel = model.ProjectId
-			}
-
 			// Call API
 			request := buildRequest(ctx, model, apiClient)
 
@@ -68,15 +62,16 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list security group: %w", err)
 			}
 
-			if items := response.GetItems(); len(items) == 0 {
-				params.Printer.Info("No security groups found for project %q", projectLabel)
-			} else {
-				if err := outputResult(params.Printer, model.OutputFormat, items); err != nil {
-					return fmt.Errorf("output security groups: %w", err)
-				}
+			items := response.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
-			return nil
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
+
 		},
 	}
 
@@ -111,8 +106,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 
 	return request
 }
-func outputResult(p *print.Printer, outputFormat string, items []iaas.SecurityGroup) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, items []iaas.SecurityGroup) error {
 	return p.OutputResult(outputFormat, items, func() error {
+		if len(items) == 0 {
+			p.Outputf("No security groups found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATEFUL", "DESCRIPTION", "LABELS")
 		for _, item := range items {

--- a/internal/cmd/security-group/list/list.go
+++ b/internal/cmd/security-group/list/list.go
@@ -86,7 +86,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
-
 		},
 	}
 

--- a/internal/cmd/security-group/list/list_test.go
+++ b/internal/cmd/security-group/list/list_test.go
@@ -182,6 +182,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		items        []iaas.SecurityGroup
 	}
 	tests := []struct {
@@ -198,7 +199,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.items); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.items); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/security-group/list/list_test.go
+++ b/internal/cmd/security-group/list/list_test.go
@@ -34,6 +34,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		globalflags.RegionFlag:    testRegion,
 
 		labelSelectorFlag: testLabels,
+		limitFlag:         "10",
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -49,6 +50,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		LabelSelector: utils.Ptr(testLabels),
+		Limit:         utils.Ptr(int64(10)),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -124,6 +126,20 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(func(model *inputModel) {
 				model.LabelSelector = utils.Ptr("foo=bar")
 			}),
+		},
+		{
+			description: "limit invalid",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[limitFlag] = "invalid"
+			}),
+			isValid: false,
+		},
+		{
+			description: "limit invalid 2",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[limitFlag] = "0"
+			}),
+			isValid: false,
 		},
 	}
 

--- a/internal/cmd/security-group/rule/list/list.go
+++ b/internal/cmd/security-group/rule/list/list.go
@@ -74,29 +74,26 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list security group rules: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				securityGroupLabel, err := iaasUtils.GetSecurityGroupName(ctx, apiClient, model.ProjectId, model.Region, model.SecurityGroupId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get security group name: %v", err)
-					securityGroupLabel = model.SecurityGroupId
-				}
+			items := resp.GetItems()
 
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No rules found in security group %q for project %q\n", securityGroupLabel, projectLabel)
-				return nil
+			securityGroupLabel, err := iaasUtils.GetSecurityGroupName(ctx, apiClient, model.ProjectId, model.Region, model.SecurityGroupId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get security group name: %v", err)
+				securityGroupLabel = model.SecurityGroupId
+			}
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, securityGroupLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -139,8 +136,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return apiClient.ListSecurityGroupRules(ctx, model.ProjectId, model.Region, model.SecurityGroupId)
 }
 
-func outputResult(p *print.Printer, outputFormat string, securityGroupRules []iaas.SecurityGroupRule) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel, securityGroupLabel string, securityGroupRules []iaas.SecurityGroupRule) error {
 	return p.OutputResult(outputFormat, securityGroupRules, func() error {
+		if len(securityGroupRules) == 0 {
+			p.Outputf("No rules found in security group %q for project %q\n", securityGroupLabel, projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "ETHER TYPE", "DIRECTION", "PROTOCOL", "REMOTE SECURITY GROUP ID")
 

--- a/internal/cmd/security-group/rule/list/list_test.go
+++ b/internal/cmd/security-group/rule/list/list_test.go
@@ -184,6 +184,8 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat       string
+		projectLabel       string
+		securityGroupLabel string
 		securityGroupRules []iaas.SecurityGroupRule
 	}
 	tests := []struct {
@@ -200,7 +202,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.securityGroupRules); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.securityGroupLabel, tt.args.securityGroupRules); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -79,9 +79,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			items := resp.GetItems()
-			if items == nil {
-				items = []iaas.Server{}
-			}
 
 			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -78,23 +78,25 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list servers: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No servers found for project %q\n", projectLabel)
-				return nil
+			var items []iaas.Server
+			if resp.Items == nil {
+				items = []iaas.Server{}
+			} else {
+				items = *resp.Items
+			}
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -140,7 +142,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, servers []iaas.Server) error {
+func outputResult(p *print.Printer, outputFormat string, projectLabel string, servers []iaas.Server) error {
+	if len(servers) == 0 {
+		p.Info("No servers found for project %q\n", projectLabel)
+	}
 	switch outputFormat {
 	case print.JSONOutputFormat:
 		details, err := json.MarshalIndent(servers, "", "  ")

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -78,11 +78,9 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list servers: %w", err)
 			}
 
-			var items []iaas.Server
-			if resp.Items == nil {
+			items := resp.GetItems()
+			if items == nil {
 				items = []iaas.Server{}
-			} else {
-				items = *resp.Items
 			}
 
 			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -165,7 +165,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, servers [
 		return nil
 	default:
 		if len(servers) == 0 {
-			p.Info("No servers found for project %q\n", projectLabel)
+			p.Outputf("No servers found for project %q\n", projectLabel)
 			return nil
 		}
 		table := tables.NewTable()

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -142,7 +142,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, projectLabel string, servers []iaas.Server) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, servers []iaas.Server) error {
 	if len(servers) == 0 {
 		p.Info("No servers found for project %q\n", projectLabel)
 	}

--- a/internal/cmd/server/list/list.go
+++ b/internal/cmd/server/list/list.go
@@ -141,9 +141,6 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, servers []iaas.Server) error {
-	if len(servers) == 0 {
-		p.Info("No servers found for project %q\n", projectLabel)
-	}
 	switch outputFormat {
 	case print.JSONOutputFormat:
 		details, err := json.MarshalIndent(servers, "", "  ")
@@ -167,6 +164,10 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, servers [
 
 		return nil
 	default:
+		if len(servers) == 0 {
+			p.Info("No servers found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "Name", "Status", "Machine Type", "Availability Zones", "Nic IPv4", "Public IPs", "Agent")
 

--- a/internal/cmd/server/list/list_test.go
+++ b/internal/cmd/server/list/list_test.go
@@ -175,6 +175,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		servers      []iaas.Server
 	}
 	tests := []struct {
@@ -191,7 +192,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.servers); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.servers); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/machine-type/list/list.go
+++ b/internal/cmd/server/machine-type/list/list.go
@@ -80,14 +80,10 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("read machine-types: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No machine-types found for project %q\n", projectLabel)
-				return nil
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// limit output
@@ -95,7 +91,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				*resp.Items = (*resp.Items)[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, *resp)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, *resp)
 		},
 	}
 
@@ -140,8 +136,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, machineTypes iaas.MachineTypeListResponse) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, machineTypes iaas.MachineTypeListResponse) error {
 	return p.OutputResult(outputFormat, machineTypes, func() error {
+		if machineTypes.Items == nil || len(*machineTypes.Items) == 0 {
+			p.Outputf("No machine-types found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetTitle("Machine-Types")
 		table.SetHeader("NAME", "VCPUS", "RAM (GB)", "DESCRIPTION", "EXTRA SPECS")

--- a/internal/cmd/server/machine-type/list/list_test.go
+++ b/internal/cmd/server/machine-type/list/list_test.go
@@ -179,6 +179,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		machineTypes iaas.MachineTypeListResponse
 	}
 	tests := []struct {
@@ -222,7 +223,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.machineTypes); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.machineTypes); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/network-interface/list/list.go
+++ b/internal/cmd/server/network-interface/list/list.go
@@ -72,25 +72,22 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list attached network interfaces: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, model.Region, model.ServerId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
-					serverLabel = model.ServerId
-				} else if serverLabel == "" {
-					serverLabel = model.ServerId
-				}
-				params.Printer.Info("No attached network interfaces found for server %q\n", serverLabel)
-				return nil
+			items := resp.GetItems()
+
+			serverLabel, err := iaasUtils.GetServerName(ctx, apiClient, model.ProjectId, model.Region, model.ServerId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
+				serverLabel = model.ServerId
+			} else if serverLabel == "" {
+				serverLabel = model.ServerId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, model.ServerId, items)
+			return outputResult(params.Printer, model.OutputFormat, model.ServerId, serverLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -133,8 +130,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return apiClient.ListServerNICs(ctx, model.ProjectId, model.Region, model.ServerId)
 }
 
-func outputResult(p *print.Printer, outputFormat, serverId string, serverNics []iaas.NIC) error {
+func outputResult(p *print.Printer, outputFormat, serverId, serverLabel string, serverNics []iaas.NIC) error {
 	return p.OutputResult(outputFormat, serverNics, func() error {
+		if len(serverNics) == 0 {
+			p.Outputf("No attached network interfaces found for server %q\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("NIC ID", "SERVER ID")
 

--- a/internal/cmd/server/network-interface/list/list_test.go
+++ b/internal/cmd/server/network-interface/list/list_test.go
@@ -180,6 +180,7 @@ func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
 		serverId     string
+		serverLabel  string
 		serverNics   []iaas.NIC
 	}
 	tests := []struct {
@@ -205,7 +206,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverId, tt.args.serverNics); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverId, tt.args.serverLabel, tt.args.serverNics); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/service-account/list/list.go
+++ b/internal/cmd/server/service-account/list/list.go
@@ -78,10 +78,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list service accounts: %w", err)
 			}
 			serviceAccounts := *resp.Items
-			if len(serviceAccounts) == 0 {
-				params.Printer.Info("No service accounts found for server %s\n", serverName)
-				return nil
-			}
 
 			if model.Limit != nil && len(serviceAccounts) > int(*model.Limit) {
 				serviceAccounts = serviceAccounts[:int(*model.Limit)]
@@ -133,6 +129,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 
 func outputResult(p *print.Printer, outputFormat, serverId, serverName string, serviceAccounts []string) error {
 	return p.OutputResult(outputFormat, serviceAccounts, func() error {
+		if len(serviceAccounts) == 0 {
+			p.Info("No service accounts found for server %s\n", serverName)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("SERVER ID", "SERVER NAME", "SERVICE ACCOUNT")
 		for i := range serviceAccounts {
@@ -140,7 +140,7 @@ func outputResult(p *print.Printer, outputFormat, serverId, serverName string, s
 		}
 		err := table.Display(p)
 		if err != nil {
-			return fmt.Errorf("rednder table: %w", err)
+			return fmt.Errorf("render table: %w", err)
 		}
 		return nil
 	})

--- a/internal/cmd/server/volume/list/list.go
+++ b/internal/cmd/server/volume/list/list.go
@@ -71,11 +71,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server volumes: %w", err)
 			}
-			volumes := *resp.Items
-			if len(volumes) == 0 {
-				params.Printer.Info("No volumes found for server %s\n", serverLabel)
-				return nil
-			}
+
+			volumes := resp.GetItems()
 
 			// get volume names
 			var volumeNames []string
@@ -124,6 +121,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, volumeNames []string, volumes []iaas.VolumeAttachment) error {
 	return p.OutputResult(outputFormat, volumes, func() error {
+		if len(volumes) == 0 {
+			p.Outputf("No volumes found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("SERVER ID", "SERVER NAME", "VOLUME ID", "VOLUME NAME")
 		for i := range volumes {

--- a/internal/cmd/volume/backup/list/list.go
+++ b/internal/cmd/volume/backup/list/list.go
@@ -72,23 +72,21 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get backups: %w", err)
 			}
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No backups found for project %s\n", projectLabel)
-				return nil
+
+			backups := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
-			backups := *resp.Items
 
 			// Truncate output
 			if model.Limit != nil && len(backups) > int(*model.Limit) {
 				backups = backups[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, backups)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, backups)
 		},
 	}
 
@@ -137,12 +135,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, backups []iaas.Backup) error {
-	if backups == nil {
-		return fmt.Errorf("backups is empty")
-	}
-
+func outputResult(p *print.Printer, outputFormat, projectLabel string, backups []iaas.Backup) error {
 	return p.OutputResult(outputFormat, backups, func() error {
+		if len(backups) == 0 {
+			p.Outputf("No backups found for project %s\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE", "STATUS", "SNAPSHOT ID", "VOLUME ID", "AVAILABILITY ZONE", "LABELS", "CREATED AT", "UPDATED AT")
 

--- a/internal/cmd/volume/backup/list/list_test.go
+++ b/internal/cmd/volume/backup/list/list_test.go
@@ -160,6 +160,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		backups      []iaas.Backup
 	}
 	tests := []struct {
@@ -170,7 +171,7 @@ func TestOutputResult(t *testing.T) {
 		{
 			name:    "empty",
 			args:    args{},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "empty backup in slice",
@@ -190,7 +191,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.backups); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.backups); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/volume/list/list.go
+++ b/internal/cmd/volume/list/list.go
@@ -76,23 +76,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list volumes: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No volumes found for project %q\n", projectLabel)
-				return nil
+			items := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -137,8 +134,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, volumes []iaas.Volume) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, volumes []iaas.Volume) error {
 	return p.OutputResult(outputFormat, volumes, func() error {
+		if len(volumes) == 0 {
+			p.Outputf("No volumes found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "Name", "Status", "Server", "Availability Zone", "Size (GB)")
 

--- a/internal/cmd/volume/list/list_test.go
+++ b/internal/cmd/volume/list/list_test.go
@@ -174,6 +174,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		volumes      []iaas.Volume
 	}
 	tests := []struct {
@@ -197,7 +198,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.volumes); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.volumes); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/volume/performance-class/list/list.go
+++ b/internal/cmd/volume/performance-class/list/list.go
@@ -77,23 +77,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list volume performance classes: %w", err)
 			}
 
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No volume performance class found for project %q\n", projectLabel)
-				return nil
+			items := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
-			items := *resp.Items
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, items)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, items)
 		},
 	}
 	configureFlags(cmd)
@@ -138,8 +135,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, performanceClasses []iaas.VolumePerformanceClass) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, performanceClasses []iaas.VolumePerformanceClass) error {
 	return p.OutputResult(outputFormat, performanceClasses, func() error {
+		if len(performanceClasses) == 0 {
+			p.Outputf("No volume performance class found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("Name", "Description")
 

--- a/internal/cmd/volume/performance-class/list/list_test.go
+++ b/internal/cmd/volume/performance-class/list/list_test.go
@@ -174,6 +174,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat       string
+		projectLabel       string
 		performanceClasses []iaas.VolumePerformanceClass
 	}
 	tests := []struct {
@@ -197,7 +198,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.performanceClasses); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.performanceClasses); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/volume/snapshot/list/list.go
+++ b/internal/cmd/volume/snapshot/list/list.go
@@ -72,25 +72,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("list snapshots: %w", err)
 			}
 
-			// Check if response is empty
-			if resp.Items == nil || len(*resp.Items) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No snapshots found for project %q\n", projectLabel)
-				return nil
+			snapshots := resp.GetItems()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
-			snapshots := *resp.Items
-
-			// Apply limit if specified
+			// Truncate output
 			if model.Limit != nil && int(*model.Limit) < len(snapshots) {
 				snapshots = snapshots[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, snapshots)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, snapshots)
 		},
 	}
 
@@ -137,12 +132,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, snapshots []iaas.Snapshot) error {
-	if snapshots == nil {
-		return fmt.Errorf("list snapshots response is empty")
-	}
-
+func outputResult(p *print.Printer, outputFormat, projectLabel string, snapshots []iaas.Snapshot) error {
 	return p.OutputResult(outputFormat, snapshots, func() error {
+		if len(snapshots) == 0 {
+			p.Outputf("No snapshots found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE", "STATUS", "VOLUME ID", "LABELS", "CREATED AT", "UPDATED AT")
 

--- a/internal/cmd/volume/snapshot/list/list_test.go
+++ b/internal/cmd/volume/snapshot/list/list_test.go
@@ -181,6 +181,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		snapshots    []iaas.Snapshot
 	}
 	tests := []struct {
@@ -191,7 +192,7 @@ func TestOutputResult(t *testing.T) {
 		{
 			name:    "empty",
 			args:    args{},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "empty snapshot in slice",
@@ -218,7 +219,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.snapshots); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.snapshots); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-241 / https://github.com/stackitcloud/stackit-cli/issues/893

**Addition:** I encountered a missing `--limit`-flag within the `stackit security-group list` command and directly fixed this after consulting  @marceljk 

## Testing Instructions


Test for every list command that is changed (like f.e. `stackit server list`) if the command returns the expected outputs like:
- `stackit server list` -> Expected: No servers found for project "xxx"
- `stackit server list --output-format json` -> Should output valid JSON
- `stackit server list --output-format yaml` -> Should output valid YAML

Mock responses if testing against API is not possible.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
