### PR TITLE
feat(sfs): extend resource-pool commands with snapshotPolicyId

### DIFF
--- a/docs/stackit_beta_sfs_resource-pool_create.md
+++ b/docs/stackit_beta_sfs_resource-pool_create.md
@@ -27,18 +27,22 @@ stackit beta sfs resource-pool create [flags]
 
   Create a SFS resource pool with visible snapshots
   $ stackit beta sfs resource-pool create --availability-zone eu01-m --ip-acl 10.88.135.144/28 --performance-class Standard --size 500 --name resource-pool-01 --snapshots-visible
+
+  Create a SFS resource pool with specific snapshot policy
+  $ stackit beta sfs resource-pool create --availability-zone eu01-m --ip-acl 10.88.135.144/28 --performance-class Standard --size 500 --name resource-pool-01 --snapshot-policy-id XXX
 ```
 
 ### Options
 
 ```
-      --availability-zone string   Availability zone
-  -h, --help                       Help for "stackit beta sfs resource-pool create"
-      --ip-acl strings             List of network addresses in the form <address/prefix>, e.g. 192.168.10.0/24 that can mount the resource pool readonly (default [])
-      --name string                Name
-      --performance-class string   Performance class
-      --size int32                 Size of the pool in Gigabytes
-      --snapshots-visible          Set snapshots visible and accessible to users
+      --availability-zone string    Availability zone
+  -h, --help                        Help for "stackit beta sfs resource-pool create"
+      --ip-acl strings              List of network addresses in the form <address/prefix>, e.g. 192.168.10.0/24 that can mount the resource pool readonly (default [])
+      --name string                 Name
+      --performance-class string    Performance class
+      --size int32                  Size of the pool in Gigabytes
+      --snapshot-policy-id string   Set snapshot policy ID
+      --snapshots-visible           Set snapshots visible and accessible to users
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_beta_sfs_resource-pool_update.md
+++ b/docs/stackit_beta_sfs_resource-pool_update.md
@@ -29,7 +29,7 @@ stackit beta sfs resource-pool update [flags]
   $ stackit beta sfs resource-pool update xxx --snapshots-visible=false
 
   Update the SFS resource pool with ID "xxx" to set snapshot policy id to "YYY"
-  $ stackit beta sfs resource-pool update xxx --snapshot-policy-id=YYY
+  $ stackit beta sfs resource-pool update xxx --snapshot-policy-id YYY
 ```
 
 ### Options

--- a/docs/stackit_beta_sfs_resource-pool_update.md
+++ b/docs/stackit_beta_sfs_resource-pool_update.md
@@ -27,16 +27,20 @@ stackit beta sfs resource-pool update [flags]
 
   Update the SFS resource pool with ID "xxx", set snapshots visible to false
   $ stackit beta sfs resource-pool update xxx --snapshots-visible=false
+
+  Update the SFS resource pool with ID "xxx" to set snapshot policy id to "YYY"
+  $ stackit beta sfs resource-pool update xxx --snapshot-policy-id=YYY
 ```
 
 ### Options
 
 ```
-  -h, --help                       Help for "stackit beta sfs resource-pool update"
-      --ip-acl strings             List of network addresses in the form <address/prefix>, e.g. 192.168.10.0/24 that can mount the resource pool readonly (default [])
-      --performance-class string   Performance class
-      --size int32                 Size of the pool in Gigabytes
-      --snapshots-visible          Set snapshots visible and accessible to users
+  -h, --help                        Help for "stackit beta sfs resource-pool update"
+      --ip-acl strings              List of network addresses in the form <address/prefix>, e.g. 192.168.10.0/24 that can mount the resource pool readonly (default [])
+      --performance-class string    Performance class
+      --size int32                  Size of the pool in Gigabytes
+      --snapshot-policy-id string   Set snapshot policy ID
+      --snapshots-visible           Set snapshots visible and accessible to users
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/beta/sfs/resource-pool/create/create.go
+++ b/internal/cmd/beta/sfs/resource-pool/create/create.go
@@ -28,6 +28,7 @@ const (
 	availabilityZoneFlag = "availability-zone"
 	nameFlag             = "name"
 	snapshotsVisibleFlag = "snapshots-visible"
+	snapshotPolicyIdFlag = "snapshot-policy-id"
 )
 
 type inputModel struct {
@@ -38,6 +39,7 @@ type inputModel struct {
 	Name             string
 	AvailabilityZone string
 	SnapshotsVisible bool
+	SnapshotPolicyId string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -62,6 +64,9 @@ The available performance class values can be obtained by running:
 			examples.NewExample(
 				`Create a SFS resource pool with visible snapshots`,
 				"$ stackit beta sfs resource-pool create --availability-zone eu01-m --ip-acl 10.88.135.144/28 --performance-class Standard --size 500 --name resource-pool-01 --snapshots-visible"),
+			examples.NewExample(
+				`Create a SFS resource pool with specific snapshot policy`,
+				"$ stackit beta sfs resource-pool create --availability-zone eu01-m --ip-acl 10.88.135.144/28 --performance-class Standard --size 500 --name resource-pool-01 --snapshot-policy-id XXX"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -124,6 +129,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(availabilityZoneFlag, "", "Availability zone")
 	cmd.Flags().String(nameFlag, "", "Name")
 	cmd.Flags().Bool(snapshotsVisibleFlag, false, "Set snapshots visible and accessible to users")
+	cmd.Flags().String(snapshotPolicyIdFlag, "", "Set snapshot policy ID")
 
 	for _, flag := range []string{sizeFlag, performanceClassFlag, ipAclFlag, availabilityZoneFlag, nameFlag} {
 		err := flags.MarkFlagsRequired(cmd, flag)
@@ -140,6 +146,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *sfs.APIClie
 		PerformanceClass:    model.PerformanceClass,
 		SizeGigabytes:       *model.SizeInGB,
 		SnapshotsAreVisible: &model.SnapshotsVisible,
+		SnapshotPolicyId:    &model.SnapshotPolicyId,
 	})
 	return req
 }
@@ -156,6 +163,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	ipAcls := flags.FlagToStringSliceValue(p, cmd, ipAclFlag)
 	name := flags.FlagToStringValue(p, cmd, nameFlag)
 	snapshotsVisible := flags.FlagToBoolValue(p, cmd, snapshotsVisibleFlag)
+	snapshotPolicyId := flags.FlagToStringValue(p, cmd, snapshotPolicyIdFlag)
 
 	model := inputModel{
 		GlobalFlagModel:  globalFlags,
@@ -165,6 +173,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		AvailabilityZone: availabilityZone,
 		Name:             name,
 		SnapshotsVisible: snapshotsVisible,
+		SnapshotPolicyId: snapshotPolicyId,
 	}
 
 	p.DebugInputModel(model)

--- a/internal/cmd/beta/sfs/resource-pool/create/create_test.go
+++ b/internal/cmd/beta/sfs/resource-pool/create/create_test.go
@@ -31,6 +31,7 @@ var (
 	testResourcePoolName                   = "sfs-resource-pool-01"
 	testResourcePoolIpAcl                  = []string{"10.88.135.144/28", "250.81.87.224/32"}
 	testSnapshotsVisible                   = true
+	testSnapshotPolicyId                   = uuid.NewString()
 )
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -43,6 +44,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		availabilityZoneFlag:      testResourcePoolAvailabilityZone,
 		nameFlag:                  testResourcePoolName,
 		snapshotsVisibleFlag:      strconv.FormatBool(testSnapshotsVisible),
+		snapshotPolicyIdFlag:      testSnapshotPolicyId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -63,6 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		SizeInGB:         &testResourcePoolSizeInGB,
 		IpAcl:            testResourcePoolIpAcl,
 		SnapshotsVisible: testSnapshotsVisible,
+		SnapshotPolicyId: testSnapshotPolicyId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -79,6 +82,7 @@ func fixtureRequest(mods ...func(request *sfs.ApiCreateResourcePoolRequest)) sfs
 		IpAcl:               testResourcePoolIpAcl,
 		SizeGigabytes:       testResourcePoolSizeInGB,
 		SnapshotsAreVisible: &testSnapshotsVisible,
+		SnapshotPolicyId:    &testSnapshotPolicyId,
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -210,6 +214,16 @@ func TestParseInput(t *testing.T) {
 				flagValues[ipAclFlag] = "192.168.178.255/32,"
 			}),
 			isValid: false,
+		},
+		{
+			description: "snapshot policy id missing",
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, snapshotPolicyIdFlag)
+			}),
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SnapshotPolicyId = ""
+			}),
+			isValid: true,
 		},
 	}
 

--- a/internal/cmd/beta/sfs/resource-pool/describe/describe.go
+++ b/internal/cmd/beta/sfs/resource-pool/describe/describe.go
@@ -111,6 +111,11 @@ func outputResult(p *print.Printer, outputFormat, resourcePoolId, projectLabel s
 			ipAclStr = strings.Join(resourcePool.IpAcl, ", ")
 		}
 
+		var snapshotPolicyId string
+		if resourcePool.SnapshotPolicy.Get() != nil {
+			snapshotPolicyId = *resourcePool.SnapshotPolicy.Get().Id
+		}
+
 		table.AddRow("ID", utils.PtrString(resourcePool.Id))
 		table.AddSeparator()
 		table.AddRow("NAME", utils.PtrString(resourcePool.Name))
@@ -128,6 +133,8 @@ func outputResult(p *print.Printer, outputFormat, resourcePoolId, projectLabel s
 			table.AddSeparator()
 		}
 		table.AddRow("SNAPSHOTS ARE VISIBLE", utils.PtrString(resourcePool.SnapshotsAreVisible))
+		table.AddSeparator()
+		table.AddRow("SNAPSHOT POLICY ID", snapshotPolicyId)
 		table.AddSeparator()
 		table.AddRow("NEXT PERFORMANCE CLASS DOWNGRADE TIME", resourcePool.PerformanceClassDowngradableAt)
 		table.AddSeparator()

--- a/internal/cmd/beta/sfs/resource-pool/list/list.go
+++ b/internal/cmd/beta/sfs/resource-pool/list/list.go
@@ -128,12 +128,16 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resourceP
 		}
 
 		table := tables.NewTable()
-		table.SetHeader("ID", "NAME", "AVAILABILITY ZONE", "STATE", "TOTAL SIZE (GB)", "USED SIZE (GB)")
+		table.SetHeader("ID", "NAME", "AVAILABILITY ZONE", "STATE", "TOTAL SIZE (GB)", "USED SIZE (GB), SNAPSHOT POLICY ID")
 		for _, resourcePool := range resourcePools {
 			totalSizeGigabytes, usedSizeGigabytes := "", ""
 			if resourcePool.HasSpace() {
 				totalSizeGigabytes = utils.PtrString(resourcePool.Space.SizeGigabytes)
 				usedSizeGigabytes = utils.PtrString(resourcePool.Space.UsedGigabytes.Get())
+			}
+			var snapshotPolicyId string
+			if resourcePool.SnapshotPolicy.Get() != nil {
+				snapshotPolicyId = *resourcePool.SnapshotPolicy.Get().Id
 			}
 			table.AddRow(
 				utils.PtrString(resourcePool.Id),
@@ -142,6 +146,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resourceP
 				utils.PtrString(resourcePool.State),
 				totalSizeGigabytes,
 				usedSizeGigabytes,
+				snapshotPolicyId,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/beta/sfs/resource-pool/list/list.go
+++ b/internal/cmd/beta/sfs/resource-pool/list/list.go
@@ -128,16 +128,12 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resourceP
 		}
 
 		table := tables.NewTable()
-		table.SetHeader("ID", "NAME", "AVAILABILITY ZONE", "STATE", "TOTAL SIZE (GB)", "USED SIZE (GB), SNAPSHOT POLICY ID")
+		table.SetHeader("ID", "NAME", "AVAILABILITY ZONE", "STATE", "TOTAL SIZE (GB)", "USED SIZE (GB)")
 		for _, resourcePool := range resourcePools {
 			totalSizeGigabytes, usedSizeGigabytes := "", ""
 			if resourcePool.HasSpace() {
 				totalSizeGigabytes = utils.PtrString(resourcePool.Space.SizeGigabytes)
 				usedSizeGigabytes = utils.PtrString(resourcePool.Space.UsedGigabytes.Get())
-			}
-			var snapshotPolicyId string
-			if resourcePool.SnapshotPolicy.Get() != nil {
-				snapshotPolicyId = *resourcePool.SnapshotPolicy.Get().Id
 			}
 			table.AddRow(
 				utils.PtrString(resourcePool.Id),
@@ -146,7 +142,6 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resourceP
 				utils.PtrString(resourcePool.State),
 				totalSizeGigabytes,
 				usedSizeGigabytes,
-				snapshotPolicyId,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/beta/sfs/resource-pool/update/update.go
+++ b/internal/cmd/beta/sfs/resource-pool/update/update.go
@@ -28,6 +28,7 @@ const (
 	sizeFlag             = "size"
 	ipAclFlag            = "ip-acl"
 	snapshotsVisibleFlag = "snapshots-visible"
+	snapshotPolicyIdFlag = "snapshot-policy-id"
 )
 
 type inputModel struct {
@@ -37,6 +38,7 @@ type inputModel struct {
 	IpAcl            []string
 	ResourcePoolId   string
 	SnapshotsVisible *bool
+	SnapshotPolicyId *string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -61,6 +63,9 @@ The available performance class values can be obtained by running:
 			examples.NewExample(
 				`Update the SFS resource pool with ID "xxx", set snapshots visible to false`,
 				"$ stackit beta sfs resource-pool update xxx --snapshots-visible=false"),
+			examples.NewExample(
+				`Update the SFS resource pool with ID "xxx" to set snapshot policy id to "YYY"`,
+				"$ stackit beta sfs resource-pool update xxx --snapshot-policy-id=YYY"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -123,6 +128,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(performanceClassFlag, "", "Performance class")
 	cmd.Flags().Var(flags.CIDRSliceFlag(), ipAclFlag, "List of network addresses in the form <address/prefix>, e.g. 192.168.10.0/24 that can mount the resource pool readonly")
 	cmd.Flags().Bool(snapshotsVisibleFlag, false, "Set snapshots visible and accessible to users")
+	cmd.Flags().String(snapshotPolicyIdFlag, "", "Set snapshot policy ID")
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sfs.APIClient) sfs.ApiUpdateResourcePoolRequest {
@@ -132,6 +138,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *sfs.APIClie
 		PerformanceClass:    model.PerformanceClass,
 		SizeGigabytes:       *sfs.NewNullableInt32(model.SizeGigabytes),
 		SnapshotsAreVisible: model.SnapshotsVisible,
+		SnapshotPolicyId:    model.SnapshotPolicyId,
 	})
 	return req
 }
@@ -148,6 +155,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	size := flags.FlagToInt32Pointer(p, cmd, sizeFlag)
 	ipAcls := flags.FlagToStringSliceValue(p, cmd, ipAclFlag)
 	snapshotsVisible := flags.FlagToBoolPointer(p, cmd, snapshotsVisibleFlag)
+	snapshotPolicyId := flags.FlagToStringPointer(p, cmd, snapshotPolicyIdFlag)
 
 	if performanceClass == nil && size == nil && ipAcls == nil && snapshotsVisible == nil {
 		return nil, &cliErr.EmptyUpdateError{}
@@ -160,6 +168,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		PerformanceClass: performanceClass,
 		ResourcePoolId:   resourcePoolId,
 		SnapshotsVisible: snapshotsVisible,
+		SnapshotPolicyId: snapshotPolicyId,
 	}
 
 	p.DebugInputModel(model)

--- a/internal/cmd/beta/sfs/resource-pool/update/update.go
+++ b/internal/cmd/beta/sfs/resource-pool/update/update.go
@@ -65,7 +65,7 @@ The available performance class values can be obtained by running:
 				"$ stackit beta sfs resource-pool update xxx --snapshots-visible=false"),
 			examples.NewExample(
 				`Update the SFS resource pool with ID "xxx" to set snapshot policy id to "YYY"`,
-				"$ stackit beta sfs resource-pool update xxx --snapshot-policy-id=YYY"),
+				"$ stackit beta sfs resource-pool update xxx --snapshot-policy-id YYY"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/internal/cmd/beta/sfs/resource-pool/update/update.go
+++ b/internal/cmd/beta/sfs/resource-pool/update/update.go
@@ -157,7 +157,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	snapshotsVisible := flags.FlagToBoolPointer(p, cmd, snapshotsVisibleFlag)
 	snapshotPolicyId := flags.FlagToStringPointer(p, cmd, snapshotPolicyIdFlag)
 
-	if performanceClass == nil && size == nil && ipAcls == nil && snapshotsVisible == nil {
+	if performanceClass == nil && size == nil && ipAcls == nil && snapshotsVisible == nil && snapshotPolicyId == nil {
 		return nil, &cliErr.EmptyUpdateError{}
 	}
 

--- a/internal/cmd/beta/sfs/resource-pool/update/update_test.go
+++ b/internal/cmd/beta/sfs/resource-pool/update/update_test.go
@@ -142,6 +142,7 @@ func TestParseInput(t *testing.T) {
 				delete(flagValues, ipAclFlag)
 				delete(flagValues, performanceClassFlag)
 				delete(flagValues, snapshotsVisibleFlag)
+				delete(flagValues, snapshotPolicyIdFlag)
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/beta/sfs/resource-pool/update/update_test.go
+++ b/internal/cmd/beta/sfs/resource-pool/update/update_test.go
@@ -34,6 +34,7 @@ var (
 	testResourcePoolPerformanceClass       = "Standard"
 	testResourcePoolSizeInGB         int32 = 50
 	testSnapshotsVisible                   = true
+	testSnapshotPolicyId                   = uuid.NewString()
 )
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
@@ -54,6 +55,7 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		sizeFlag:                  strconv.FormatInt(int64(testResourcePoolSizeInGB), 10),
 		ipAclFlag:                 strings.Join(testResourcePoolIpAcl, ","),
 		snapshotsVisibleFlag:      strconv.FormatBool(testSnapshotsVisible),
+		snapshotPolicyIdFlag:      testSnapshotPolicyId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -75,6 +77,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		PerformanceClass: &testResourcePoolPerformanceClass,
 		IpAcl:            ipAclClone,
 		SnapshotsVisible: &testSnapshotsVisible,
+		SnapshotPolicyId: &testSnapshotPolicyId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -89,6 +92,7 @@ func fixtureRequest(mods ...func(request *sfs.ApiUpdateResourcePoolRequest)) sfs
 		PerformanceClass:    &testResourcePoolPerformanceClass,
 		SizeGigabytes:       *sfs.NewNullableInt32(&testResourcePoolSizeInGB),
 		SnapshotsAreVisible: &testSnapshotsVisible,
+		SnapshotPolicyId:    &testSnapshotPolicyId,
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -265,6 +269,17 @@ func TestParseInput(t *testing.T) {
 				}
 				model.IpAcl = append(model.IpAcl, "198.51.100.14/24", "198.51.100.14/32")
 			}),
+		},
+		{
+			description: "snapshot policy id missing",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				delete(flagValues, snapshotPolicyIdFlag)
+			}),
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.SnapshotPolicyId = nil
+			}),
+			isValid: true,
 		},
 	}
 


### PR DESCRIPTION
## Description

relates to STACKITCLI-394

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
