### PR TITLE
chore(alb): migrate to new SDK structure

### DIFF
--- a/docs/stackit_beta_alb_pool_update.md
+++ b/docs/stackit_beta_alb_pool_update.md
@@ -14,7 +14,7 @@ stackit beta alb pool update [flags]
 
 ```
   Update an application target pool from a configuration file (the name of the pool is read from the file)
-  $ stackit beta alb update --configuration my-target-pool.json --name my-load-balancer
+  $ stackit beta alb pool update --configuration my-target-pool.json --name my-load-balancer
 ```
 
 ### Options
@@ -22,7 +22,7 @@ stackit beta alb pool update [flags]
 ```
   -c, --configuration string   Filename of the input configuration file
   -h, --help                   Help for "stackit beta alb pool update"
-  -n, --name string            Name of the target pool name to update
+  -n, --name string            Name of the application load balancer
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
-	github.com/stackitcloud/stackit-sdk-go/services/alb v0.10.0
+	github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2
 	github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/cdn v1.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6

--- a/go.sum
+++ b/go.sum
@@ -598,6 +598,8 @@ github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0/go.mod h1:WU1hhxnjXw2EV7CYa1nlEvNpMiRY6CvmIOaHuL3pOaA=
 github.com/stackitcloud/stackit-sdk-go/services/alb v0.10.0 h1:V9+885qkSv621rZZatg1YE5ENM1ElALxQDJsh+hDIUg=
 github.com/stackitcloud/stackit-sdk-go/services/alb v0.10.0/go.mod h1:V6+MolxM/M2FWyWZA+FRFKEzzUe10MU9eEVfMvxHGi8=
+github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2 h1:hGzfOJjlCRoFpri5eYIiwhE27qu02pKZLprKvbsTC/w=
+github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2/go.mod h1:eK6oRB5Tmpt6KbXQ4UYBGg2LgW5bPtVoncL9E8JSRww=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0 h1:HxPgBu04j5tj6nfZ2r0l6v4VXC0/tYOGe4sA5Addra8=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0/go.mod h1:uYI9pHAA2g84jJN25ejFUxa0/JtfpPZqMDkctQ1BzJk=
 github.com/stackitcloud/stackit-sdk-go/services/cdn v1.10.0 h1:YALzjYAApyQMKyt4C2LKhPRZHa6brmbFeKuuwl+KOTs=

--- a/internal/cmd/beta/alb/create/create.go
+++ b/internal/cmd/beta/alb/create/create.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb/wait"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/alb/v2api/wait"
 )
 
 const (
@@ -86,7 +86,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating loadbalancer", func() error {
-					_, err := wait.CreateOrUpdateLoadbalancerWaitHandler(ctx, apiClient, model.ProjectId, model.Region, *resp.Name).WaitWithContext(ctx)
+					_, err := wait.CreateOrUpdateLoadbalancerWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, *resp.Name).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -123,7 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) (req alb.ApiCreateLoadBalancerRequest, err error) {
-	req = apiClient.CreateLoadBalancer(ctx, model.ProjectId, model.Region)
+	req = apiClient.DefaultAPI.CreateLoadBalancer(ctx, model.ProjectId, model.Region)
 	payload, err := readPayload(ctx, model)
 	if err != nil {
 		return req, err

--- a/internal/cmd/beta/alb/create/create_test.go
+++ b/internal/cmd/beta/alb/create/create_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -27,7 +27,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &alb.APIClient{}
+var testClient = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testRegion = "eu01"
 var testConfig = "testdata/testconfig.json"
@@ -69,7 +69,7 @@ func fixturePayload(mods ...func(payload *alb.CreateLoadBalancerPayload)) (paylo
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiCreateLoadBalancerRequest)) alb.ApiCreateLoadBalancerRequest {
-	request := testClient.CreateLoadBalancer(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateLoadBalancer(testCtx, testProjectId, testRegion)
 
 	request = request.CreateLoadBalancerPayload(fixturePayload())
 	for _, mod := range mods {
@@ -163,7 +163,7 @@ func TestBuildRequest(t *testing.T) {
 				},
 				Configuration: &testConfig,
 			},
-			expectedRequest: testClient.
+			expectedRequest: testClient.DefaultAPI.
 				CreateLoadBalancer(testCtx, testProjectId, testRegion).
 				CreateLoadBalancerPayload(fixturePayload()),
 		},
@@ -177,7 +177,7 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/delete/delete.go
+++ b/internal/cmd/beta/alb/delete/delete.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -91,5 +91,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiDeleteLoadBalancerRequest {
-	return apiClient.DeleteLoadBalancer(ctx, model.ProjectId, model.Region, model.Name)
+	return apiClient.DefaultAPI.DeleteLoadBalancer(ctx, model.ProjectId, model.Region, model.Name)
 }

--- a/internal/cmd/beta/alb/delete/delete.go
+++ b/internal/cmd/beta/alb/delete/delete.go
@@ -70,7 +70,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("delete loadbalancer: %w", err)
 			}
 
-			params.Printer.Outputf("Load balancer %q deleted.", model.Name)
+			params.Printer.Outputf("Load balancer %q deleted.\n", model.Name)
 			return nil
 		},
 	}

--- a/internal/cmd/beta/alb/delete/delete_test.go
+++ b/internal/cmd/beta/alb/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
@@ -19,7 +19,7 @@ var (
 	testCtx              = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectId        = uuid.NewString()
 	testRegion           = "eu01"
-	testClient           = &alb.APIClient{}
+	testClient           = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testLoadBalancerName = "my-test-loadbalancer"
 )
 
@@ -60,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiDeleteLoadBalancerRequest)) alb.ApiDeleteLoadBalancerRequest {
-	request := testClient.DeleteLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancerName)
+	request := testClient.DefaultAPI.DeleteLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancerName)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -134,7 +134,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedResult,
-				cmp.AllowUnexported(tt.expectedResult),
+				cmp.AllowUnexported(tt.expectedResult, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/describe/describe.go
+++ b/internal/cmd/beta/alb/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -85,7 +85,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiGetLoadBalancerRequest {
-	return apiClient.GetLoadBalancer(ctx, model.ProjectId, model.Region, model.Name)
+	return apiClient.DefaultAPI.GetLoadBalancer(ctx, model.ProjectId, model.Region, model.Name)
 }
 
 func outputResult(p *print.Printer, outputFormat string, loadbalancer *alb.LoadBalancer) error {
@@ -95,11 +95,11 @@ func outputResult(p *print.Printer, outputFormat string, loadbalancer *alb.LoadB
 		content = append(content, buildLoadBalancerTable(loadbalancer))
 
 		if loadbalancer.Listeners != nil {
-			content = append(content, buildListenersTable(*loadbalancer.Listeners))
+			content = append(content, buildListenersTable(loadbalancer.Listeners))
 		}
 
 		if loadbalancer.TargetPools != nil {
-			content = append(content, buildTargetPoolsTable(*loadbalancer.TargetPools))
+			content = append(content, buildTargetPoolsTable(loadbalancer.TargetPools))
 		}
 
 		err := tables.DisplayTables(p, content)
@@ -116,7 +116,7 @@ func buildLoadBalancerTable(loadbalancer *alb.LoadBalancer) tables.Table {
 	privateAccessOnly := false
 	if loadbalancer.Options != nil {
 		if loadbalancer.Options.AccessControl != nil && loadbalancer.Options.AccessControl.AllowedSourceRanges != nil {
-			acl = *loadbalancer.Options.AccessControl.AllowedSourceRanges
+			acl = loadbalancer.Options.AccessControl.AllowedSourceRanges
 		}
 
 		if loadbalancer.Options.PrivateNetworkOnly != nil {
@@ -125,16 +125,16 @@ func buildLoadBalancerTable(loadbalancer *alb.LoadBalancer) tables.Table {
 	}
 
 	networkId := "-"
-	if loadbalancer.Networks != nil && len(*loadbalancer.Networks) > 0 {
-		networks := *loadbalancer.Networks
+	if len(loadbalancer.Networks) > 0 {
+		networks := loadbalancer.Networks
 		networkId = *networks[0].NetworkId
 	}
 
 	externalAddress := utils.PtrStringDefault(loadbalancer.ExternalAddress, "-")
 
 	errorDescriptions := []string{}
-	if loadbalancer.Errors != nil && len((*loadbalancer.Errors)) > 0 {
-		for _, err := range *loadbalancer.Errors {
+	if len(loadbalancer.Errors) > 0 {
+		for _, err := range loadbalancer.Errors {
 			errorDescriptions = append(errorDescriptions, *err.Description)
 		}
 	}
@@ -179,7 +179,7 @@ func buildTargetPoolsTable(targetPools []alb.TargetPool) tables.Table {
 	table.SetTitle("Target Pools")
 	table.SetHeader("NAME", "PORT", "TARGETS")
 	for _, targetPool := range targetPools {
-		table.AddRow(utils.PtrString(targetPool.Name), utils.PtrString(targetPool.TargetPort), len(*targetPool.Targets))
+		table.AddRow(utils.PtrString(targetPool.Name), utils.PtrString(targetPool.TargetPort), len(targetPool.Targets))
 	}
 	return table
 }

--- a/internal/cmd/beta/alb/describe/describe_test.go
+++ b/internal/cmd/beta/alb/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
@@ -20,7 +20,7 @@ var (
 	testCtx              = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectId        = uuid.NewString()
 	testRegion           = "eu01"
-	testClient           = &alb.APIClient{}
+	testClient           = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testLoadBalancerName = "my-test-loadbalancer"
 )
 
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiGetLoadBalancerRequest)) alb.ApiGetLoadBalancerRequest {
-	request := testClient.GetLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancerName)
+	request := testClient.DefaultAPI.GetLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancerName)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -135,7 +135,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedResult,
-				cmp.AllowUnexported(tt.expectedResult),
+				cmp.AllowUnexported(tt.expectedResult, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/list/list.go
+++ b/internal/cmd/beta/alb/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -117,7 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiListLoadBalancersRequest {
-	request := apiClient.ListLoadBalancers(ctx, model.ProjectId, model.Region)
+	request := apiClient.DefaultAPI.ListLoadBalancers(ctx, model.ProjectId, model.Region)
 
 	return request
 }
@@ -135,7 +135,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, items []a
 
 			var errNo int
 			if item.Errors != nil {
-				errNo = len(*item.Errors)
+				errNo = len(item.Errors)
 			}
 			table.AddRow(utils.PtrString(item.Name),
 				utils.PtrString(item.ExternalAddress),

--- a/internal/cmd/beta/alb/list/list_test.go
+++ b/internal/cmd/beta/alb/list/list_test.go
@@ -16,14 +16,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &alb.APIClient{}
+	testClient    = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 )
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiListLoadBalancersRequest)) alb.ApiListLoadBalancersRequest {
-	request := testClient.ListLoadBalancers(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListLoadBalancers(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -129,7 +129,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/observability-credentials/add/add.go
+++ b/internal/cmd/beta/alb/observability-credentials/add/add.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -100,7 +100,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiCreateCredentialsRequest {
-	req := apiClient.CreateCredentials(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.CreateCredentials(ctx, model.ProjectId, model.Region)
 	payload := alb.CreateCredentialsPayload{
 		DisplayName: model.Displayname,
 		Password:    model.Password,

--- a/internal/cmd/beta/alb/observability-credentials/add/add_test.go
+++ b/internal/cmd/beta/alb/observability-credentials/add/add_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &alb.APIClient{}
+var testClient = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 
 var (
 	testProjectId   = uuid.NewString()
@@ -59,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiCreateCredentialsRequest)) alb.ApiCreateCredentialsRequest {
-	request := testClient.CreateCredentials(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateCredentials(testCtx, testProjectId, testRegion)
 	request = request.CreateCredentialsPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -125,7 +125,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 				cmp.AllowUnexported(alb.NullableString{}),
 			)

--- a/internal/cmd/beta/alb/observability-credentials/delete/delete.go
+++ b/internal/cmd/beta/alb/observability-credentials/delete/delete.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/alb/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -86,5 +86,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiDeleteCredentialsRequest {
-	return apiClient.DeleteCredentials(ctx, model.ProjectId, model.Region, model.CredentialsRef)
+	return apiClient.DefaultAPI.DeleteCredentials(ctx, model.ProjectId, model.Region, model.CredentialsRef)
 }

--- a/internal/cmd/beta/alb/observability-credentials/delete/delete_test.go
+++ b/internal/cmd/beta/alb/observability-credentials/delete/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -21,7 +21,7 @@ var (
 	testCtx           = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectId     = uuid.NewString()
 	testRegion        = "eu01"
-	testClient        = &alb.APIClient{}
+	testClient        = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testCredentialRef = "credential-12345"
 )
 
@@ -62,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiDeleteCredentialsRequest)) alb.ApiDeleteCredentialsRequest {
-	request := testClient.DeleteCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
+	request := testClient.DefaultAPI.DeleteCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -183,7 +183,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/observability-credentials/describe/describe.go
+++ b/internal/cmd/beta/alb/observability-credentials/describe/describe.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -84,7 +84,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiGetCredentialsRequest {
-	return apiClient.GetCredentials(ctx, model.ProjectId, model.Region, model.CredentialRef)
+	return apiClient.DefaultAPI.GetCredentials(ctx, model.ProjectId, model.Region, model.CredentialRef)
 }
 
 func outputResult(p *print.Printer, outputFormat string, response alb.CredentialsResponse) error {

--- a/internal/cmd/beta/alb/observability-credentials/describe/describe_test.go
+++ b/internal/cmd/beta/alb/observability-credentials/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
@@ -20,7 +20,7 @@ var (
 	testCtx           = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectId     = uuid.NewString()
 	testRegion        = "eu01"
-	testClient        = &alb.APIClient{}
+	testClient        = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testCredentialRef = "credential-12345"
 )
 
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiGetCredentialsRequest)) alb.ApiGetCredentialsRequest {
-	request := testClient.GetCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
+	request := testClient.DefaultAPI.GetCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -135,7 +135,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedResult,
-				cmp.AllowUnexported(tt.expectedResult),
+				cmp.AllowUnexported(tt.expectedResult, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/observability-credentials/list/list.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -108,7 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiListCredentialsRequest {
-	req := apiClient.ListCredentials(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.ListCredentials(ctx, model.ProjectId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/alb/observability-credentials/list/list_test.go
+++ b/internal/cmd/beta/alb/observability-credentials/list/list_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "test")
-	testClient = &alb.APIClient{}
+	testClient = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 
 	testProjectId = uuid.NewString()
 	testRegion    = "eu01"
@@ -55,7 +55,7 @@ func fixtureInputModel(mods ...func(inputModel *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiListCredentialsRequest)) alb.ApiListCredentialsRequest {
-	request := testClient.ListCredentials(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListCredentials(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -144,7 +144,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/observability-credentials/update/update.go
+++ b/internal/cmd/beta/alb/observability-credentials/update/update.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -96,7 +96,7 @@ func configureFlags(cmd *cobra.Command, params *types.CmdParams) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) (req alb.ApiUpdateCredentialsRequest, err error) {
-	req = apiClient.UpdateCredentials(ctx, model.ProjectId, model.Region, *model.CredentialsRef)
+	req = apiClient.DefaultAPI.UpdateCredentials(ctx, model.ProjectId, model.Region, *model.CredentialsRef)
 
 	payload := alb.UpdateCredentialsPayload{
 		DisplayName: model.Displayname,

--- a/internal/cmd/beta/alb/observability-credentials/update/update_test.go
+++ b/internal/cmd/beta/alb/observability-credentials/update/update_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -16,7 +16,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &alb.APIClient{}
+var testClient = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 
 var (
 	testProjectId     = uuid.NewString()
@@ -60,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiUpdateCredentialsRequest)) alb.ApiUpdateCredentialsRequest {
-	request := testClient.UpdateCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
+	request := testClient.DefaultAPI.UpdateCredentials(testCtx, testProjectId, testRegion, testCredentialRef)
 	request = request.UpdateCredentialsPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -185,7 +185,7 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 				cmp.AllowUnexported(alb.NullableString{}),
 			)

--- a/internal/cmd/beta/alb/plans/plans.go
+++ b/internal/cmd/beta/alb/plans/plans.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -88,7 +88,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiListPlansRequest {
-	request := apiClient.ListPlans(ctx, model.Region)
+	request := apiClient.DefaultAPI.ListPlans(ctx, model.Region)
 
 	return request
 }

--- a/internal/cmd/beta/alb/plans/plans_test.go
+++ b/internal/cmd/beta/alb/plans/plans_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &alb.APIClient{}
+	testClient    = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 )
 
@@ -47,7 +47,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiListPlansRequest)) alb.ApiListPlansRequest {
-	request := testClient.ListPlans(testCtx, testRegion)
+	request := testClient.DefaultAPI.ListPlans(testCtx, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -120,7 +120,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/pool/update/update.go
+++ b/internal/cmd/beta/alb/pool/update/update.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 const (
@@ -121,7 +121,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 	if payload.Name == nil {
 		return req, fmt.Errorf("update target pool: no poolname provided")
 	}
-	req = apiClient.UpdateTargetPool(ctx, model.ProjectId, model.Region, *model.AlbName, *payload.Name)
+	req = apiClient.DefaultAPI.UpdateTargetPool(ctx, model.ProjectId, model.Region, *model.AlbName, *payload.Name)
 	return req.UpdateTargetPoolPayload(payload), nil
 }
 

--- a/internal/cmd/beta/alb/pool/update/update.go
+++ b/internal/cmd/beta/alb/pool/update/update.go
@@ -46,7 +46,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Example: examples.Build(
 			examples.NewExample(
 				`Update an application target pool from a configuration file (the name of the pool is read from the file)`,
-				"$ stackit beta alb update --configuration my-target-pool.json --name my-load-balancer"),
+				"$ stackit beta alb pool update --configuration my-target-pool.json --name my-load-balancer"),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -92,7 +92,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(configurationFlag, "c", "", "Filename of the input configuration file")
-	cmd.Flags().StringP(albNameFlag, "n", "", "Name of the target pool name to update")
+	cmd.Flags().StringP(albNameFlag, "n", "", "Name of the application load balancer")
 	err := flags.MarkFlagsRequired(cmd, configurationFlag, albNameFlag)
 	cobra.CheckErr(err)
 }

--- a/internal/cmd/beta/alb/pool/update/update_test.go
+++ b/internal/cmd/beta/alb/pool/update/update_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -28,7 +28,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx          = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient       = &alb.APIClient{}
+	testClient       = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testProjectId    = uuid.NewString()
 	testRegion       = "eu01"
 	testLoadBalancer = "my-load-balancer"
@@ -75,7 +75,7 @@ func fixturePayload(mods ...func(payload *alb.UpdateTargetPoolPayload)) (payload
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiUpdateTargetPoolRequest)) alb.ApiUpdateTargetPoolRequest {
-	request := testClient.UpdateTargetPool(testCtx, testProjectId, testRegion, testLoadBalancer, testPool)
+	request := testClient.DefaultAPI.UpdateTargetPool(testCtx, testProjectId, testRegion, testLoadBalancer, testPool)
 
 	request = request.UpdateTargetPoolPayload(fixturePayload())
 	for _, mod := range mods {
@@ -172,7 +172,7 @@ func TestBuildRequest(t *testing.T) {
 				Configuration: &testConfig,
 				AlbName:       &testLoadBalancer,
 			},
-			expectedRequest: testClient.
+			expectedRequest: testClient.DefaultAPI.
 				UpdateTargetPool(testCtx, testProjectId, testRegion, testLoadBalancer, testPool).
 				UpdateTargetPoolPayload(fixturePayload()),
 		},
@@ -186,7 +186,7 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/quotas/quotas.go
+++ b/internal/cmd/beta/alb/quotas/quotas.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -87,7 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClient) alb.ApiGetQuotaRequest {
-	request := apiClient.GetQuota(ctx, model.ProjectId, model.Region)
+	request := apiClient.DefaultAPI.GetQuota(ctx, model.ProjectId, model.Region)
 
 	return request
 }

--- a/internal/cmd/beta/alb/quotas/quotas_test.go
+++ b/internal/cmd/beta/alb/quotas/quotas_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &alb.APIClient{}
+	testClient    = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testRegion    = "eu01"
 )
@@ -46,7 +46,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiGetQuotaRequest)) alb.ApiGetQuotaRequest {
-	request := testClient.GetQuota(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.GetQuota(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -119,7 +119,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/alb/template/template-alb.yaml
+++ b/internal/cmd/beta/alb/template/template-alb.yaml
@@ -4,7 +4,7 @@ externalAddress: 123.123.123.123
 
 # public listening interfaces of the loadbalancer
 listeners:
-  - displayName: listener1
+  - name: listener1
     # for plain http the https block must be removed
     # http: {}
     https:
@@ -16,27 +16,28 @@ listeners:
     port: 443
     # protocal may be PROTOCOL_HTTPS or PROTOCOL_HTTP
     protocol: PROTOCOL_HTTPS
-    rules:
-      # fqdn of the virtual host of the load balancer
-      - host: front.facing.host
-        http:
-          subRules:
+    http:
+      hosts:
+        # fqdn of the virtual host of the load balancer
+        - host: front.facing.host
+          rules:
             - cookiePersistence:
                 name: cookie1
                 ttl: 120s
               headers:
-                - name: testheader1
-                  exactMatch: X-test-header1
-                - name: testheader2
-                  exactMatch: X-test-header2
-                - name: testheader3
-                  exactMatch: X-test-header3
-              pathPrefix: /foo
+                - exactMatch: X-test-header1
+                  name: testheader1
+                - exactMatch: X-test-header2
+                  name: testheader2
+                - exactMatch: X-test-header3
+                  name: testheader3
+              path:
+                prefix: /foo
               queryParameters:
-                - name: query-param
-                  exactMatch: q
-                - name: region
-                  exactMatch: region
+                - exactMatch: q
+                  name: query-param
+                - exactMatch: region
+                  name: region
               targetPool: my-target-pool
               webSocket: false
 networks:
@@ -50,7 +51,7 @@ options:
     allowedSourceRanges:
       - 10.100.42.0/24
   ephemeralAddress: true
-  privateNetworkOnly: true
+  privateNetworkOnly: false
 
   # Enable observability features. Appropriate credentials must be made
   # available using the credentials endpoint

--- a/internal/cmd/beta/alb/template/template.go
+++ b/internal/cmd/beta/alb/template/template.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/beta/alb/update/update.go
+++ b/internal/cmd/beta/alb/update/update.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb/wait"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/alb/v2api/wait"
 )
 
 const (
@@ -92,7 +92,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "updating loadbalancer", func() error {
-					_, err = wait.CreateOrUpdateLoadbalancerWaitHandler(ctx, apiClient, model.ProjectId, model.Region, *resp.Name).
+					_, err = wait.CreateOrUpdateLoadbalancerWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, *resp.Name).
 						WaitWithContext(ctx)
 					return err
 				})
@@ -141,7 +141,7 @@ func getCurrentAlbVersion(ctx context.Context, apiClient *alb.APIClient, model *
 	if err != nil {
 		return nil, err
 	}
-	resp, err := apiClient.GetLoadBalancer(ctx, model.ProjectId, model.Region, *updatePayload.Name).Execute()
+	resp, err := apiClient.DefaultAPI.GetLoadBalancer(ctx, model.ProjectId, model.Region, *updatePayload.Name).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *alb.APIClie
 		return req, fmt.Errorf("no name found in loadbalancer configuration")
 	}
 	payload.Version = model.Version
-	req = apiClient.UpdateLoadBalancer(ctx, model.ProjectId, model.Region, *payload.Name)
+	req = apiClient.DefaultAPI.UpdateLoadBalancer(ctx, model.ProjectId, model.Region, *payload.Name)
 	return req.UpdateLoadBalancerPayload(payload), nil
 }
 

--- a/internal/cmd/beta/alb/update/update_test.go
+++ b/internal/cmd/beta/alb/update/update_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -28,7 +28,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx          = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient       = &alb.APIClient{}
+	testClient       = &alb.APIClient{DefaultAPI: &alb.DefaultAPIService{}}
 	testProjectId    = uuid.NewString()
 	testRegion       = "eu01"
 	testLoadBalancer = "my-load-balancer"
@@ -72,7 +72,7 @@ func fixturePayload(mods ...func(payload *alb.UpdateLoadBalancerPayload)) (paylo
 }
 
 func fixtureRequest(mods ...func(request *alb.ApiUpdateLoadBalancerRequest)) alb.ApiUpdateLoadBalancerRequest {
-	request := testClient.UpdateLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancer)
+	request := testClient.DefaultAPI.UpdateLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancer)
 
 	request = request.UpdateLoadBalancerPayload(fixturePayload())
 	for _, mod := range mods {
@@ -166,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 				},
 				Configuration: &testConfig,
 			},
-			expectedRequest: testClient.
+			expectedRequest: testClient.DefaultAPI.
 				UpdateLoadBalancer(testCtx, testProjectId, testRegion, testLoadBalancer).
 				UpdateLoadBalancerPayload(fixturePayload()),
 		},
@@ -180,7 +180,7 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, alb.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/pkg/services/alb/client/client.go
+++ b/internal/pkg/services/alb/client/client.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*alb.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.AlbCustomEndpoint), true, genericclient.CreateApiClient[*alb.APIClient](alb.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.AlbCustomEndpoint), false, genericclient.CreateApiClient[*alb.APIClient](alb.NewAPIClient))
 }


### PR DESCRIPTION
## Description

relates to STACKITCLI-355

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
