### PR TITLE
refac(cdn): Migrate to new SDK structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
 	github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2
 	github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0
-	github.com/stackitcloud/stackit-sdk-go/services/cdn v1.10.0
+	github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6
 	github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3
 	github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2 h1:hGzfOJjlCRoFpri5e
 github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2/go.mod h1:eK6oRB5Tmpt6KbXQ4UYBGg2LgW5bPtVoncL9E8JSRww=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0 h1:HxPgBu04j5tj6nfZ2r0l6v4VXC0/tYOGe4sA5Addra8=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.12.0/go.mod h1:uYI9pHAA2g84jJN25ejFUxa0/JtfpPZqMDkctQ1BzJk=
-github.com/stackitcloud/stackit-sdk-go/services/cdn v1.10.0 h1:YALzjYAApyQMKyt4C2LKhPRZHa6brmbFeKuuwl+KOTs=
-github.com/stackitcloud/stackit-sdk-go/services/cdn v1.10.0/go.mod h1:915b/lJgDikYFEoRQ8wc8aCtPvUCceYk7gGm9nViJe0=
+github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0 h1:Wqxx0PDTL2F5gqI5jjznuJY0TdqECltjA0aa/rHY63U=
+github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0/go.mod h1:MHB1N3EQ9GuAduAQoNS+gb1MjrWJieszbpOso9TQv5s=
 github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6 h1:GBRb49x5Nax/oQQaaf2F3kKwv8DQQOL0TQOC0C/v/Ew=
 github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6/go.mod h1:IX9iL3MigDZUmzwswTJMfYvyi118KAHrFMfjJUy5NYk=
 github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3 h1:TxChb2qbO82JiQEBYClSSD5HZxqKeKJ6dIvkEUCJmbs=

--- a/internal/cmd/beta/cdn/distribution/create/create.go
+++ b/internal/cmd/beta/cdn/distribution/create/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -154,7 +154,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command, params *types.CmdParams) {
-	cmd.Flags().Var(flags.EnumSliceFlag(false, []string{}, sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...), flagRegion, fmt.Sprintf("Regions in which content should be cached, multiple of: %q", cdn.AllowedRegionEnumValues))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, []string{}, sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...), flagRegion, fmt.Sprintf("Regions in which content should be cached, multiple of: %q", utils.FormatPossibleValues(sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...)))
 	cmd.Flags().Bool(flagHTTP, false, "Use HTTP backend")
 	cmd.Flags().String(flagHTTPOriginURL, "", "Origin URL for HTTP backend")
 	cmd.Flags().StringSlice(flagHTTPOriginRequestHeaders, []string{}, "Origin request headers for HTTP backend in the format 'HeaderName: HeaderValue', repeatable. WARNING: do not store sensitive values in the headers!")
@@ -264,27 +264,27 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClient) cdn.ApiCreateDistributionRequest {
-	req := apiClient.CreateDistribution(ctx, model.ProjectId)
-	var backend cdn.CreateDistributionPayloadGetBackendArgType
+	req := apiClient.DefaultAPI.CreateDistribution(ctx, model.ProjectId)
+	var backend cdn.CreateDistributionPayloadBackend
 	if model.HTTP != nil {
-		backend = cdn.CreateDistributionPayloadGetBackendArgType{
+		backend = cdn.CreateDistributionPayloadBackend{
 			HttpBackendCreate: &cdn.HttpBackendCreate{
 				Geofencing:           model.HTTP.Geofencing,
 				OriginRequestHeaders: model.HTTP.OriginRequestHeaders,
-				OriginUrl:            &model.HTTP.OriginURL,
-				Type:                 utils.Ptr("http"),
+				OriginUrl:            model.HTTP.OriginURL,
+				Type:                 "http",
 			},
 		}
 	} else {
-		backend = cdn.CreateDistributionPayloadGetBackendArgType{
+		backend = cdn.CreateDistributionPayloadBackend{
 			BucketBackendCreate: &cdn.BucketBackendCreate{
-				BucketUrl: &model.Bucket.URL,
-				Credentials: cdn.NewBucketCredentials(
+				BucketUrl: model.Bucket.URL,
+				Credentials: *cdn.NewBucketCredentials(
 					model.Bucket.AccessKeyID,
 					model.Bucket.Password,
 				),
-				Region: &model.Bucket.Region,
-				Type:   utils.Ptr("bucket"),
+				Region: model.Bucket.Region,
+				Type:   "bucket",
 			},
 		}
 	}
@@ -294,30 +294,28 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClie
 		model.Regions,
 	)
 	if len(model.BlockedCountries) > 0 {
-		payload.BlockedCountries = &model.BlockedCountries
+		payload.BlockedCountries = model.BlockedCountries
 	}
 	if len(model.BlockedIPs) > 0 {
-		payload.BlockedIps = &model.BlockedIPs
+		payload.BlockedIps = model.BlockedIPs
 	}
 	if model.DefaultCacheDuration != "" {
 		payload.DefaultCacheDuration = utils.Ptr(model.DefaultCacheDuration)
 	}
 	if model.Loki != nil {
-		payload.LogSink = &cdn.CreateDistributionPayloadGetLogSinkArgType{
-			LokiLogSinkCreate: &cdn.LokiLogSinkCreate{
-				Credentials: &cdn.LokiLogSinkCredentials{
-					Password: &model.Loki.Password,
-					Username: &model.Loki.Username,
-				},
-				PushUrl: &model.Loki.PushURL,
-				Type:    utils.Ptr("loki"),
+		payload.LogSink = &cdn.LokiLogSinkCreate{
+			Credentials: cdn.LokiLogSinkCredentials{
+				Password: model.Loki.Password,
+				Username: model.Loki.Username,
 			},
+			PushUrl: model.Loki.PushURL,
+			Type:    "loki",
 		}
 	}
 	payload.MonthlyLimitBytes = model.MonthlyLimitBytes
 	if model.Optimizer {
-		payload.Optimizer = &cdn.CreateDistributionPayloadGetOptimizerArgType{
-			Enabled: utils.Ptr(true),
+		payload.Optimizer = &cdn.Optimizer{
+			Enabled: true,
 		}
 	}
 	return req.CreateDistributionPayload(*payload)
@@ -328,7 +326,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resp *cdn
 		return fmt.Errorf("create distribution response is nil")
 	}
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Created CDN distribution for %q. ID: %s\n", projectLabel, utils.PtrString(resp.Distribution.Id))
+		p.Outputf("Created CDN distribution for %q. ID: %s\n", projectLabel, resp.Distribution.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/cdn/distribution/create/create_test.go
+++ b/internal/cmd/beta/cdn/distribution/create/create_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 	"k8s.io/utils/ptr"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -23,7 +23,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &cdn.APIClient{}
+var testClient = &cdn.APIClient{DefaultAPI: &cdn.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 const testRegions = cdn.REGION_EU
@@ -129,10 +129,10 @@ func modelLoki() func(model *inputModel) {
 
 func fixturePayload(mods ...func(payload *cdn.CreateDistributionPayload)) cdn.CreateDistributionPayload {
 	payload := *cdn.NewCreateDistributionPayload(
-		cdn.CreateDistributionPayloadGetBackendArgType{
+		cdn.CreateDistributionPayloadBackend{
 			HttpBackendCreate: &cdn.HttpBackendCreate{
-				Type:      utils.Ptr("http"),
-				OriginUrl: utils.Ptr("https://http-backend.example.com"),
+				Type:      "http",
+				OriginUrl: "https://http-backend.example.com",
 			},
 		},
 		[]cdn.Region{testRegions},
@@ -145,18 +145,18 @@ func fixturePayload(mods ...func(payload *cdn.CreateDistributionPayload)) cdn.Cr
 
 func payloadRegions(regions ...cdn.Region) func(payload *cdn.CreateDistributionPayload) {
 	return func(payload *cdn.CreateDistributionPayload) {
-		payload.Regions = &regions
+		payload.Regions = regions
 	}
 }
 
 func payloadBucketBackend() func(payload *cdn.CreateDistributionPayload) {
 	return func(payload *cdn.CreateDistributionPayload) {
-		payload.Backend = &cdn.CreateDistributionPayloadGetBackendArgType{
+		payload.Backend = cdn.CreateDistributionPayloadBackend{
 			BucketBackendCreate: &cdn.BucketBackendCreate{
-				Type:      utils.Ptr("bucket"),
-				BucketUrl: utils.Ptr("https://bucket-backend.example.com"),
-				Region:    utils.Ptr("eu"),
-				Credentials: cdn.NewBucketCredentials(
+				Type:      "bucket",
+				BucketUrl: "https://bucket-backend.example.com",
+				Region:    "eu",
+				Credentials: *cdn.NewBucketCredentials(
 					"access-key-id",
 					"",
 				),
@@ -167,18 +167,16 @@ func payloadBucketBackend() func(payload *cdn.CreateDistributionPayload) {
 
 func payloadLoki() func(payload *cdn.CreateDistributionPayload) {
 	return func(payload *cdn.CreateDistributionPayload) {
-		payload.LogSink = &cdn.CreateDistributionPayloadGetLogSinkArgType{
-			LokiLogSinkCreate: &cdn.LokiLogSinkCreate{
-				Type:        utils.Ptr("loki"),
-				PushUrl:     utils.Ptr("https://loki.example.com"),
-				Credentials: cdn.NewLokiLogSinkCredentials("", "loki-user"),
-			},
+		payload.LogSink = &cdn.LokiLogSinkCreate{
+			Type:        "loki",
+			PushUrl:     "https://loki.example.com",
+			Credentials: *cdn.NewLokiLogSinkCredentials("", "loki-user"),
 		}
 	}
 }
 
 func fixtureRequest(mods ...func(payload *cdn.CreateDistributionPayload)) cdn.ApiCreateDistributionRequest {
-	req := testClient.CreateDistribution(testCtx, testProjectId)
+	req := testClient.DefaultAPI.CreateDistribution(testCtx, testProjectId)
 	req = req.CreateDistributionPayload(fixturePayload(mods...))
 	return req
 }
@@ -466,11 +464,11 @@ func TestBuildRequest(t *testing.T) {
 			expected: fixtureRequest(
 				func(payload *cdn.CreateDistributionPayload) {
 					payload.MonthlyLimitBytes = utils.Ptr[int64](5368709120)
-					payload.Optimizer = &cdn.CreateDistributionPayloadGetOptimizerArgType{
-						Enabled: utils.Ptr(true),
+					payload.Optimizer = &cdn.Optimizer{
+						Enabled: true,
 					}
-					payload.BlockedCountries = &[]string{"DE", "AT"}
-					payload.BlockedIps = &[]string{"127.0.0.1"}
+					payload.BlockedCountries = []string{"DE", "AT"}
+					payload.BlockedIps = []string{"127.0.0.1"}
 					payload.DefaultCacheDuration = utils.Ptr("PT2H")
 				},
 			),
@@ -488,7 +486,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expected,
-				cmp.AllowUnexported(tt.expected),
+				cmp.AllowUnexported(tt.expected, cdn.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {
@@ -516,8 +514,8 @@ func TestOutputResult(t *testing.T) {
 			description:  "table output",
 			outputFormat: "table",
 			response: &cdn.CreateDistributionResponse{
-				Distribution: &cdn.Distribution{
-					Id: ptr.To("dist-1234"),
+				Distribution: cdn.Distribution{
+					Id: "dist-1234",
 				},
 			},
 			expected: fmt.Sprintf("Created CDN distribution for %q. ID: dist-1234\n", testProjectId),

--- a/internal/cmd/beta/cdn/distribution/delete/delete.go
+++ b/internal/cmd/beta/cdn/distribution/delete/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -89,5 +89,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClient) cdn.ApiDeleteDistributionRequest {
-	return apiClient.DeleteDistribution(ctx, model.ProjectId, model.DistributionID)
+	return apiClient.DefaultAPI.DeleteDistribution(ctx, model.ProjectId, model.DistributionID)
 }

--- a/internal/cmd/beta/cdn/distribution/delete/delete_test.go
+++ b/internal/cmd/beta/cdn/distribution/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
@@ -18,7 +18,7 @@ type testCtxKey struct{}
 var (
 	testCtx            = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectId      = uuid.NewString()
-	testClient         = &cdn.APIClient{}
+	testClient         = &cdn.APIClient{DefaultAPI: &cdn.DefaultAPIService{}}
 	testDistributionID = uuid.NewString()
 )
 
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *cdn.ApiDeleteDistributionRequest)) cdn.ApiDeleteDistributionRequest {
-	request := testClient.DeleteDistribution(testCtx, testProjectId, testDistributionID)
+	request := testClient.DefaultAPI.DeleteDistribution(testCtx, testProjectId, testDistributionID)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -120,7 +120,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedResult,
-				cmp.AllowUnexported(tt.expectedResult),
+				cmp.AllowUnexported(tt.expectedResult, cdn.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/cdn/distribution/describe/describe.go
+++ b/internal/cmd/beta/cdn/distribution/describe/describe.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -93,7 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClient) cdn.ApiGetDistributionRequest {
-	return apiClient.GetDistribution(ctx, model.ProjectId, model.DistributionID).WithWafStatus(model.WithWAF)
+	return apiClient.DefaultAPI.GetDistribution(ctx, model.ProjectId, model.DistributionID).WithWafStatus(model.WithWAF)
 }
 
 func outputResult(p *print.Printer, outputFormat string, distribution *cdn.GetDistributionResponse) error {
@@ -104,10 +104,10 @@ func outputResult(p *print.Printer, outputFormat string, distribution *cdn.GetDi
 		d := distribution.Distribution
 		var content []tables.Table
 
-		content = append(content, buildDistributionTable(d))
+		content = append(content, buildDistributionTable(&d))
 
 		if d.Waf != nil {
-			content = append(content, buildWAFTable(d))
+			content = append(content, buildWAFTable(&d))
 		}
 
 		err := tables.DisplayTables(p, content)
@@ -119,41 +119,41 @@ func outputResult(p *print.Printer, outputFormat string, distribution *cdn.GetDi
 }
 
 func buildDistributionTable(d *cdn.Distribution) tables.Table {
-	regions := strings.Join(sdkUtils.EnumSliceToStringSlice(*d.Config.Regions), ", ")
+	regions := strings.Join(sdkUtils.EnumSliceToStringSlice(d.Config.Regions), ", ")
 	defaultCacheDuration := ""
-	if d.Config.DefaultCacheDuration != nil && d.Config.DefaultCacheDuration.IsSet() {
+	if d.Config.DefaultCacheDuration.IsSet() && d.Config.DefaultCacheDuration.Get() != nil {
 		defaultCacheDuration = *d.Config.DefaultCacheDuration.Get()
 	}
 	logSinkPushUrl := ""
-	if d.Config.LogSink != nil && d.Config.LogSink.LokiLogSink != nil {
-		logSinkPushUrl = *d.Config.LogSink.LokiLogSink.PushUrl
+	if d.Config.LogSink != nil && d.Config.LogSink.PushUrl != "" {
+		logSinkPushUrl = d.Config.LogSink.PushUrl
 	}
 	monthlyLimitBytes := ""
-	if d.Config.MonthlyLimitBytes != nil {
-		monthlyLimitBytes = fmt.Sprintf("%d", *d.Config.MonthlyLimitBytes)
+	if d.Config.MonthlyLimitBytes.IsSet() && d.Config.MonthlyLimitBytes.Get() != nil {
+		monthlyLimitBytes = fmt.Sprintf("%d", *d.Config.MonthlyLimitBytes.Get())
 	}
 	optimizerEnabled := ""
 	if d.Config.Optimizer != nil {
-		optimizerEnabled = fmt.Sprintf("%t", *d.Config.Optimizer.Enabled)
+		optimizerEnabled = fmt.Sprintf("%t", d.Config.Optimizer.Enabled)
 	}
 	table := tables.NewTable()
 	table.SetTitle("Distribution")
-	table.AddRow("ID", utils.PtrString(d.Id))
+	table.AddRow("ID", d.Id)
 	table.AddSeparator()
-	table.AddRow("STATUS", utils.PtrString(d.Status))
+	table.AddRow("STATUS", d.Status)
 	table.AddSeparator()
 	table.AddRow("REGIONS", regions)
 	table.AddSeparator()
-	table.AddRow("CREATED AT", utils.PtrString(d.CreatedAt))
+	table.AddRow("CREATED AT", d.CreatedAt)
 	table.AddSeparator()
-	table.AddRow("UPDATED AT", utils.PtrString(d.UpdatedAt))
+	table.AddRow("UPDATED AT", d.UpdatedAt)
 	table.AddSeparator()
-	table.AddRow("PROJECT ID", utils.PtrString(d.ProjectId))
+	table.AddRow("PROJECT ID", d.ProjectId)
 	table.AddSeparator()
-	if d.Errors != nil && len(*d.Errors) > 0 {
+	if len(d.Errors) > 0 {
 		var errorDescriptions []string
-		for _, err := range *d.Errors {
-			errorDescriptions = append(errorDescriptions, *err.En)
+		for _, err := range d.Errors {
+			errorDescriptions = append(errorDescriptions, err.En)
 		}
 		table.AddRow("ERRORS", strings.Join(errorDescriptions, "\n"))
 		table.AddSeparator()
@@ -162,33 +162,33 @@ func buildDistributionTable(d *cdn.Distribution) tables.Table {
 		b := d.Config.Backend.BucketBackend
 		table.AddRow("BACKEND TYPE", "BUCKET")
 		table.AddSeparator()
-		table.AddRow("BUCKET URL", utils.PtrString(b.BucketUrl))
+		table.AddRow("BUCKET URL", b.BucketUrl)
 		table.AddSeparator()
-		table.AddRow("BUCKET REGION", utils.PtrString(b.Region))
+		table.AddRow("BUCKET REGION", b.Region)
 		table.AddSeparator()
 	} else if d.Config.Backend.HttpBackend != nil {
 		h := d.Config.Backend.HttpBackend
 		var geofencing []string
 		if h.Geofencing != nil {
-			for k, v := range *h.Geofencing {
+			for k, v := range h.Geofencing {
 				geofencing = append(geofencing, fmt.Sprintf("%s: %s", k, strings.Join(v, ", ")))
 			}
 		}
 		slices.Sort(geofencing)
 		table.AddRow("BACKEND TYPE", "HTTP")
 		table.AddSeparator()
-		table.AddRow("HTTP ORIGIN URL", utils.PtrString(h.OriginUrl))
+		table.AddRow("HTTP ORIGIN URL", h.OriginUrl)
 		table.AddSeparator()
 		if h.OriginRequestHeaders != nil {
-			table.AddRow("HTTP ORIGIN REQUEST HEADERS", utils.JoinStringMap(*h.OriginRequestHeaders, ": ", ", "))
+			table.AddRow("HTTP ORIGIN REQUEST HEADERS", utils.JoinStringMap(h.OriginRequestHeaders, ": ", ", "))
 			table.AddSeparator()
 		}
 		table.AddRow("HTTP GEOFENCING PROPERTIES", strings.Join(geofencing, "\n"))
 		table.AddSeparator()
 	}
-	table.AddRow("BLOCKED COUNTRIES", strings.Join(*d.Config.BlockedCountries, ", "))
+	table.AddRow("BLOCKED COUNTRIES", strings.Join(d.Config.BlockedCountries, ", "))
 	table.AddSeparator()
-	table.AddRow("BLOCKED IPS", strings.Join(*d.Config.BlockedIps, ", "))
+	table.AddRow("BLOCKED IPS", strings.Join(d.Config.BlockedIps, ", "))
 	table.AddSeparator()
 	table.AddRow("DEFAULT CACHE DURATION", defaultCacheDuration)
 	table.AddSeparator()
@@ -204,16 +204,16 @@ func buildDistributionTable(d *cdn.Distribution) tables.Table {
 func buildWAFTable(d *cdn.Distribution) tables.Table {
 	table := tables.NewTable()
 	table.SetTitle("WAF")
-	for _, disabled := range *d.Waf.DisabledRules {
-		table.AddRow("DISABLED RULE ID", utils.PtrString(disabled.Id))
+	for _, disabled := range d.Waf.DisabledRules {
+		table.AddRow("DISABLED RULE ID", disabled.Id)
 		table.AddSeparator()
 	}
-	for _, enabled := range *d.Waf.EnabledRules {
-		table.AddRow("ENABLED RULE ID", utils.PtrString(enabled.Id))
+	for _, enabled := range d.Waf.EnabledRules {
+		table.AddRow("ENABLED RULE ID", enabled.Id)
 		table.AddSeparator()
 	}
-	for _, logOnly := range *d.Waf.LogOnlyRules {
-		table.AddRow("LOG-ONLY RULE ID", utils.PtrString(logOnly.Id))
+	for _, logOnly := range d.Waf.LogOnlyRules {
+		table.AddRow("LOG-ONLY RULE ID", logOnly.Id)
 		table.AddSeparator()
 	}
 	return table

--- a/internal/cmd/beta/cdn/distribution/describe/describe_test.go
+++ b/internal/cmd/beta/cdn/distribution/describe/describe_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -24,7 +25,7 @@ var (
 	testCtx            = context.WithValue(context.Background(), testCtxKey{}, "test")
 	testProjectID      = uuid.NewString()
 	testDistributionID = uuid.NewString()
-	testClient         = &cdn.APIClient{}
+	testClient         = &cdn.APIClient{DefaultAPI: &cdn.DefaultAPIService{}}
 	testTime           = time.Time{}
 )
 
@@ -55,31 +56,31 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 func fixtureResponse(mods ...func(resp *cdn.GetDistributionResponse)) *cdn.GetDistributionResponse {
 	response := &cdn.GetDistributionResponse{
-		Distribution: &cdn.Distribution{
-			Config: &cdn.Config{
-				Backend: &cdn.ConfigBackend{
+		Distribution: cdn.Distribution{
+			Config: cdn.Config{
+				Backend: cdn.ConfigBackend{
 					BucketBackend: &cdn.BucketBackend{
-						BucketUrl: utils.Ptr("https://example.com"),
-						Region:    utils.Ptr("eu"),
-						Type:      utils.Ptr("bucket"),
+						BucketUrl: "https://example.com",
+						Region:    "eu",
+						Type:      "bucket",
 					},
 				},
-				BlockedCountries:     utils.Ptr([]string{}),
-				BlockedIps:           utils.Ptr([]string{}),
-				DefaultCacheDuration: nil,
+				BlockedCountries:     []string{},
+				BlockedIps:           []string{},
+				DefaultCacheDuration: *cdn.NewNullableString(nil),
 				LogSink:              nil,
-				MonthlyLimitBytes:    nil,
+				MonthlyLimitBytes:    *cdn.NewNullableInt64(nil),
 				Optimizer:            nil,
-				Regions:              &[]cdn.Region{cdn.REGION_EU},
-				Waf:                  nil,
+				Regions:              []cdn.Region{cdn.REGION_EU},
+				Waf:                  cdn.WafConfig{},
 			},
-			CreatedAt: utils.Ptr(testTime),
-			Domains:   &[]cdn.Domain{},
+			CreatedAt: testTime,
+			Domains:   []cdn.Domain{},
 			Errors:    nil,
-			Id:        utils.Ptr(testDistributionID),
-			ProjectId: utils.Ptr(testProjectID),
-			Status:    utils.Ptr(cdn.DISTRIBUTIONSTATUS_ACTIVE),
-			UpdatedAt: utils.Ptr(testTime),
+			Id:        testDistributionID,
+			ProjectId: testProjectID,
+			Status:    wait.DISTRIBUTIONSTATUS_ACTIVE,
+			UpdatedAt: testTime,
 			Waf:       nil,
 		},
 	}
@@ -158,21 +159,21 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "base",
 			model:       fixtureInputModel(),
-			expected:    testClient.GetDistribution(testCtx, testProjectID, testDistributionID).WithWafStatus(false),
+			expected:    testClient.DefaultAPI.GetDistribution(testCtx, testProjectID, testDistributionID).WithWafStatus(false),
 		},
 		{
 			description: "with WAF",
 			model: fixtureInputModel(func(model *inputModel) {
 				model.WithWAF = true
 			}),
-			expected: testClient.GetDistribution(testCtx, testProjectID, testDistributionID).WithWafStatus(true),
+			expected: testClient.DefaultAPI.GetDistribution(testCtx, testProjectID, testDistributionID).WithWafStatus(true),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			got := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(got, tt.expected,
-				cmp.AllowUnexported(tt.expected),
+				cmp.AllowUnexported(tt.expected, cdn.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {
@@ -243,12 +244,12 @@ func TestOutputResult(t *testing.T) {
 			format:      "table",
 			distribution: fixtureResponse(
 				func(r *cdn.GetDistributionResponse) {
-					r.Distribution.Errors = &[]cdn.StatusError{
+					r.Distribution.Errors = []cdn.StatusError{
 						{
-							En: utils.Ptr("First error message"),
+							En: "First error message",
 						},
 						{
-							En: utils.Ptr("Second error message"),
+							En: "Second error message",
 						},
 					}
 				},
@@ -300,42 +301,41 @@ func TestOutputResult(t *testing.T) {
 			distribution: fixtureResponse(
 				func(r *cdn.GetDistributionResponse) {
 					r.Distribution.Waf = &cdn.DistributionWaf{
-						EnabledRules: &[]cdn.WafStatusRuleBlock{
-							{Id: utils.Ptr("rule-id-1")},
-							{Id: utils.Ptr("rule-id-2")},
+						EnabledRules: []cdn.WafStatusRuleBlock{
+							{Id: "rule-id-1"},
+							{Id: "rule-id-2"},
 						},
-						DisabledRules: &[]cdn.WafStatusRuleBlock{
-							{Id: utils.Ptr("rule-id-3")},
-							{Id: utils.Ptr("rule-id-4")},
+						DisabledRules: []cdn.WafStatusRuleBlock{
+							{Id: "rule-id-3"},
+							{Id: "rule-id-4"},
 						},
-						LogOnlyRules: &[]cdn.WafStatusRuleBlock{
-							{Id: utils.Ptr("rule-id-5")},
-							{Id: utils.Ptr("rule-id-6")},
+						LogOnlyRules: []cdn.WafStatusRuleBlock{
+							{Id: "rule-id-5"},
+							{Id: "rule-id-6"},
 						},
 					}
-					r.Distribution.Config.Backend = &cdn.ConfigBackend{
+					r.Distribution.Config.Backend = cdn.ConfigBackend{
 						HttpBackend: &cdn.HttpBackend{
-							OriginUrl: utils.Ptr("https://origin.example.com"),
-							OriginRequestHeaders: &map[string]string{
+							OriginUrl: "https://origin.example.com",
+							OriginRequestHeaders: map[string]string{
 								"X-Custom-Header": "CustomValue",
 							},
-							Geofencing: &map[string][]string{
+							Geofencing: map[string][]string{
 								"origin1.example.com": {"US", "CA"},
 								"origin2.example.com": {"FR", "DE"},
 							},
 						},
 					}
-					r.Distribution.Config.BlockedCountries = &[]string{"US", "CN"}
-					r.Distribution.Config.BlockedIps = &[]string{"127.0.0.1"}
-					r.Distribution.Config.DefaultCacheDuration = cdn.NewNullableString(utils.Ptr("P1DT2H30M"))
-					r.Distribution.Config.LogSink = &cdn.ConfigLogSink{
-						LokiLogSink: &cdn.LokiLogSink{
-							PushUrl: utils.Ptr("https://logs.example.com"),
-						},
+					r.Distribution.Config.BlockedCountries = []string{"US", "CN"}
+					r.Distribution.Config.BlockedIps = []string{"127.0.0.1"}
+					r.Distribution.Config.DefaultCacheDuration = *cdn.NewNullableString(utils.Ptr("P1DT2H30M"))
+					r.Distribution.Config.LogSink = &cdn.LokiLogSink{
+						PushUrl: "https://logs.example.com",
 					}
-					r.Distribution.Config.MonthlyLimitBytes = utils.Ptr(int64(104857600))
+					monthlyLimit := int64(104857600)
+					r.Distribution.Config.MonthlyLimitBytes = *cdn.NewNullableInt64(&monthlyLimit)
 					r.Distribution.Config.Optimizer = &cdn.Optimizer{
-						Enabled: utils.Ptr(true),
+						Enabled: true,
 					}
 				}),
 			//nolint:staticcheck //you can't use escape sequences in ``-string-literals

--- a/internal/cmd/beta/cdn/distribution/list/list.go
+++ b/internal/cmd/beta/cdn/distribution/list/list.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -19,7 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/cdn/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type inputModel struct {
@@ -107,12 +106,12 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClient, nextPageID cdn.ListDistributionsResponseGetNextPageIdentifierAttributeType, pageLimit int32) cdn.ApiListDistributionsRequest {
-	req := apiClient.ListDistributions(ctx, model.ProjectId)
+func buildRequest(ctx context.Context, model *inputModel, apiClient *cdn.APIClient, nextPageID string, pageLimit int32) cdn.ApiListDistributionsRequest {
+	req := apiClient.DefaultAPI.ListDistributions(ctx, model.ProjectId)
 	req = req.SortBy(model.SortBy)
 	req = req.PageSize(pageLimit)
-	if nextPageID != nil {
-		req = req.PageIdentifier(*nextPageID)
+	if nextPageID != "" {
+		req = req.PageIdentifier(nextPageID)
 	}
 	return req
 }
@@ -131,13 +130,13 @@ func outputResult(p *print.Printer, outputFormat string, distributions []cdn.Dis
 		table.SetHeader("ID", "REGIONS", "STATUS")
 		for _, d := range distributions {
 			var joinedRegions string
-			if d.Config != nil && d.Config.Regions != nil {
-				joinedRegions = strings.Join(sdkUtils.EnumSliceToStringSlice(*d.Config.Regions), ", ")
+			if d.Config.Regions != nil {
+				joinedRegions = strings.Join(sdkUtils.EnumSliceToStringSlice(d.Config.Regions), ", ")
 			}
 			table.AddRow(
-				utils.PtrString(d.Id),
+				d.Id,
 				joinedRegions,
-				utils.PtrString(d.Status),
+				d.Status,
 			)
 		}
 		err := table.Display(p)
@@ -149,7 +148,7 @@ func outputResult(p *print.Printer, outputFormat string, distributions []cdn.Dis
 }
 
 func fetchDistributions(ctx context.Context, model *inputModel, apiClient *cdn.APIClient) ([]cdn.Distribution, error) {
-	var nextPageID cdn.ListDistributionsResponseGetNextPageIdentifierAttributeType
+	var nextPageID string
 	var distributions []cdn.Distribution
 	received := int32(0)
 	limit := int32(math.MaxInt32)
@@ -164,11 +163,14 @@ func fetchDistributions(ctx context.Context, model *inputModel, apiClient *cdn.A
 			return nil, fmt.Errorf("list distributions: %w", err)
 		}
 		if response.Distributions != nil {
-			distributions = append(distributions, *response.Distributions...)
+			distributions = append(distributions, response.Distributions...)
 		}
-		nextPageID = response.NextPageIdentifier
+		nextPageID = ""
+		if response.NextPageIdentifier != nil {
+			nextPageID = *response.NextPageIdentifier
+		}
 		received += want
-		if nextPageID == nil || received >= limit {
+		if nextPageID == "" || received >= limit {
 			break
 		}
 	}

--- a/internal/cmd/beta/cdn/distribution/list/list_test.go
+++ b/internal/cmd/beta/cdn/distribution/list/list_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	sdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -25,13 +26,13 @@ import (
 type testCtxKey struct{}
 
 var testProjectId = uuid.NewString()
-var testClient = &cdn.APIClient{}
+var testClient = &cdn.APIClient{DefaultAPI: &cdn.DefaultAPIService{}}
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 
 const (
 	testNextPageID = "next-page-id-123"
 	testID         = "dist-1"
-	testStatus     = cdn.DISTRIBUTIONSTATUS_ACTIVE
+	testStatus     = wait.DISTRIBUTIONSTATUS_ACTIVE
 )
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -59,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request cdn.ApiListDistributionsRequest) cdn.ApiListDistributionsRequest) cdn.ApiListDistributionsRequest {
-	request := testClient.ListDistributions(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListDistributions(testCtx, testProjectId)
 	request = request.PageSize(100)
 	request = request.SortBy("createdAt")
 	for _, mod := range mods {
@@ -181,7 +182,7 @@ func TestBuildRequest(t *testing.T) {
 	tests := []struct {
 		description string
 		inputModel  *inputModel
-		nextPageID  *string
+		nextPageID  string
 		expected    cdn.ApiListDistributionsRequest
 	}{
 		{
@@ -201,7 +202,7 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "with next page id",
 			inputModel:  fixtureInputModel(),
-			nextPageID:  utils.Ptr(testNextPageID),
+			nextPageID:  testNextPageID,
 			expected: fixtureRequest(func(req cdn.ApiListDistributionsRequest) cdn.ApiListDistributionsRequest {
 				return req.PageIdentifier(testNextPageID)
 			}),
@@ -211,7 +212,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			req := buildRequest(testCtx, tt.inputModel, testClient, tt.nextPageID, maxPageSize)
 			diff := cmp.Diff(req, tt.expected,
-				cmp.AllowUnexported(tt.expected),
+				cmp.AllowUnexported(tt.expected, cdn.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {
@@ -241,7 +242,30 @@ func fixtureDistributions(count int) []cdn.Distribution {
 	for i := 0; i < count; i++ {
 		id := fmt.Sprintf("dist-%d", i+1)
 		distributions[i] = cdn.Distribution{
-			Id: &id,
+			Id:        id,
+			ProjectId: testProjectId,
+			Status:    string(testStatus),
+			Config: cdn.Config{
+				Backend: cdn.HttpBackendAsConfigBackend(&cdn.HttpBackend{
+					Type:                 "http",
+					OriginUrl:            "https://example.com",
+					AdditionalProperties: map[string]interface{}{},
+				}),
+				Waf: cdn.WafConfig{
+					Mode:                 "unknown_default_open_api",
+					Type:                 "unknown_default_open_api",
+					AdditionalProperties: map[string]interface{}{},
+				},
+				Tls: cdn.TlsConfig{
+					AdditionalProperties: map[string]interface{}{},
+				},
+				Regions:              []cdn.Region{cdn.REGION_EU},
+				BlockedCountries:     []string{},
+				BlockedIps:           []string{},
+				AdditionalProperties: map[string]interface{}{},
+			},
+			Domains:              []cdn.Domain{},
+			AdditionalProperties: map[string]interface{}{},
 		}
 	}
 	return distributions
@@ -262,20 +286,17 @@ func TestFetchDistributions(t *testing.T) {
 			},
 			expected: nil,
 		},
+
 		{
 			description: "single distribution, single page",
 			responses: []testResponse{
 				fixtureTestResponse(
 					func(resp *testResponse) {
-						resp.body.Distributions = &[]cdn.Distribution{
-							{Id: utils.Ptr("dist-1")},
-						}
+						resp.body.Distributions = fixtureDistributions(1)
 					},
 				),
 			},
-			expected: []cdn.Distribution{
-				{Id: utils.Ptr("dist-1")},
-			},
+			expected: fixtureDistributions(1),
 		},
 		{
 			description: "multiple distributions, multiple pages",
@@ -283,23 +304,16 @@ func TestFetchDistributions(t *testing.T) {
 				fixtureTestResponse(
 					func(resp *testResponse) {
 						resp.body.NextPageIdentifier = utils.Ptr(testNextPageID)
-						resp.body.Distributions = &[]cdn.Distribution{
-							{Id: utils.Ptr("dist-1")},
-						}
+						resp.body.Distributions = fixtureDistributions(1)
 					},
 				),
 				fixtureTestResponse(
 					func(resp *testResponse) {
-						resp.body.Distributions = &[]cdn.Distribution{
-							{Id: utils.Ptr("dist-2")},
-						}
+						resp.body.Distributions = fixtureDistributions(2)[1:]
 					},
 				),
 			},
-			expected: []cdn.Distribution{
-				{Id: utils.Ptr("dist-1")},
-				{Id: utils.Ptr("dist-2")},
-			},
+			expected: fixtureDistributions(2),
 		},
 		{
 			description: "API error",
@@ -318,9 +332,7 @@ func TestFetchDistributions(t *testing.T) {
 				fixtureTestResponse(
 					func(resp *testResponse) {
 						resp.body.NextPageIdentifier = utils.Ptr(testNextPageID)
-						resp.body.Distributions = &[]cdn.Distribution{
-							{Id: utils.Ptr("dist-1")},
-						}
+						resp.body.Distributions = fixtureDistributions(1)
 					},
 				),
 				fixtureTestResponse(
@@ -339,13 +351,13 @@ func TestFetchDistributions(t *testing.T) {
 					func(resp *testResponse) {
 						resp.body.NextPageIdentifier = utils.Ptr(testNextPageID)
 						distributions := fixtureDistributions(100)
-						resp.body.Distributions = &distributions
+						resp.body.Distributions = distributions
 					},
 				),
 				fixtureTestResponse(
 					func(resp *testResponse) {
 						distributions := fixtureDistributions(10)
-						resp.body.Distributions = &distributions
+						resp.body.Distributions = distributions
 					},
 				),
 			},
@@ -395,7 +407,11 @@ func TestFetchDistributions(t *testing.T) {
 			if callCount != len(tt.responses) {
 				t.Errorf("fetchDistributions() expected %d calls, got %d", len(tt.responses), callCount)
 			}
-			diff := cmp.Diff(got, tt.expected)
+			diff := cmp.Diff(got, tt.expected,
+				cmpopts.EquateComparable(
+					cdn.NullableString{},
+					cdn.NullableInt64{},
+				))
 			if diff != "" {
 				t.Errorf("fetchDistributions() mismatch (-want +got):\n%s", diff)
 			}
@@ -430,14 +446,14 @@ func TestOutputResult(t *testing.T) {
 			outputFormat: "table",
 			distributions: []cdn.Distribution{
 				{
-					Id: utils.Ptr(testID),
-					Config: &cdn.Config{
-						Regions: &[]cdn.Region{
+					Id: testID,
+					Config: cdn.Config{
+						Regions: []cdn.Region{
 							cdn.REGION_EU,
 							cdn.REGION_AF,
 						},
 					},
-					Status: utils.Ptr(testStatus),
+					Status: testStatus,
 				},
 			},
 			expected: `

--- a/internal/cmd/beta/cdn/distribution/update/update.go
+++ b/internal/cmd/beta/cdn/distribution/update/update.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -127,7 +127,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command, params *types.CmdParams) {
-	cmd.Flags().Var(flags.EnumSliceFlag(false, []string{}, sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...), flagRegions, fmt.Sprintf("Regions in which content should be cached, multiple of: %q", cdn.AllowedRegionEnumValues))
+	cmd.Flags().Var(flags.EnumSliceFlag(false, []string{}, sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...), flagRegions, fmt.Sprintf("Regions in which content should be cached, multiple of: %q", utils.FormatPossibleValues(sdkUtils.EnumSliceToStringSlice(cdn.AllowedRegionEnumValues)...)))
 	cmd.Flags().Bool(flagHTTP, false, "Use HTTP backend")
 	cmd.Flags().String(flagHTTPOriginURL, "", "Origin URL for HTTP backend")
 	cmd.Flags().StringSlice(flagHTTPOriginRequestHeaders, []string{}, "Origin request headers for HTTP backend in the format 'HeaderName: HeaderValue', repeatable. WARNING: do not store sensitive values in the headers!")
@@ -241,16 +241,16 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, apiClient *cdn.APIClient, model *inputModel) cdn.ApiPatchDistributionRequest {
-	req := apiClient.PatchDistribution(ctx, model.ProjectId, model.DistributionID)
+	req := apiClient.DefaultAPI.PatchDistribution(ctx, model.ProjectId, model.DistributionID)
 	payload := cdn.NewPatchDistributionPayload()
 	cfg := &cdn.ConfigPatch{}
 	payload.Config = cfg
 	if len(model.Regions) > 0 {
-		cfg.Regions = &model.Regions
+		cfg.Regions = model.Regions
 	}
 	if model.Bucket != nil {
 		bucket := &cdn.BucketBackendPatch{
-			Type: utils.Ptr("bucket"),
+			Type: "bucket",
 		}
 		cfg.Backend = &cdn.ConfigPatchBackend{
 			BucketBackendPatch: bucket,
@@ -269,7 +269,7 @@ func buildRequest(ctx context.Context, apiClient *cdn.APIClient, model *inputMod
 		}
 	} else if model.HTTP != nil {
 		http := &cdn.HttpBackendPatch{
-			Type: utils.Ptr("http"),
+			Type: "http",
 		}
 		cfg.Backend = &cdn.ConfigPatchBackend{
 			HttpBackendPatch: http,
@@ -285,22 +285,20 @@ func buildRequest(ctx context.Context, apiClient *cdn.APIClient, model *inputMod
 		}
 	}
 	if len(model.BlockedCountries) > 0 {
-		cfg.BlockedCountries = &model.BlockedCountries
+		cfg.BlockedCountries = model.BlockedCountries
 	}
 	if len(model.BlockedIPs) > 0 {
-		cfg.BlockedIps = &model.BlockedIPs
+		cfg.BlockedIps = model.BlockedIPs
 	}
 	if model.DefaultCacheDuration != "" {
-		cfg.DefaultCacheDuration = cdn.NewNullableString(&model.DefaultCacheDuration)
+		cfg.DefaultCacheDuration = *cdn.NewNullableString(&model.DefaultCacheDuration)
 	}
 	if model.MonthlyLimitBytes != nil && *model.MonthlyLimitBytes > 0 {
-		cfg.MonthlyLimitBytes = model.MonthlyLimitBytes
+		cfg.MonthlyLimitBytes = *cdn.NewNullableInt64(model.MonthlyLimitBytes)
 	}
 	if model.Loki != nil {
 		loki := &cdn.LokiLogSinkPatch{}
-		cfg.LogSink = cdn.NewNullableConfigPatchLogSink(&cdn.ConfigPatchLogSink{
-			LokiLogSinkPatch: loki,
-		})
+		cfg.LogSink = *cdn.NewNullableLokiLogSinkPatch(loki)
 		if model.Loki.PushURL != "" {
 			loki.PushUrl = utils.Ptr(model.Loki.PushURL)
 		}
@@ -325,7 +323,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, resp *cdn
 		return fmt.Errorf("update distribution response is empty")
 	}
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Updated CDN distribution for %q. ID: %s\n", projectLabel, utils.PtrString(resp.Distribution.Id))
+		p.Outputf("Updated CDN distribution for %q. ID: %s\n", projectLabel, resp.Distribution.Id)
 		return nil
 	})
 }

--- a/internal/cmd/beta/cdn/distribution/update/update_test.go
+++ b/internal/cmd/beta/cdn/distribution/update/update_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
-	"k8s.io/utils/ptr"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -23,7 +22,7 @@ const testCacheDuration = "P1DT12H"
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &cdn.APIClient{}
+var testClient = &cdn.APIClient{DefaultAPI: &cdn.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testDistributionID = uuid.NewString()
 
@@ -55,7 +54,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(payload *cdn.PatchDistributionPayload)) cdn.ApiPatchDistributionRequest {
-	req := testClient.PatchDistribution(testCtx, testProjectId, testDistributionID)
+	req := testClient.DefaultAPI.PatchDistribution(testCtx, testProjectId, testDistributionID)
 	if payload := fixturePayload(mods...); payload != nil {
 		req = req.PatchDistributionPayload(*fixturePayload(mods...))
 	}
@@ -240,17 +239,18 @@ func TestBuildRequest(t *testing.T) {
 			),
 			expected: fixtureRequest(
 				func(payload *cdn.PatchDistributionPayload) {
-					payload.Config.Regions = &[]cdn.Region{cdn.REGION_EU, cdn.REGION_US}
-					payload.Config.BlockedCountries = &[]string{"DE", "AT", "CH"}
-					payload.Config.BlockedIps = &[]string{"127.0.0.1", "10.0.0.8"}
-					payload.Config.DefaultCacheDuration = cdn.NewNullableString(utils.Ptr(testCacheDuration))
-					payload.Config.MonthlyLimitBytes = utils.Ptr(testMonthlyLimitBytes)
-					payload.Config.LogSink = cdn.NewNullableConfigPatchLogSink(&cdn.ConfigPatchLogSink{
-						LokiLogSinkPatch: &cdn.LokiLogSinkPatch{
+					payload.Config.Regions = []cdn.Region{cdn.REGION_EU, cdn.REGION_US}
+					payload.Config.BlockedCountries = []string{"DE", "AT", "CH"}
+					payload.Config.BlockedIps = []string{"127.0.0.1", "10.0.0.8"}
+					payload.Config.DefaultCacheDuration = *cdn.NewNullableString(utils.Ptr(testCacheDuration))
+					monthlyLimitBytes := testMonthlyLimitBytes
+					payload.Config.MonthlyLimitBytes = *cdn.NewNullableInt64(&monthlyLimitBytes)
+					payload.Config.LogSink = *cdn.NewNullableLokiLogSinkPatch(
+						&cdn.LokiLogSinkPatch{
 							Credentials: cdn.NewLokiLogSinkCredentials("loki-pass", "loki-user"),
 							PushUrl:     utils.Ptr("https://loki.example.com"),
 						},
-					})
+					)
 					payload.Config.Optimizer = &cdn.OptimizerPatch{
 						Enabled: utils.Ptr(true),
 					}
@@ -277,7 +277,7 @@ func TestBuildRequest(t *testing.T) {
 								"X-Another-Header": "another-value",
 							},
 							OriginUrl: utils.Ptr("https://http-backend.example.com"),
-							Type:      utils.Ptr("http"),
+							Type:      "http",
 						},
 					}
 				}),
@@ -300,7 +300,7 @@ func TestBuildRequest(t *testing.T) {
 							BucketUrl:   utils.Ptr("https://bucket.example.com"),
 							Credentials: cdn.NewBucketCredentials("bucket-access-key-id", "bucket-pass"),
 							Region:      utils.Ptr("EU"),
-							Type:        utils.Ptr("bucket"),
+							Type:        "bucket",
 						},
 					}
 				}),
@@ -311,7 +311,13 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, testClient, tt.model)
 
 			diff := cmp.Diff(request, tt.expected,
-				cmp.AllowUnexported(tt.expected, cdn.NullableString{}, cdn.NullableConfigPatchLogSink{}),
+				cmp.AllowUnexported(
+					cdn.ApiPatchDistributionRequest{},
+					cdn.NullableString{},
+					cdn.NullableInt64{},
+					cdn.NullableLokiLogSinkPatch{},
+					cdn.DefaultAPIService{},
+				),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {
@@ -339,8 +345,8 @@ func TestOutputResult(t *testing.T) {
 			description:  "table output",
 			outputFormat: "table",
 			response: &cdn.PatchDistributionResponse{
-				Distribution: &cdn.Distribution{
-					Id: ptr.To("dist-1234"),
+				Distribution: cdn.Distribution{
+					Id: "dist-1234",
 				},
 			},
 			expected: fmt.Sprintf("Updated CDN distribution for %q. ID: dist-1234\n", testProjectId),

--- a/internal/pkg/services/cdn/client/client.go
+++ b/internal/pkg/services/cdn/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/cdn"
+	cdn "github.com/stackitcloud/stackit-sdk-go/services/cdn/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
@@ -10,5 +10,5 @@ import (
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*cdn.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.CDNCustomEndpointKey), true, cdn.NewAPIClient)
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.CDNCustomEndpointKey), false, cdn.NewAPIClient)
 }

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -271,3 +271,16 @@ func GetSliceFromPointer[T any](s *[]T) []T {
 	}
 	return *s
 }
+
+// FormatPossibleValues formats a slice into a list for usage in the provider docs
+func FormatPossibleValues(values ...string) []string {
+	var formattedValues []string
+	for _, value := range values {
+		if value == "unknown_default_open_api" {
+			continue
+		}
+
+		formattedValues = append(formattedValues, value)
+	}
+	return formattedValues
+}


### PR DESCRIPTION
STACKITCLI-356

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
