### PR TITLE
docs: remove deprecated formula installation guide

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,46 +20,6 @@ brew tap stackitcloud/tap
 brew install --cask stackit
 ```
 
-#### Formula deprecated
-
-The homebrew formula is deprecated, will no longer be updated and will be removed after 2026-01-22.
-You need to install the STACKIT CLI as cask.  
-Therefor you need to uninstall the formula and reinstall it as cask.  
-
-Your profiles should normally remain. To ensure that nothing will be gone, you should backup them.
-
-1. Export your existing profiles. This will create a json file in your current directory.
-```shell
-stackit config profile export default
-```
-
-2. If you have multiple profiles, then execute the export command for each of them. You can find your profiles via:
-
-```shell
-stackit config profile list
-stackit config profile export <profile-name>
-```
-
-3. Uninstall the formula.
-```shell
-brew uninstall stackit
-```
-
-4. Install the STACKIT CLI as cask.
-```shell
-brew install --cask stackit
-```
-
-5. Check if your configs are still stored.
-```shell
-stackit config profile list
-```
-
-6. In case the profiles are gone, import your profiles via:
-```shell
-$ stackit config profile import -c @default.json --name myProfile
-```
-
 ### Linux
 
 #### Snapcraft


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-379

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
