### PR TITLE
fix(resource manager): print valid JSON/YAML output for list cmds

### DIFF
--- a/internal/cmd/project/list/list.go
+++ b/internal/cmd/project/list/list.go
@@ -82,10 +82,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(projects) == 0 {
-				params.Printer.Info("No projects found matching the criteria\n")
-				return nil
-			}
 
 			return outputResult(params.Printer, model.OutputFormat, projects)
 		},
@@ -192,7 +188,7 @@ func fetchProjects(ctx context.Context, model *inputModel, apiClient resourceMan
 		if err != nil {
 			return nil, fmt.Errorf("get projects: %w", err)
 		}
-		respProjects := *resp.Items
+		respProjects := resp.GetItems()
 		if len(respProjects) == 0 {
 			break
 		}
@@ -214,6 +210,10 @@ func fetchProjects(ctx context.Context, model *inputModel, apiClient resourceMan
 
 func outputResult(p *print.Printer, outputFormat string, projects []resourcemanager.Project) error {
 	return p.OutputResult(outputFormat, projects, func() error {
+		if len(projects) == 0 {
+			p.Outputf("No projects found matching the criteria\n")
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "STATE", "PARENT ID")
 		for i := range projects {


### PR DESCRIPTION
## Description

relates to STACKITCLI-270 / https://github.com/stackitcloud/stackit-cli/issues/893

## Testing Instructions

**Projects:** (response needs to be mocked)
- `stackit project list` -> No projects found matching the criteria
- `stackit project list --output-format json` -> Should output valid JSON
- `stackit project list --output-format yaml` -> Should output valid YAML

**Organizations:** Already resolved in https://github.com/stackitcloud/stackit-cli/pull/1312
## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
