### PR TITLE
fix(fs): use new OsFS instead of os.DirFS during execution

### DIFF
--- a/internal/pkg/utils/os_fs.go
+++ b/internal/pkg/utils/os_fs.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"io/fs"
+	"os"
+)
+
+var _ fs.ReadFileFS = OsFS{}
+
+type OsFS struct{}
+
+func (o OsFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}
+
+func (o OsFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 // These values are overwritten by GoReleaser at build time
@@ -28,7 +29,7 @@ func main() {
 		Printer:    printer,
 		CliVersion: version,
 		Date:       date,
-		Fs:         os.DirFS("/"),
+		Fs:         utils.OsFS{},
 		Args:       os.Args[1:],
 	}
 	if !cmd.Execute(&params) {


### PR DESCRIPTION
DirFS("/") roots the filesystem. Relative paths are resolved relative to this root. Paths with a leading `/` are invalid. Introduced OsFS to use during normal CLI execution, which forwards to corresponding os package functions.
While still allowing other FS implementations during testing.

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
