### PR TITLE
fix(observability): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/observability/credentials/list/list.go
+++ b/internal/cmd/observability/credentials/list/list.go
@@ -68,22 +68,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list Observability credentials: %w", err)
 			}
-			credentials := *resp.Credentials
-			if len(credentials) == 0 {
-				instanceLabel, err := observabilityUtils.GetInstanceName(ctx, apiClient, model.InstanceId, model.ProjectId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
-					instanceLabel = model.InstanceId
-				}
-				params.Printer.Info("No credentials found for instance %q\n", instanceLabel)
-				return nil
+
+			credentials := resp.GetCredentials()
+
+			instanceLabel, err := observabilityUtils.GetInstanceName(ctx, apiClient, model.InstanceId, model.ProjectId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
+				instanceLabel = model.InstanceId
 			}
 
 			// Truncate output
 			if model.Limit != nil && len(credentials) > int(*model.Limit) {
 				credentials = credentials[:*model.Limit]
 			}
-			return outputResult(params.Printer, model.OutputFormat, credentials)
+			return outputResult(params.Printer, model.OutputFormat, instanceLabel, credentials)
 		},
 	}
 	configureFlags(cmd)
@@ -124,8 +122,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, credentials []observability.ServiceKeysList) error {
+func outputResult(p *print.Printer, outputFormat, instanceLabel string, credentials []observability.ServiceKeysList) error {
 	return p.OutputResult(outputFormat, credentials, func() error {
+		if len(credentials) == 0 {
+			p.Outputf("No credentials found for instance %q\n", instanceLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("USERNAME")
 		for i := range credentials {

--- a/internal/cmd/observability/credentials/list/list_test.go
+++ b/internal/cmd/observability/credentials/list/list_test.go
@@ -173,8 +173,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		credentials  []observability.ServiceKeysList
+		outputFormat  string
+		instanceLabel string
+		credentials   []observability.ServiceKeysList
 	}
 	tests := []struct {
 		name    string
@@ -204,7 +205,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.credentials); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.instanceLabel, tt.args.credentials); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/observability/instance/list/list.go
+++ b/internal/cmd/observability/instance/list/list.go
@@ -66,15 +66,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get Observability instances: %w", err)
 			}
-			instances := *resp.Instances
-			if len(instances) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No instances found for project %q\n", projectLabel)
-				return nil
+
+			instances := resp.GetInstances()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -82,7 +80,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				instances = instances[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, instances)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, instances)
 		},
 	}
 
@@ -122,8 +120,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, instances []observability.ProjectInstanceFull) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, instances []observability.ProjectInstanceFull) error {
 	return p.OutputResult(outputFormat, instances, func() error {
+		if len(instances) == 0 {
+			p.Outputf("No instances found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "PLAN", "STATUS")
 		for i := range instances {

--- a/internal/cmd/observability/instance/list/list_test.go
+++ b/internal/cmd/observability/instance/list/list_test.go
@@ -150,6 +150,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		instances    []observability.ProjectInstanceFull
 	}
 	tests := []struct {
@@ -180,7 +181,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.instances); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.instances); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/observability/plans/plans.go
+++ b/internal/cmd/observability/plans/plans.go
@@ -66,15 +66,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get Observability service plans: %w", err)
 			}
-			plans := *resp.Plans
-			if len(plans) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No plans found for project %q\n", projectLabel)
-				return nil
+
+			plans := resp.GetPlans()
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -82,7 +80,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				plans = plans[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, plans)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, plans)
 		},
 	}
 
@@ -122,8 +120,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, plans []observability.Plan) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, plans []observability.Plan) error {
 	return p.OutputResult(outputFormat, plans, func() error {
+		if len(plans) == 0 {
+			p.Outputf("No plans found for project %q\n", projectLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "PLAN NAME", "DESCRIPTION")
 		for i := range plans {

--- a/internal/cmd/observability/plans/plans_test.go
+++ b/internal/cmd/observability/plans/plans_test.go
@@ -150,6 +150,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
+		projectLabel string
 		plans        []observability.Plan
 	}
 	tests := []struct {
@@ -180,7 +181,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.plans); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.plans); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/observability/scrape-config/list/list.go
+++ b/internal/cmd/observability/scrape-config/list/list.go
@@ -69,15 +69,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get scrape configurations: %w", err)
 			}
-			configs := *resp.Data
-			if len(configs) == 0 {
-				instanceLabel, err := observabilityUtils.GetInstanceName(ctx, apiClient, model.InstanceId, model.ProjectId)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
-					instanceLabel = model.InstanceId
-				}
-				params.Printer.Info("No scrape configurations found for instance %q\n", instanceLabel)
-				return nil
+
+			configs := resp.GetData()
+
+			instanceLabel, err := observabilityUtils.GetInstanceName(ctx, apiClient, model.InstanceId, model.ProjectId)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
+				instanceLabel = model.InstanceId
 			}
 
 			// Truncate output
@@ -85,7 +83,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				configs = configs[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, configs)
+			return outputResult(params.Printer, model.OutputFormat, instanceLabel, configs)
 		},
 	}
 
@@ -127,8 +125,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *observabili
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, configs []observability.Job) error {
+func outputResult(p *print.Printer, outputFormat, instanceLabel string, configs []observability.Job) error {
 	return p.OutputResult(outputFormat, configs, func() error {
+		if len(configs) == 0 {
+			p.Outputf("No scrape configurations found for instance %q\n", instanceLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("NAME", "TARGETS", "SCRAPE INTERVAL")
 		for i := range configs {

--- a/internal/cmd/observability/scrape-config/list/list_test.go
+++ b/internal/cmd/observability/scrape-config/list/list_test.go
@@ -174,8 +174,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		configs      []observability.Job
+		outputFormat  string
+		instanceLabel string
+		configs       []observability.Job
 	}
 	tests := []struct {
 		name    string
@@ -205,7 +206,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.configs); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.instanceLabel, tt.args.configs); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

relates to STACKITCLI-268 / https://github.com/stackitcloud/stackit-cli/issues/893

## Testing Instructions

**Observability Plans:**
- `stackit observability plans` -> Expected: No plans found for project "xxx"
- `stackit observability plans --output-format json` -> Should output valid JSON
- `stackit observability plans --output-format yaml` -> Should output valid YAML

**Observability Instance:**
- `stackit observability instance list` -> Expected: No servers found for project "xxx"
- `stackit observability instance list --output-format json` -> Should output valid JSON
- `stackit observability instance list --output-format yaml` -> Should output valid YAML

_Create Observability Instance with ID yyy and name zzz_

**Observability Credentials:**
- `stackit observability credentials list --instance-id yyy` -> Expected: No credentials found for instance "zzz"
- `stackit observability credentials list --instance-id yyy --output-format json` -> Should output valid JSON
- `stackit observability credentials list --instance-id yyy --output-format yaml` -> Should output valid YAML

**Observability Scrape Config:**
- `stackit observability scrape-config list --instance-id yyy` -> Expected: No scrape configurations found for instance "zzz"
- `stackit observability scrape-config list --instance-id yyy --output-format json` -> Should output valid JSON
- `stackit observability scrape-config list --instance-id yyy --output-format yaml` -> Should output valid YAML

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
