### PR TITLE
fix(Server Update Management): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/server/os-update/list/list.go
+++ b/internal/cmd/server/os-update/list/list.go
@@ -67,27 +67,24 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server os-update: %w", err)
 			}
-			updates := *resp.Items
-			if len(updates) == 0 {
-				serverLabel := model.ServerId
-				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
-					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
-					if err != nil {
-						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
-					} else if serverName != "" {
-						serverLabel = serverName
-					}
+			updates := resp.GetItems()
+
+			serverLabel := model.ServerId
+			// Get server name
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
+				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
+				if err != nil {
+					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
+				} else if serverName != "" {
+					serverLabel = serverName
 				}
-				params.Printer.Info("No os-updates found for server %s\n", serverLabel)
-				return nil
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(updates) > int(*model.Limit) {
 				updates = updates[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, updates)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, updates)
 		},
 	}
 	configureFlags(cmd)
@@ -131,8 +128,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, updates []serverupdate.Update) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, updates []serverupdate.Update) error {
 	return p.OutputResult(outputFormat, updates, func() error {
+		if len(updates) == 0 {
+			p.Outputf("No os-updates found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "STATUS", "INSTALLED UPDATES", "FAILED UPDATES", "START DATE", "END DATE")
 		for i := range updates {

--- a/internal/cmd/server/os-update/list/list_test.go
+++ b/internal/cmd/server/os-update/list/list_test.go
@@ -157,6 +157,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		serverLabel  string
 		updates      []serverupdate.Update
 	}
 	tests := []struct {
@@ -173,7 +174,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.updates); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverLabel, tt.args.updates); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/server/os-update/schedule/list/list.go
+++ b/internal/cmd/server/os-update/schedule/list/list.go
@@ -67,27 +67,25 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list server os-update schedules: %w", err)
 			}
-			schedules := *resp.Items
-			if len(schedules) == 0 {
-				serverLabel := model.ServerId
-				// Get server name
-				if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
-					serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
-					if err != nil {
-						params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
-					} else if serverName != "" {
-						serverLabel = serverName
-					}
+
+			schedules := resp.GetItems()
+
+			serverLabel := model.ServerId
+			// Get server name
+			if iaasApiClient, err := iaasClient.ConfigureClient(params.Printer, params.CliVersion); err == nil {
+				serverName, err := iaasUtils.GetServerName(ctx, iaasApiClient, model.ProjectId, model.Region, model.ServerId)
+				if err != nil {
+					params.Printer.Debug(print.ErrorLevel, "get server name: %v", err)
+				} else if serverName != "" {
+					serverLabel = serverName
 				}
-				params.Printer.Info("No os-update schedules found for server %s\n", serverLabel)
-				return nil
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(schedules) > int(*model.Limit) {
 				schedules = schedules[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, schedules)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, schedules)
 		},
 	}
 	configureFlags(cmd)
@@ -131,8 +129,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, schedules []serverupdate.UpdateSchedule) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, schedules []serverupdate.UpdateSchedule) error {
 	return p.OutputResult(outputFormat, schedules, func() error {
+		if len(schedules) == 0 {
+			p.Outputf("No os-update schedules found for server %s\n", serverLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("SCHEDULE ID", "SCHEDULE NAME", "ENABLED", "RRULE", "MAINTENANCE WINDOW")
 		for i := range schedules {

--- a/internal/cmd/server/os-update/schedule/list/list_test.go
+++ b/internal/cmd/server/os-update/schedule/list/list_test.go
@@ -157,6 +157,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		serverLabel  string
 		schedules    []serverupdate.UpdateSchedule
 	}
 	tests := []struct {
@@ -173,7 +174,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.schedules); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serverLabel, tt.args.schedules); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-387 / https://github.com/stackitcloud/stackit-cli/issues/893

## Testing Instructions

Create a new server with name yyy and id zzz

- `stackit server os-update list --server-id zzz` -> Expected: No os-updates found for server yyy
- `stackit server os-update list --server-id zzz --output-format json` -> Should output valid JSON
- `stackit server os-update list --server-id zzz --output-format yaml` -> Should output valid YAML


- `stackit server os-update schedule list --server-id zzz` -> Expected: No os-update schedules found for server yyy
- `stackit server os-update schedule list --server-id zzz --output-format json` -> Should output valid JSON
- `stackit server os-update schedule list --server-id zzz --output-format yaml` -> Should output valid YAML

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
