### PR TITLE
Feat/stackitcli 398 snaplock expiry time

### DIFF
--- a/internal/cmd/beta/sfs/snapshot/create/create.go
+++ b/internal/cmd/beta/sfs/snapshot/create/create.go
@@ -136,6 +136,11 @@ func outputResult(p *print.Printer, outputFormat, snapshotLabel, resourcePoolLab
 			snapshotLabel,
 			resourcePoolLabel,
 		)
+
+		if resp.ResourcePoolSnapshot.SnaplockExpiryTime.IsSet() && resp.ResourcePoolSnapshot.SnaplockExpiryTime.Get() != nil {
+			p.Outputf("Snaplock expiry time: %s\n", utils.ConvertTimePToDateTimeString(resp.ResourcePoolSnapshot.SnaplockExpiryTime.Get()))
+		}
+
 		return nil
 	})
 }

--- a/internal/cmd/beta/sfs/snapshot/create/create_test.go
+++ b/internal/cmd/beta/sfs/snapshot/create/create_test.go
@@ -3,6 +3,7 @@ package create
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -201,6 +202,17 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				resp: &sfs.CreateResourcePoolSnapshotResponse{
 					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set full snapshot",
+			args: args{
+				resp: &sfs.CreateResourcePoolSnapshotResponse{
+					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{
+						SnaplockExpiryTime: *sfs.NewNullableTime(utils.Ptr(time.Now().Add(time.Hour))),
+					},
 				},
 			},
 			wantErr: false,

--- a/internal/cmd/beta/sfs/snapshot/describe/describe.go
+++ b/internal/cmd/beta/sfs/snapshot/describe/describe.go
@@ -109,6 +109,10 @@ func outputResult(p *print.Printer, outputFormat string, resp *sfs.GetResourcePo
 		table := tables.NewTable()
 
 		snap := *resp.ResourcePoolSnapshot
+		var snaplockExpiryTime string
+		if snap.SnaplockExpiryTime.IsSet() && snap.SnaplockExpiryTime.Get() != nil {
+			snaplockExpiryTime = utils.ConvertTimePToDateTimeString(snap.SnaplockExpiryTime.Get())
+		}
 		table.AddRow("NAME", utils.PtrString(snap.SnapshotName))
 		table.AddSeparator()
 		if snap.Comment.IsSet() && snap.Comment.Get() != nil {
@@ -122,6 +126,8 @@ func outputResult(p *print.Printer, outputFormat string, resp *sfs.GetResourcePo
 		table.AddRow("LOGICAL SIZE (GB)", utils.PtrString(snap.LogicalSizeGigabytes))
 		table.AddSeparator()
 		table.AddRow("CREATED AT", utils.ConvertTimePToDateTimeString(snap.CreatedAt))
+		table.AddSeparator()
+		table.AddRow("SNAPLOCK EXPIRY TIME", snaplockExpiryTime)
 		table.AddSeparator()
 
 		p.Outputln(table.Render())

--- a/internal/cmd/beta/sfs/snapshot/describe/describe_test.go
+++ b/internal/cmd/beta/sfs/snapshot/describe/describe_test.go
@@ -3,6 +3,7 @@ package describe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -212,10 +214,26 @@ func TestOutputResult(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: " set empty snapshot",
+			name: "set empty snapshot",
 			args: args{
 				resp: &sfs.GetResourcePoolSnapshotResponse{
 					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set full snapshot",
+			args: args{
+				resp: &sfs.GetResourcePoolSnapshotResponse{
+					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{
+						SnapshotName:         utils.Ptr("name"),
+						ResourcePoolId:       utils.Ptr("rp-id"),
+						SizeGigabytes:        utils.Ptr(int32(10)),
+						LogicalSizeGigabytes: utils.Ptr(int32(8)),
+						CreatedAt:            utils.Ptr(time.Now()),
+						SnaplockExpiryTime:   *sfs.NewNullableTime(utils.Ptr(time.Now().Add(time.Hour))),
+					},
 				},
 			},
 			wantErr: false,

--- a/internal/cmd/beta/sfs/snapshot/list/list.go
+++ b/internal/cmd/beta/sfs/snapshot/list/list.go
@@ -126,12 +126,17 @@ func outputResult(p *print.Printer, outputFormat string, resp []sfs.ResourcePool
 			"SIZE (GB)",
 			"LOGICAL SIZE (GB)",
 			"CREATED AT",
+			"SNAPLOCK EXPIRY TIME",
 		)
 
 		for _, snap := range resp {
 			var comment string
 			if snap.Comment.IsSet() && snap.Comment.Get() != nil {
 				comment = utils.PtrString(snap.Comment.Get())
+			}
+			var snaplockExpiryTime string
+			if snap.SnaplockExpiryTime.IsSet() && snap.SnaplockExpiryTime.Get() != nil {
+				snaplockExpiryTime = utils.ConvertTimePToDateTimeString(snap.SnaplockExpiryTime.Get())
 			}
 			table.AddRow(
 				utils.PtrString(snap.SnapshotName),
@@ -140,6 +145,7 @@ func outputResult(p *print.Printer, outputFormat string, resp []sfs.ResourcePool
 				utils.PtrString(snap.SizeGigabytes),
 				utils.PtrString(snap.LogicalSizeGigabytes),
 				utils.ConvertTimePToDateTimeString(snap.CreatedAt),
+				snaplockExpiryTime,
 			)
 		}
 

--- a/internal/cmd/beta/sfs/snapshot/list/list_test.go
+++ b/internal/cmd/beta/sfs/snapshot/list/list_test.go
@@ -3,6 +3,7 @@ package list
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -157,6 +159,22 @@ func TestOutputResult(t *testing.T) {
 			name: "set empty snapshot",
 			args: args{
 				resp: []sfs.ResourcePoolSnapshot{{}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set full snapshot",
+			args: args{
+				resp: []sfs.ResourcePoolSnapshot{
+					{
+						SnapshotName:         utils.Ptr("name"),
+						ResourcePoolId:       utils.Ptr("rp-id"),
+						SizeGigabytes:        utils.Ptr(int32(10)),
+						LogicalSizeGigabytes: utils.Ptr(int32(8)),
+						CreatedAt:            utils.Ptr(time.Now()),
+						SnaplockExpiryTime:   *sfs.NewNullableTime(utils.Ptr(time.Now().Add(time.Hour))),
+					},
+				},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/sfs/snapshot/update/update.go
+++ b/internal/cmd/beta/sfs/snapshot/update/update.go
@@ -146,6 +146,11 @@ func outputResult(p *print.Printer, outputFormat, snapshotLabel, resourcePoolLab
 			snapshotLabel,
 			resourcePoolLabel,
 		)
+
+		if resp.ResourcePoolSnapshot.SnaplockExpiryTime.IsSet() && resp.ResourcePoolSnapshot.SnaplockExpiryTime.Get() != nil {
+			p.Outputf("Snaplock expiry time: %s\n", utils.ConvertTimePToDateTimeString(resp.ResourcePoolSnapshot.SnaplockExpiryTime.Get()))
+		}
+
 		return nil
 	})
 }

--- a/internal/cmd/beta/sfs/snapshot/update/update_test.go
+++ b/internal/cmd/beta/sfs/snapshot/update/update_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -231,6 +232,17 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				resp: &sfs.UpdateResourcePoolSnapshotResponse{
 					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set snaplock expiry time",
+			args: args{
+				resp: &sfs.UpdateResourcePoolSnapshotResponse{
+					ResourcePoolSnapshot: &sfs.ResourcePoolSnapshot{
+						SnaplockExpiryTime: *sfs.NewNullableTime(utils.Ptr(time.Now())),
+					},
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-398

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
