### PR TITLE
fix(load-balancer): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/load-balancer/list/list.go
+++ b/internal/cmd/load-balancer/list/list.go
@@ -67,23 +67,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("get load balancers: %w", err)
 			}
 
-			if resp.LoadBalancers == nil || (resp.LoadBalancers != nil && len(*resp.LoadBalancers) == 0) {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No load balancers found for project %q\n", projectLabel)
-				return nil
+			loadBalancers := utils.GetSliceFromPointer(resp.LoadBalancers)
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
-			loadBalancers := *resp.LoadBalancers
 			// Truncate output
 			if model.Limit != nil && len(loadBalancers) > int(*model.Limit) {
 				loadBalancers = loadBalancers[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, loadBalancers)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, loadBalancers)
 		},
 	}
 
@@ -123,8 +120,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *loadbalance
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, loadBalancers []loadbalancer.LoadBalancer) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, loadBalancers []loadbalancer.LoadBalancer) error {
 	return p.OutputResult(outputFormat, loadBalancers, func() error {
+		if len(loadBalancers) == 0 {
+			p.Outputf("No load balancers found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("NAME", "STATE", "IP ADDRESS", "LISTENERS", "TARGET POOLS")
 		for i := range loadBalancers {

--- a/internal/cmd/load-balancer/list/list_test.go
+++ b/internal/cmd/load-balancer/list/list_test.go
@@ -155,6 +155,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat  string
+		projectLabel  string
 		loadBalancers []loadbalancer.LoadBalancer
 	}
 	tests := []struct {
@@ -185,7 +186,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.loadBalancers); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.loadBalancers); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -84,37 +84,35 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list Load Balancer observability credentials: %w", err)
 			}
-			credentialsPtr := resp.Credentials
 
-			var credentials []loadbalancer.CredentialsResponse
-			if credentialsPtr != nil && len(*credentialsPtr) > 0 {
-				credentials = *credentialsPtr
-				filterOp, err := getFilterOp(model.Used, model.Unused)
-				if err != nil {
-					return err
-				}
-				credentials, err = lbUtils.FilterCredentials(ctx, apiClient, credentials, model.ProjectId, model.Region, filterOp)
-				if err != nil {
-					return fmt.Errorf("filter credentials: %w", err)
-				}
+			credentials := utils.GetSliceFromPointer(resp.Credentials)
+
+			filterOp, err := getFilterOp(model.Used, model.Unused)
+			if err != nil {
+				return err
 			}
 
-			if len(credentials) == 0 {
-				opLabel := "No "
-				if model.Used {
-					opLabel += "used"
-				} else if model.Unused {
-					opLabel += "unused"
-				}
-				params.Printer.Info("%s observability credentials found for Load Balancer on project %q\n", opLabel, projectLabel)
-				return nil
+			filteredCredentials, err := lbUtils.FilterCredentials(ctx, apiClient, credentials, model.ProjectId, model.Region, filterOp)
+			if err != nil {
+				return fmt.Errorf("filter credentials: %w", err)
+			}
+			if filteredCredentials == nil { // lbUtils.FilterCredentials can return nil with no error, if credentials is an empty slice and filterOp is not 0 (if either the --used or the --unused is set)
+				filteredCredentials = credentials
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, credentials)
+
+			opLabel := "No"
+			if model.Used {
+				opLabel += " used"
+			} else if model.Unused {
+				opLabel += " unused"
+			}
+
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, opLabel, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -159,8 +157,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *loadbalance
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, credentials []loadbalancer.CredentialsResponse) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel, opLabel string, credentials []loadbalancer.CredentialsResponse) error {
 	return p.OutputResult(outputFormat, credentials, func() error {
+		if len(credentials) == 0 {
+			p.Outputf("%s observability credentials found for Load Balancer on project %q\n", opLabel, projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("REFERENCE", "DISPLAY NAME", "USERNAME")
 		for i := range credentials {

--- a/internal/cmd/load-balancer/observability-credentials/list/list.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list.go
@@ -96,8 +96,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("filter credentials: %w", err)
 			}
-			if filteredCredentials == nil { // lbUtils.FilterCredentials can return nil with no error, if credentials is an empty slice and filterOp is not 0 (if either the --used or the --unused is set)
-				filteredCredentials = credentials
+			if filteredCredentials != nil { // lbUtils.FilterCredentials can return nil with no error, if credentials is an empty slice and filterOp is not 0 (if either the --used or the --unused is set)
+				credentials = filteredCredentials
 			}
 
 			// Truncate output

--- a/internal/cmd/load-balancer/observability-credentials/list/list_test.go
+++ b/internal/cmd/load-balancer/observability-credentials/list/list_test.go
@@ -232,6 +232,8 @@ func TestGetFilterOp(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		opLabel      string
+		projectLabel string
 		credentials  []loadbalancer.CredentialsResponse
 	}
 	tests := []struct {
@@ -255,7 +257,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.credentials); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.opLabel, tt.args.credentials); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-241 / https://github.com/stackitcloud/stackit-cli/issues/893


## Testing Instructions

- `stackit load-balancer list` -> Expected: No load balancers found for project "xxx"
- `stackit load-balancer list --output-format json` -> Should output valid JSON
- `stackit load-balancer list --output-format yaml` -> Should output valid YAML

- `stackit load-balancer observability-credentials list` -> Expected: No observability credentials found for Load Balancer on project "xxx"
- `stackit load-balancer observability-credentials list --output-format json` -> Should output valid JSON
- `stackit load-balancer observability-credentials list --output-format yaml` -> Should output valid YAML

Test with `--used` flag

- `stackit load-balancer observability-credentials list --used` -> Expected: No used observability credentials found for Load Balancer on project "xxx"
- `stackit load-balancer observability-credentials list --output-format json --used` -> Should output valid JSON
- `stackit load-balancer observability-credentials list --output-format yaml --used` -> Should output valid YAML

Test with `--unused` flag

- `stackit load-balancer observability-credentials list --unused` -> Expected: No unused observability credentials found for Load Balancer on project "xxx"
- `stackit load-balancer observability-credentials list --output-format json --unused` -> Should output valid JSON
- `stackit load-balancer observability-credentials list --output-format yaml --unused` -> Should output valid YAML

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
