### PR TITLE
fix(Run Commands Service): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/server/command/list/list.go
+++ b/internal/cmd/server/command/list/list.go
@@ -78,16 +78,14 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server commands: %w", err)
 			}
-			if commands := resp.Items; commands == nil || len(*commands) == 0 {
-				params.Printer.Info("No commands found for server %s\n", serverLabel)
-				return nil
-			}
-			commands := *resp.Items
+
+			commands := resp.GetItems()
+
 			// Truncate output
 			if model.Limit != nil && len(commands) > int(*model.Limit) {
 				commands = commands[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, commands)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, commands)
 		},
 	}
 	configureFlags(cmd)
@@ -131,8 +129,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, commands []runcommand.Commands) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, commands []runcommand.Commands) error {
 	return p.OutputResult(outputFormat, commands, func() error {
+		if len(commands) == 0 {
+			p.Outputf("No commands found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "TEMPLATE NAME", "TEMPLATE TITLE", "STATUS", "STARTED_AT", "FINISHED_AT")
 		for i := range commands {

--- a/internal/cmd/server/command/list/list_test.go
+++ b/internal/cmd/server/command/list/list_test.go
@@ -157,6 +157,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		serverLabel  string
 		commands     []runcommand.Commands
 	}
 	tests := []struct {
@@ -173,7 +174,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.commands); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverLabel, tt.args.commands); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/command/template/list/list.go
+++ b/internal/cmd/server/command/template/list/list.go
@@ -62,11 +62,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server command templates: %w", err)
 			}
-			if templates := resp.Items; templates == nil || len(*templates) == 0 {
-				params.Printer.Info("No commands templates found\n")
-				return nil
-			}
-			templates := *resp.Items
+
+			templates := resp.GetItems()
 
 			// Truncate output
 			if model.Limit != nil && len(templates) > int(*model.Limit) {
@@ -113,6 +110,10 @@ func buildRequest(ctx context.Context, _ *inputModel, apiClient *runcommand.APIC
 
 func outputResult(p *print.Printer, outputFormat string, templates []runcommand.CommandTemplate) error {
 	return p.OutputResult(outputFormat, templates, func() error {
+		if len(templates) == 0 {
+			p.Outputf("No commands templates found\n")
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("NAME", "OS TYPE", "TITLE")
 		for i := range templates {


### PR DESCRIPTION
## Description

relates to STACKITCLI-385 / https://github.com/stackitcloud/stackit-cli/issues/893

## Testing Instructions

Create a new server with name yyy and id zzz
- `stackit server command list --server-id zzz` -> Expected: No commands found for server yyy
- `stackit server command list --server-id zzz --output-format json` -> Should output valid JSON
- `stackit server command list --server-id zzz --output-format yaml` -> Should output valid YAML

Here the response needs to be mocked:
- `stackit server command template list` -> Expected: No templates found
- `stackit server command template list --output-format json` -> Should output valid JSON
- `stackit server command template list--output-format yaml` -> Should output valid YAML

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
