### PR TITLE
fix(lint) configure staticcheck with defaults and disable deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     cooldown:
         default-days: 7
         exclude: ["github.com/stackitcloud*"]
+    groups:
+        stackit:
+          patterns:
+            - "github.com/stackitcloud/stackit-sdk-go/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -66,6 +66,18 @@ linters:
         - name: atomic
         - name: empty-lines
         - name: early-return
+    staticcheck:
+      checks:
+        # default from https://golangci-lint.run/docs/linters/configuration/#staticcheck
+        - all
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1016"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
+        # customizations
+        - "-SA1019" # disable deprecation errors while we switch over to the SDK structure with multi API version support
   exclusions:
     generated: lax
     paths:


### PR DESCRIPTION
Preparation for multiversion SDK

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
