### PR TITLE
fix(Server Backup Management): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/server/backup/list/list.go
+++ b/internal/cmd/server/backup/list/list.go
@@ -67,27 +67,24 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server backups: %w", err)
 			}
-			backups := *resp.Items
-			if len(backups) == 0 {
-				serverLabel := model.ServerId
-				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
-					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
-					if err != nil {
-						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
-					} else if serverName != "" {
-						serverLabel = serverName
-					}
+			backups := resp.GetItems()
+
+			// Get server name
+			serverLabel := model.ServerId
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
+				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
+				if err != nil {
+					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
+				} else if serverName != "" {
+					serverLabel = serverName
 				}
-				params.Printer.Info("No backups found for server %s\n", serverLabel)
-				return nil
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(backups) > int(*model.Limit) {
 				backups = backups[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, backups)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, backups)
 		},
 	}
 	configureFlags(cmd)
@@ -131,8 +128,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, backups []serverbackup.Backup) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, backups []serverbackup.Backup) error {
 	return p.OutputResult(outputFormat, backups, func() error {
+		if len(backups) == 0 {
+			p.Outputf("No backups found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE (GB)", "STATUS", "CREATED AT", "EXPIRES AT", "LAST RESTORED AT", "VOLUME BACKUPS")
 		for i := range backups {

--- a/internal/cmd/server/backup/list/list_test.go
+++ b/internal/cmd/server/backup/list/list_test.go
@@ -154,6 +154,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		serverLabel  string
 		backups      []serverbackup.Backup
 	}
 	tests := []struct {
@@ -179,7 +180,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.backups); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverLabel, tt.args.backups); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/backup/schedule/list/list.go
+++ b/internal/cmd/server/backup/schedule/list/list.go
@@ -78,17 +78,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server backup schedules: %w", err)
 			}
-			schedules := *resp.Items
-			if len(schedules) == 0 {
-				params.Printer.Info("No backup schedules found for server %s\n", serverLabel)
-				return nil
-			}
+			schedules := resp.GetItems()
 
 			// Truncate output
 			if model.Limit != nil && len(schedules) > int(*model.Limit) {
 				schedules = schedules[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, schedules)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, schedules)
 		},
 	}
 	configureFlags(cmd)
@@ -132,8 +128,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, schedules []serverbackup.BackupSchedule) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, schedules []serverbackup.BackupSchedule) error {
 	return p.OutputResult(outputFormat, schedules, func() error {
+		if len(schedules) == 0 {
+			p.Outputf("No backup schedules found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("SCHEDULE ID", "SCHEDULE NAME", "ENABLED", "RRULE", "BACKUP NAME", "BACKUP RETENTION DAYS", "BACKUP VOLUME IDS")
 		for i := range schedules {

--- a/internal/cmd/server/backup/schedule/list/list_test.go
+++ b/internal/cmd/server/backup/schedule/list/list_test.go
@@ -155,6 +155,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		serverLabel  string
 		schedules    []serverbackup.BackupSchedule
 	}
 	tests := []struct {
@@ -191,7 +192,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.schedules); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverLabel, tt.args.schedules); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-386 / https://github.com/stackitcloud/stackit-cli/issues/893

## Testing Instructions

Create a new server with name yyy and id zzz

- `stackit server backup list --server-id zzz` -> Expected: No backups found for server yyy
- `stackit server backup list --server-id zzz --output-format json` -> Should output valid JSON
- `stackit server backup list --server-id zzz --output-format yaml` -> Should output valid YAML


- `stackit server backup schedule list --server-id zzz` -> Expected: No backup schedules found for server yyy
- `stackit server backup schedule list --server-id zzz --output-format json` -> Should output valid JSON
- `stackit server backup schedule list --server-id zzz --output-format yaml` -> Should output valid YAML

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
