### PR TITLE
chore(sqlserverflex): migrate to multiversion sdk

### DIFF
--- a/docs/stackit_beta_sqlserverflex_instance_create.md
+++ b/docs/stackit_beta_sqlserverflex_instance_create.md
@@ -29,12 +29,12 @@ stackit beta sqlserverflex instance create [flags]
 ```
       --acl strings              The access control list (ACL). Must contain at least one valid subnet, for instance '0.0.0.0/0' for open access (discouraged), '1.2.3.0/24 for a public IP range of an organization, '1.2.3.4/32' for a single IP range, etc. (default [])
       --backup-schedule string   Backup schedule
-      --cpu int                  Number of CPUs
+      --cpu int32                Number of CPUs
       --edition string           Edition of the SQLServer instance
       --flavor-id string         ID of the flavor
   -h, --help                     Help for "stackit beta sqlserverflex instance create"
   -n, --name string              Instance name
-      --ram int                  Amount of RAM (in GB)
+      --ram int32                Amount of RAM (in GB)
       --retention-days int       The days for how long the backup files should be stored before being cleaned up
       --storage-class string     Storage class
       --storage-size int         Storage size (in GB)

--- a/docs/stackit_beta_sqlserverflex_instance_update.md
+++ b/docs/stackit_beta_sqlserverflex_instance_update.md
@@ -25,11 +25,11 @@ stackit beta sqlserverflex instance update INSTANCE_ID [flags]
 ```
       --acl strings              Lists of IP networks in CIDR notation which are allowed to access this instance (default [])
       --backup-schedule string   Backup schedule
-      --cpu int                  Number of CPUs
+      --cpu int32                Number of CPUs
       --flavor-id string         ID of the flavor
   -h, --help                     Help for "stackit beta sqlserverflex instance update"
   -n, --name string              Instance name
-      --ram int                  Amount of RAM (in GB)
+      --ram int32                Amount of RAM (in GB)
       --version string           Version
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0
-	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.4.3
+	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0 h1:QoKyQPe8FqDqJLNgE
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0/go.mod h1:KhVYCR58wETqdI7Quwhe3OR3BhB2T/b7DzaMsfDnr8g=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.4.3 h1:AQrcr+qeIuZob+3TT2q1L4WOPtpsu5SEpkTnOUHDqfE=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.4.3/go.mod h1:8BBGC69WFXWWmKgzSjgE4HvsI7pEgO0RN2cASwuPJ18=
+github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0 h1:PwjQeupEnXxhu+uWCUzO/hUfL4yqNblOcZbP2jvaQtU=
+github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
 github.com/stbenjam/no-sprintf-host-port v0.3.1 h1:AyX7+dxI4IdLBPtDbsGAyqiTSLpCP9hWRrXQDU4Cm/g=
 github.com/stbenjam/no-sprintf-host-port v0.3.1/go.mod h1:ODbZesTCHMVKthBHskvUUexdcNHAQRXk9NpSsL8p/HQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/cmd/beta/sqlserverflex/database/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/database/create/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -69,9 +69,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Call API
 			req := buildRequest(ctx, model, apiClient)
-			resp, err := spinner.Run2(params.Printer, "Creating database", func() (*sqlserverflex.CreateDatabaseResponse, error) {
-				return req.Execute()
-			})
+			resp, err := spinner.Run2(params.Printer, "Creating database", req.Execute)
 			if err != nil {
 				return fmt.Errorf("create SQLServer Flex database: %w", err)
 			}
@@ -110,11 +108,11 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiCreateDatabaseRequest {
-	req := apiClient.CreateDatabase(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.CreateDatabase(ctx, model.ProjectId, model.InstanceId, model.Region)
 	payload := sqlserverflex.CreateDatabasePayload{
-		Name: &model.DatabaseName,
-		Options: &sqlserverflex.DatabaseDocumentationCreateDatabaseRequestOptions{
-			Owner: &model.Owner,
+		Name: model.DatabaseName,
+		Options: sqlserverflex.DatabaseDocumentationCreateDatabaseRequestOptions{
+			Owner: model.Owner,
 		},
 	}
 	req = req.CreateDatabasePayload(payload)

--- a/internal/cmd/beta/sqlserverflex/database/create/create_test.go
+++ b/internal/cmd/beta/sqlserverflex/database/create/create_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -18,7 +18,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testDatabaseName = "my-database"
@@ -66,11 +67,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiCreateDatabaseRequest)) sqlserverflex.ApiCreateDatabaseRequest {
-	request := testClient.CreateDatabase(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.CreateDatabase(testCtx, testProjectId, testInstanceId, testRegion)
 	payload := sqlserverflex.CreateDatabasePayload{
-		Name: &testDatabaseName,
-		Options: &sqlserverflex.DatabaseDocumentationCreateDatabaseRequestOptions{
-			Owner: &testOwner,
+		Name: testDatabaseName,
+		Options: sqlserverflex.DatabaseDocumentationCreateDatabaseRequestOptions{
+			Owner: testOwner,
 		},
 	}
 	request = request.CreateDatabasePayload(payload)
@@ -203,7 +204,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/database/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/database/delete/delete.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -107,6 +107,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiDeleteDatabaseRequest {
-	req := apiClient.DeleteDatabase(ctx, model.ProjectId, model.InstanceId, model.DatabaseName, model.Region)
+	req := apiClient.DefaultAPI.DeleteDatabase(ctx, model.ProjectId, model.InstanceId, model.DatabaseName, model.Region)
 	return req
 }

--- a/internal/cmd/beta/sqlserverflex/database/delete/delete_test.go
+++ b/internal/cmd/beta/sqlserverflex/database/delete/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
@@ -17,7 +17,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testDatabaseName = "my-database"
@@ -62,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiDeleteDatabaseRequest)) sqlserverflex.ApiDeleteDatabaseRequest {
-	request := testClient.DeleteDatabase(testCtx, testProjectId, testInstanceId, testDatabaseName, testRegion)
+	request := testClient.DefaultAPI.DeleteDatabase(testCtx, testProjectId, testInstanceId, testDatabaseName, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -184,7 +185,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/database/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/database/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -98,7 +98,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiGetDatabaseRequest {
-	req := apiClient.GetDatabase(ctx, model.ProjectId, model.InstanceId, model.DatabaseName, model.Region)
+	req := apiClient.DefaultAPI.GetDatabase(ctx, model.ProjectId, model.InstanceId, model.DatabaseName, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/describe/describe_test.go
+++ b/internal/cmd/beta/sqlserverflex/database/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -18,7 +18,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testDatabaseName = "my-database"
@@ -63,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiGetDatabaseRequest)) sqlserverflex.ApiGetDatabaseRequest {
-	request := testClient.GetDatabase(testCtx, testProjectId, testInstanceId, testDatabaseName, testRegion)
+	request := testClient.DefaultAPI.GetDatabase(testCtx, testProjectId, testInstanceId, testDatabaseName, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -185,7 +186,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/database/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -122,7 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiListDatabasesRequest {
-	req := apiClient.ListDatabases(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.ListDatabases(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/sqlserverflex/database/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/database/list/list_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -19,7 +19,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -55,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiListDatabasesRequest)) sqlserverflex.ApiListDatabasesRequest {
-	request := testClient.ListDatabases(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.ListDatabases(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -165,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -20,19 +20,19 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/wait"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api/wait"
 )
 
 // enforce implementation of interfaces
 var (
-	_ sqlServerFlexClient = &sqlserverflex.APIClient{}
+	_ sqlServerFlexClient = sqlserverflex.APIClient{}.DefaultAPI
 )
 
 type sqlServerFlexClient interface {
 	CreateInstance(ctx context.Context, projectId string, region string) sqlserverflex.ApiCreateInstanceRequest
-	ListFlavorsExecute(ctx context.Context, projectId string, region string) (*sqlserverflex.ListFlavorsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId string, region string) (*sqlserverflex.ListStoragesResponse, error)
+	ListFlavors(ctx context.Context, projectId string, region string) sqlserverflex.ApiListFlavorsRequest
+	ListStorages(ctx context.Context, projectId, flavorId string, region string) sqlserverflex.ApiListStoragesRequest
 }
 
 const (
@@ -52,12 +52,12 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 
-	InstanceName   *string
-	ACL            *[]string
+	InstanceName   string
+	ACL            []string
 	BackupSchedule *string
 	FlavorId       *string
-	CPU            *int64
-	RAM            *int64
+	CPU            *int32
+	RAM            *int32
 	StorageClass   *string
 	StorageSize    *int64
 	Version        *string
@@ -110,7 +110,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating instance", func() error {
-					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -143,8 +143,8 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "The access control list (ACL). Must contain at least one valid subnet, for instance '0.0.0.0/0' for open access (discouraged), '1.2.3.0/24 for a public IP range of an organization, '1.2.3.4/32' for a single IP range, etc.")
 	cmd.Flags().String(backupScheduleFlag, "", "Backup schedule")
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
-	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")
-	cmd.Flags().Int64(ramFlag, 0, "Amount of RAM (in GB)")
+	cmd.Flags().Int32(cpuFlag, 0, "Number of CPUs")
+	cmd.Flags().Int32(ramFlag, 0, "Amount of RAM (in GB)")
 	cmd.Flags().Int64(storageSizeFlag, 0, "Storage size (in GB)")
 	cmd.Flags().String(storageClassFlag, "", "Storage class")
 	cmd.Flags().String(versionFlag, "", "SQLServer version")
@@ -162,8 +162,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	}
 
 	flavorId := flags.FlagToStringPointer(p, cmd, flavorIdFlag)
-	cpu := flags.FlagToInt64Pointer(p, cmd, cpuFlag)
-	ram := flags.FlagToInt64Pointer(p, cmd, ramFlag)
+	cpu := flags.FlagToInt32Pointer(p, cmd, cpuFlag)
+	ram := flags.FlagToInt32Pointer(p, cmd, ramFlag)
 
 	if flavorId == nil && (cpu == nil || ram == nil) {
 		return nil, &cliErr.DatabaseInputFlavorError{
@@ -180,8 +180,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
-		InstanceName:    flags.FlagToStringPointer(p, cmd, instanceNameFlag),
-		ACL:             flags.FlagToStringSlicePointer(p, cmd, aclFlag),
+		InstanceName:    flags.FlagToStringValue(p, cmd, instanceNameFlag),
+		ACL:             flags.FlagToStringSliceValue(p, cmd, aclFlag),
 		BackupSchedule:  flags.FlagToStringPointer(p, cmd, backupScheduleFlag),
 		FlavorId:        flavorId,
 		CPU:             cpu,
@@ -203,7 +203,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 	var flavorId *string
 	var err error
 
-	flavors, err := apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+	flavors, err := apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get SQLServer Flex flavors: %w", err)
 	}
@@ -225,7 +225,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 		flavorId = model.FlavorId
 	}
 
-	storages, err := apiClient.ListStoragesExecute(ctx, model.ProjectId, *flavorId, model.Region)
+	storages, err := apiClient.ListStorages(ctx, model.ProjectId, *flavorId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get SQLServer Flex storages: %w", err)
 	}
@@ -241,15 +241,15 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 
 	req = req.CreateInstancePayload(sqlserverflex.CreateInstancePayload{
 		Name:           model.InstanceName,
-		Acl:            &sqlserverflex.CreateInstancePayloadAcl{Items: model.ACL},
+		Acl:            &sqlserverflex.InstanceDocumentationACL{Items: model.ACL},
 		BackupSchedule: model.BackupSchedule,
-		FlavorId:       flavorId,
-		Storage: &sqlserverflex.CreateInstancePayloadStorage{
+		FlavorId:       *flavorId,
+		Storage: &sqlserverflex.InstanceDocumentationStorage{
 			Class: model.StorageClass,
 			Size:  model.StorageSize,
 		},
 		Version: model.Version,
-		Options: &sqlserverflex.CreateInstancePayloadOptions{
+		Options: &sqlserverflex.InstanceDocumentationOptions{
 			Edition:       model.Edition,
 			RetentionDays: retentionDays,
 		},

--- a/internal/cmd/beta/sqlserverflex/instance/create/create_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -19,37 +19,32 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testRegion = "eu01"
 
-// enforce implementation of interfaces
-var (
-	_ sqlServerFlexClient = &sqlServerFlexClientMocked{}
-)
-
-type sqlServerFlexClientMocked struct {
+type mockSettings struct {
 	listFlavorsFails  bool
 	listFlavorsResp   *sqlserverflex.ListFlavorsResponse
 	listStoragesFails bool
 	listStoragesResp  *sqlserverflex.ListStoragesResponse
 }
 
-func (c *sqlServerFlexClientMocked) CreateInstance(ctx context.Context, projectId, region string) sqlserverflex.ApiCreateInstanceRequest {
-	return testClient.CreateInstance(ctx, projectId, region)
-}
-
-func (c *sqlServerFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListStoragesResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list storages failed")
+func newAPIMock(s mockSettings) sqlserverflex.DefaultAPI {
+	return &sqlserverflex.DefaultAPIServiceMock{
+		ListStoragesExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListStoragesRequest) (*sqlserverflex.ListStoragesResponse, error) {
+			if s.listFlavorsFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return s.listStoragesResp, nil
+		}),
+		ListFlavorsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error) {
+			if s.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return s.listFlavorsResp, nil
+		}),
 	}
-	return c.listStoragesResp, nil
-}
-
-func (c *sqlServerFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*sqlserverflex.ListFlavorsResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
-	}
-	return c.listFlavorsResp, nil
 }
 
 var testProjectId = uuid.NewString()
@@ -82,8 +77,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		InstanceName:   utils.Ptr("example-name"),
-		ACL:            utils.Ptr([]string{"0.0.0.0/0"}),
+		InstanceName:   "example-name",
+		ACL:            []string{"0.0.0.0/0"},
 		BackupSchedule: utils.Ptr("0 0/6 * * *"),
 		FlavorId:       utils.Ptr(testFlavorId),
 		StorageClass:   utils.Ptr("storage-class"),
@@ -99,7 +94,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiCreateInstanceRequest)) sqlserverflex.ApiCreateInstanceRequest {
-	request := testClient.CreateInstance(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateInstance(testCtx, testProjectId, testRegion)
 	request = request.CreateInstancePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -109,16 +104,16 @@ func fixtureRequest(mods ...func(request *sqlserverflex.ApiCreateInstanceRequest
 
 func fixturePayload(mods ...func(payload *sqlserverflex.CreateInstancePayload)) sqlserverflex.CreateInstancePayload {
 	payload := sqlserverflex.CreateInstancePayload{
-		Name:           utils.Ptr("example-name"),
-		Acl:            &sqlserverflex.CreateInstancePayloadAcl{Items: utils.Ptr([]string{"0.0.0.0/0"})},
+		Name:           "example-name",
+		Acl:            &sqlserverflex.InstanceDocumentationACL{Items: []string{"0.0.0.0/0"}},
 		BackupSchedule: utils.Ptr("0 0/6 * * *"),
-		FlavorId:       utils.Ptr(testFlavorId),
-		Storage: &sqlserverflex.CreateInstancePayloadStorage{
+		FlavorId:       testFlavorId,
+		Storage: &sqlserverflex.InstanceDocumentationStorage{
 			Class: utils.Ptr("storage-class"),
 			Size:  utils.Ptr(int64(10)),
 		},
 		Version: utils.Ptr("6.0"),
-		Options: &sqlserverflex.CreateInstancePayloadOptions{
+		Options: &sqlserverflex.InstanceDocumentationOptions{
 			Edition:       utils.Ptr("developer"),
 			RetentionDays: utils.Ptr("32"),
 		},
@@ -154,8 +149,8 @@ func TestParseInput(t *testing.T) {
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
 				model.FlavorId = nil
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 		},
 		{
@@ -222,9 +217,7 @@ func TestParseInput(t *testing.T) {
 			aclValues:   []string{"198.51.100.14/24", "198.51.100.14/32"},
 			isValid:     true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ACL = utils.Ptr(
-					append(*model.ACL, "198.51.100.14/24", "198.51.100.14/32"),
-				)
+				model.ACL = append(model.ACL, "198.51.100.14/24", "198.51.100.14/32")
 			}),
 		},
 		{
@@ -233,9 +226,7 @@ func TestParseInput(t *testing.T) {
 			aclValues:   []string{"198.51.100.14/24,198.51.100.14/32"},
 			isValid:     true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ACL = utils.Ptr(
-					append(*model.ACL, "198.51.100.14/24", "198.51.100.14/32"),
-				)
+				model.ACL = append(model.ACL, "198.51.100.14/24", "198.51.100.14/32")
 			}),
 		},
 		{
@@ -277,16 +268,16 @@ func TestBuildRequest(t *testing.T) {
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"storage-class"},
+				StorageClasses: []string{"storage-class"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -298,28 +289,28 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
 			listStoragesResp: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"storage-class"},
+				StorageClasses: []string{"storage-class"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -331,8 +322,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -343,21 +334,21 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(5))
-					model.RAM = utils.Ptr(int64(9))
+					model.CPU = utils.Ptr(int32(5))
+					model.RAM = utils.Ptr(int32(9))
 				},
 			),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
@@ -368,8 +359,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -383,16 +374,16 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"storage-class"},
+				StorageClasses: []string{"storage-class"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -408,16 +399,16 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"storage-class"},
+				StorageClasses: []string{"storage-class"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -429,13 +420,13 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &sqlServerFlexClientMocked{
+			client := mockSettings{
 				listFlavorsFails:  tt.listFlavorsFails,
 				listFlavorsResp:   tt.listFlavorsResp,
 				listStoragesFails: tt.listStoragesFails,
 				listStoragesResp:  tt.listStoragesResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPIMock(client))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -446,6 +437,9 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmp.FilterPath(func(p cmp.Path) bool {
+					return p.String() == "ApiService"
+				}, cmp.Ignore()),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/instance/delete/delete.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/wait"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api/wait"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -76,7 +76,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Deleting instance", func() error {
-					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -113,6 +113,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiDeleteInstanceRequest {
-	req := apiClient.DeleteInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.DeleteInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }

--- a/internal/cmd/beta/sqlserverflex/instance/delete/delete_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/delete/delete_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testRegion = "eu01"
@@ -58,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiDeleteInstanceRequest)) sqlserverflex.ApiDeleteInstanceRequest {
-	request := testClient.DeleteInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.DeleteInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -162,7 +163,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/instance/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -86,7 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }
 
@@ -98,7 +98,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *sqlserverflex
 	return p.OutputResult(outputFormat, instance, func() error {
 		var acls string
 		if instance.Acl != nil && instance.Acl.HasItems() {
-			aclsArray := *instance.Acl.Items
+			aclsArray := instance.Acl.Items
 			acls = strings.Join(aclsArray, ",")
 		}
 

--- a/internal/cmd/beta/sqlserverflex/instance/describe/describe_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -18,7 +18,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testRegion = "eu01"
@@ -60,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiGetInstanceRequest)) sqlserverflex.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -164,7 +165,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/instance/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -115,7 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiListInstancesRequest {
-	req := apiClient.ListInstances(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.ListInstances(ctx, model.ProjectId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/sqlserverflex/instance/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/list/list_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -18,7 +18,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 
 const testRegion = "eu01"
@@ -51,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiListInstancesRequest)) sqlserverflex.ApiListInstancesRequest {
-	request := testClient.ListInstances(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListInstances(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -140,7 +141,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/instance/update/update.go
+++ b/internal/cmd/beta/sqlserverflex/instance/update/update.go
@@ -19,20 +19,20 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/wait"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api/wait"
 )
 
 // enforce implementation of interfaces
 var (
-	_ sqlServerFlexClient = &sqlserverflex.APIClient{}
+	_ sqlServerFlexClient = sqlserverflex.APIClient{}.DefaultAPI
 )
 
 type sqlServerFlexClient interface {
 	PartialUpdateInstance(ctx context.Context, projectId, instanceId string, region string) sqlserverflex.ApiPartialUpdateInstanceRequest
-	GetInstanceExecute(ctx context.Context, projectId, instanceId string, region string) (*sqlserverflex.GetInstanceResponse, error)
-	ListFlavorsExecute(ctx context.Context, projectId string, region string) (*sqlserverflex.ListFlavorsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId string, region string) (*sqlserverflex.ListStoragesResponse, error)
+	GetInstance(ctx context.Context, projectId, instanceId string, region string) sqlserverflex.ApiGetInstanceRequest
+	ListFlavors(ctx context.Context, projectId string, region string) sqlserverflex.ApiListFlavorsRequest
+	ListStorages(ctx context.Context, projectId, flavorId string, region string) sqlserverflex.ApiListStoragesRequest
 }
 
 const (
@@ -52,11 +52,11 @@ type inputModel struct {
 
 	InstanceId     string
 	InstanceName   *string
-	ACL            *[]string
+	ACL            []string
 	BackupSchedule *string
 	FlavorId       *string
-	CPU            *int64
-	RAM            *int64
+	CPU            *int32
+	RAM            *int32
 	Version        *string
 }
 
@@ -88,7 +88,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -101,7 +101,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				return err
 			}
@@ -114,7 +114,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Updating instance", func() error {
-					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -134,8 +134,8 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "Lists of IP networks in CIDR notation which are allowed to access this instance")
 	cmd.Flags().String(backupScheduleFlag, "", "Backup schedule")
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
-	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")
-	cmd.Flags().Int64(ramFlag, 0, "Amount of RAM (in GB)")
+	cmd.Flags().Int32(cpuFlag, 0, "Number of CPUs")
+	cmd.Flags().Int32(ramFlag, 0, "Amount of RAM (in GB)")
 	cmd.Flags().String(versionFlag, "", "Version")
 }
 
@@ -149,9 +149,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 	instanceName := flags.FlagToStringPointer(p, cmd, instanceNameFlag)
 	flavorId := flags.FlagToStringPointer(p, cmd, flavorIdFlag)
-	cpu := flags.FlagToInt64Pointer(p, cmd, cpuFlag)
-	ram := flags.FlagToInt64Pointer(p, cmd, ramFlag)
-	acl := flags.FlagToStringSlicePointer(p, cmd, aclFlag)
+	cpu := flags.FlagToInt32Pointer(p, cmd, cpuFlag)
+	ram := flags.FlagToInt32Pointer(p, cmd, ramFlag)
+	acl := flags.FlagToStringSliceValue(p, cmd, aclFlag)
 	backupSchedule := flags.FlagToStringPointer(p, cmd, backupScheduleFlag)
 	version := flags.FlagToStringPointer(p, cmd, versionFlag)
 
@@ -190,7 +190,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 	var flavorId *string
 	var err error
 
-	flavors, err := apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+	flavors, err := apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get SQLServer Flex flavors: %w", err)
 	}
@@ -199,7 +199,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 		ram := model.RAM
 		cpu := model.CPU
 		if model.RAM == nil || model.CPU == nil {
-			currentInstance, err := apiClient.GetInstanceExecute(ctx, model.ProjectId, model.InstanceId, model.Region)
+			currentInstance, err := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region).Execute()
 			if err != nil {
 				return req, fmt.Errorf("get SQLServer Flex instance: %w", err)
 			}
@@ -226,9 +226,9 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlServerFle
 		flavorId = model.FlavorId
 	}
 
-	var payloadAcl *sqlserverflex.CreateInstancePayloadAcl
+	var payloadAcl *sqlserverflex.InstanceDocumentationACL
 	if model.ACL != nil {
-		payloadAcl = &sqlserverflex.CreateInstancePayloadAcl{Items: model.ACL}
+		payloadAcl = &sqlserverflex.InstanceDocumentationACL{Items: model.ACL}
 	}
 
 	req = req.PartialUpdateInstancePayload(sqlserverflex.PartialUpdateInstancePayload{

--- a/internal/cmd/beta/sqlserverflex/instance/update/update_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/update/update_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -19,15 +19,11 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testRegion = "eu01"
 
-// enforce implementation of interfaces
-var (
-	_ sqlServerFlexClient = &sqlServerFlexClientMocked{}
-)
-
-type sqlServerFlexClientMocked struct {
+type mockSettings struct {
 	listFlavorsFails  bool
 	listFlavorsResp   *sqlserverflex.ListFlavorsResponse
 	listStoragesFails bool
@@ -36,29 +32,27 @@ type sqlServerFlexClientMocked struct {
 	getInstanceResp   *sqlserverflex.GetInstanceResponse
 }
 
-func (c *sqlServerFlexClientMocked) PartialUpdateInstance(ctx context.Context, projectId, instanceId, region string) sqlserverflex.ApiPartialUpdateInstanceRequest {
-	return testClient.PartialUpdateInstance(ctx, projectId, instanceId, region)
-}
-
-func (c *sqlServerFlexClientMocked) GetInstanceExecute(_ context.Context, _, _, _ string) (*sqlserverflex.GetInstanceResponse, error) {
-	if c.getInstanceFails {
-		return nil, fmt.Errorf("get instance failed")
+func newAPIMock(settings mockSettings) sqlserverflex.DefaultAPI {
+	return &sqlserverflex.DefaultAPIServiceMock{
+		GetInstanceExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiGetInstanceRequest) (*sqlserverflex.GetInstanceResponse, error) {
+			if settings.getInstanceFails {
+				return nil, fmt.Errorf("get instance failed")
+			}
+			return settings.getInstanceResp, nil
+		}),
+		ListStoragesExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListStoragesRequest) (*sqlserverflex.ListStoragesResponse, error) {
+			if settings.listFlavorsFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return settings.listStoragesResp, nil
+		}),
+		ListFlavorsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error) {
+			if settings.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return settings.listFlavorsResp, nil
+		}),
 	}
-	return c.getInstanceResp, nil
-}
-
-func (c *sqlServerFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListStoragesResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list storages failed")
-	}
-	return c.listStoragesResp, nil
-}
-
-func (c *sqlServerFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*sqlserverflex.ListFlavorsResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
-	}
-	return c.listFlavorsResp, nil
 }
 
 var testProjectId = uuid.NewString()
@@ -127,7 +121,7 @@ func fixtureStandardInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceId:     testInstanceId,
 		FlavorId:       utils.Ptr(testFlavorId),
 		InstanceName:   utils.Ptr("example-name"),
-		ACL:            utils.Ptr([]string{"0.0.0.0/0"}),
+		ACL:            []string{"0.0.0.0/0"},
 		BackupSchedule: utils.Ptr("0 0 * * *"),
 		Version:        utils.Ptr("5.0"),
 	}
@@ -138,7 +132,7 @@ func fixtureStandardInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiPartialUpdateInstanceRequest)) sqlserverflex.ApiPartialUpdateInstanceRequest {
-	request := testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.PartialUpdateInstancePayload(sqlserverflex.PartialUpdateInstancePayload{})
 	for _, mod := range mods {
 		mod(&request)
@@ -198,8 +192,8 @@ func TestParseInput(t *testing.T) {
 			isValid: true,
 			expectedModel: fixtureStandardInputModel(func(model *inputModel) {
 				model.FlavorId = nil
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 		},
 		{
@@ -275,7 +269,7 @@ func TestParseInput(t *testing.T) {
 			aclValues:   []string{"198.51.100.14/24", "198.51.100.14/32"},
 			isValid:     true,
 			expectedModel: fixtureRequiredInputModel(func(model *inputModel) {
-				model.ACL = utils.Ptr([]string{"198.51.100.14/24", "198.51.100.14/32"})
+				model.ACL = []string{"198.51.100.14/24", "198.51.100.14/32"}
 			}),
 		},
 	}
@@ -370,15 +364,15 @@ func TestBuildRequest(t *testing.T) {
 			}),
 			isValid: true,
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(sqlserverflex.PartialUpdateInstancePayload{
 					FlavorId: utils.Ptr(testFlavorId),
 				}),
@@ -386,20 +380,20 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "update flavor from cpu and ram",
 			model: fixtureRequiredInputModel(func(model *inputModel) {
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 			isValid: true,
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(sqlserverflex.PartialUpdateInstancePayload{
 					FlavorId: utils.Ptr(testFlavorId),
 				}),
@@ -408,8 +402,8 @@ func TestBuildRequest(t *testing.T) {
 			description: "get flavors fails",
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -419,21 +413,21 @@ func TestBuildRequest(t *testing.T) {
 			description: "flavor id not found",
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
-					model.CPU = utils.Ptr(int64(5))
-					model.RAM = utils.Ptr(int64(9))
+					model.CPU = utils.Ptr(int32(5))
+					model.RAM = utils.Ptr(int32(9))
 				},
 			),
 			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
-				Flavors: &[]sqlserverflex.InstanceFlavorEntry{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
@@ -444,7 +438,7 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.RAM = utils.Ptr(int64(4))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			getInstanceFails: true,
@@ -455,8 +449,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -466,7 +460,7 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &sqlServerFlexClientMocked{
+			s := mockSettings{
 				getInstanceFails:  tt.getInstanceFails,
 				getInstanceResp:   tt.getInstanceResp,
 				listFlavorsFails:  tt.listFlavorsFails,
@@ -474,7 +468,7 @@ func TestBuildRequest(t *testing.T) {
 				listStoragesFails: tt.listStoragesFails,
 				listStoragesResp:  tt.listStoragesResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPIMock(s))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -487,6 +481,10 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.FilterPath(func(p cmp.Path) bool {
+					s := p.String()
+					return s == "ApiService"
+				}, cmp.Ignore()),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/beta/sqlserverflex/options/options.go
+++ b/internal/cmd/beta/sqlserverflex/options/options.go
@@ -15,21 +15,21 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 // enforce implementation of interfaces
 var (
-	_ sqlServerFlexOptionsClient = &sqlserverflex.APIClient{}
+	_ sqlServerFlexOptionsClient = sqlserverflex.APIClient{}.DefaultAPI
 )
 
 type sqlServerFlexOptionsClient interface {
-	ListFlavorsExecute(ctx context.Context, projectId string, region string) (*sqlserverflex.ListFlavorsResponse, error)
-	ListVersionsExecute(ctx context.Context, projectId string, region string) (*sqlserverflex.ListVersionsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId string, region string) (*sqlserverflex.ListStoragesResponse, error)
-	ListRolesExecute(ctx context.Context, projectId string, instanceId string, region string) (*sqlserverflex.ListRolesResponse, error)
-	ListCollationsExecute(ctx context.Context, projectId string, instanceId string, region string) (*sqlserverflex.ListCollationsResponse, error)
-	ListCompatibilityExecute(ctx context.Context, projectId string, instanceId string, region string) (*sqlserverflex.ListCompatibilityResponse, error)
+	ListFlavors(ctx context.Context, projectId string, region string) sqlserverflex.ApiListFlavorsRequest
+	ListVersions(ctx context.Context, projectId string, region string) sqlserverflex.ApiListVersionsRequest
+	ListStorages(ctx context.Context, projectId, flavorId string, region string) sqlserverflex.ApiListStoragesRequest
+	ListRoles(ctx context.Context, projectId string, instanceId string, region string) sqlserverflex.ApiListRolesRequest
+	ListCollations(ctx context.Context, projectId string, instanceId string, region string) sqlserverflex.ApiListCollationsRequest
+	ListCompatibility(ctx context.Context, projectId string, instanceId string, region string) sqlserverflex.ApiListCompatibilityRequest
 }
 
 const (
@@ -59,12 +59,12 @@ type inputModel struct {
 }
 
 type options struct {
-	Flavors           *[]sqlserverflex.InstanceFlavorEntry `json:"flavors,omitempty"`
-	Versions          *[]string                            `json:"versions,omitempty"`
-	Storages          *flavorStorages                      `json:"flavorStorages,omitempty"`
-	UserRoles         *instanceUserRoles                   `json:"userRoles,omitempty"`
-	DBCollations      *instanceDBCollations                `json:"dbCollations,omitempty"`
-	DBCompatibilities *instanceDBCompatibilities           `json:"dbCompatibilities,omitempty"`
+	Flavors           []sqlserverflex.InstanceFlavorEntry `json:"flavors,omitempty"`
+	Versions          []string                            `json:"versions,omitempty"`
+	Storages          *flavorStorages                     `json:"flavorStorages,omitempty"`
+	UserRoles         *instanceUserRoles                  `json:"userRoles,omitempty"`
+	DBCollations      *instanceDBCollations               `json:"dbCollations,omitempty"`
+	DBCompatibilities *instanceDBCompatibilities          `json:"dbCompatibilities,omitempty"`
 }
 
 type flavorStorages struct {
@@ -121,7 +121,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			err = buildAndExecuteRequest(ctx, params.Printer, model, apiClient)
+			err = buildAndExecuteRequest(ctx, params.Printer, model, apiClient.DefaultAPI)
 			if err != nil {
 				return fmt.Errorf("get SQL Server Flex options: %w", err)
 			}
@@ -203,37 +203,37 @@ func buildAndExecuteRequest(ctx context.Context, p *print.Printer, model *inputM
 	var err error
 
 	if model.Flavors {
-		flavors, err = apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+		flavors, err = apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex flavors: %w", err)
 		}
 	}
 	if model.Versions {
-		versions, err = apiClient.ListVersionsExecute(ctx, model.ProjectId, model.Region)
+		versions, err = apiClient.ListVersions(ctx, model.ProjectId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex versions: %w", err)
 		}
 	}
 	if model.Storages {
-		storages, err = apiClient.ListStoragesExecute(ctx, model.ProjectId, *model.FlavorId, model.Region)
+		storages, err = apiClient.ListStorages(ctx, model.ProjectId, *model.FlavorId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex storages: %w", err)
 		}
 	}
 	if model.UserRoles {
-		userRoles, err = apiClient.ListRolesExecute(ctx, model.ProjectId, *model.InstanceId, model.Region)
+		userRoles, err = apiClient.ListRoles(ctx, model.ProjectId, *model.InstanceId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex user roles: %w", err)
 		}
 	}
 	if model.DBCollations {
-		dbCollations, err = apiClient.ListCollationsExecute(ctx, model.ProjectId, *model.InstanceId, model.Region)
+		dbCollations, err = apiClient.ListCollations(ctx, model.ProjectId, *model.InstanceId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex DB collations: %w", err)
 		}
 	}
 	if model.DBCompatibilities {
-		dbCompatibilities, err = apiClient.ListCompatibilityExecute(ctx, model.ProjectId, *model.InstanceId, model.Region)
+		dbCompatibilities, err = apiClient.ListCompatibility(ctx, model.ProjectId, *model.InstanceId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get SQL Server Flex DB compatibilities: %w", err)
 		}
@@ -259,31 +259,31 @@ func outputResult(p *print.Printer, model *inputModel, flavors *sqlserverflex.Li
 	if userRoles != nil && model.InstanceId != nil {
 		options.UserRoles = &instanceUserRoles{
 			InstanceId: *model.InstanceId,
-			UserRoles:  *userRoles.Roles,
+			UserRoles:  userRoles.Roles,
 		}
 	}
 	if dbCollations != nil && model.InstanceId != nil {
 		options.DBCollations = &instanceDBCollations{
 			InstanceId:   *model.InstanceId,
-			DBCollations: *dbCollations.Collations,
+			DBCollations: dbCollations.Collations,
 		}
 	}
 	if dbCompatibilities != nil && model.InstanceId != nil {
 		options.DBCompatibilities = &instanceDBCompatibilities{
 			InstanceId:        *model.InstanceId,
-			DBCompatibilities: *dbCompatibilities.Compatibilities,
+			DBCompatibilities: dbCompatibilities.Compatibilities,
 		}
 	}
 
 	return p.OutputResult(model.OutputFormat, options, func() error {
 		content := []tables.Table{}
-		if model.Flavors && len(*options.Flavors) != 0 {
-			content = append(content, buildFlavorsTable(*options.Flavors))
+		if model.Flavors && len(options.Flavors) != 0 {
+			content = append(content, buildFlavorsTable(options.Flavors))
 		}
-		if model.Versions && len(*options.Versions) != 0 {
-			content = append(content, buildVersionsTable(*options.Versions))
+		if model.Versions && len(options.Versions) != 0 {
+			content = append(content, buildVersionsTable(options.Versions))
 		}
-		if model.Storages && options.Storages.Storages != nil && len(*options.Storages.Storages.StorageClasses) != 0 {
+		if model.Storages && options.Storages.Storages != nil && len(options.Storages.Storages.StorageClasses) != 0 {
 			content = append(content, buildStoragesTable(*options.Storages.Storages))
 		}
 		if model.UserRoles && len(options.UserRoles.UserRoles) != 0 {
@@ -329,7 +329,7 @@ func buildVersionsTable(versions []string) tables.Table {
 }
 
 func buildStoragesTable(storagesResp sqlserverflex.ListStoragesResponse) tables.Table {
-	storages := *storagesResp.StorageClasses
+	storages := storagesResp.StorageClasses
 	table := tables.NewTable()
 	table.SetTitle("Storages")
 	table.SetHeader("MINIMUM", "MAXIMUM", "STORAGE CLASS")

--- a/internal/cmd/beta/sqlserverflex/options/options_test.go
+++ b/internal/cmd/beta/sqlserverflex/options/options_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -20,12 +20,7 @@ type testCtxKey struct{}
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testInstanceId = uuid.NewString()
 
-// enforce implementation of interfaces
-var (
-	_ sqlServerFlexOptionsClient = &sqlServerFlexClientMocked{}
-)
-
-type sqlServerFlexClientMocked struct {
+type mockSettings struct {
 	listFlavorsFails           bool
 	listVersionsFails          bool
 	listStoragesFails          bool
@@ -41,68 +36,67 @@ type sqlServerFlexClientMocked struct {
 	listDBCompatibilitiesCalled bool
 }
 
-func (c *sqlServerFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*sqlserverflex.ListFlavorsResponse, error) {
-	c.listFlavorsCalled = true
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
+func newAPIMock(s *mockSettings) sqlserverflex.DefaultAPI {
+	return &sqlserverflex.DefaultAPIServiceMock{
+		ListFlavorsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error) {
+			s.listFlavorsCalled = true
+			if s.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return utils.Ptr(sqlserverflex.ListFlavorsResponse{
+				Flavors: []sqlserverflex.InstanceFlavorEntry{},
+			}), nil
+		}),
+		ListVersionsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListVersionsRequest) (*sqlserverflex.ListVersionsResponse, error) {
+			s.listVersionsCalled = true
+			if s.listVersionsFails {
+				return nil, fmt.Errorf("list versions failed")
+			}
+			return utils.Ptr(sqlserverflex.ListVersionsResponse{
+				Versions: []string{},
+			}), nil
+		}),
+		ListStoragesExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListStoragesRequest) (*sqlserverflex.ListStoragesResponse, error) {
+			s.listStoragesCalled = true
+			if s.listStoragesFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return utils.Ptr(sqlserverflex.ListStoragesResponse{
+				StorageClasses: []string{},
+				StorageRange: &sqlserverflex.StorageRange{
+					Min: utils.Ptr(int64(10)),
+					Max: utils.Ptr(int64(100)),
+				},
+			}), nil
+		}),
+		ListRolesExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListRolesRequest) (*sqlserverflex.ListRolesResponse, error) {
+			s.listUserRolesCalled = true
+			if s.listUserRolesFails {
+				return nil, fmt.Errorf("list roles failed")
+			}
+			return utils.Ptr(sqlserverflex.ListRolesResponse{
+				Roles: []string{},
+			}), nil
+		}),
+		ListCollationsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListCollationsRequest) (*sqlserverflex.ListCollationsResponse, error) {
+			s.listDBCollationsCalled = true
+			if s.listDBCollationsFails {
+				return nil, fmt.Errorf("list collations failed")
+			}
+			return utils.Ptr(sqlserverflex.ListCollationsResponse{
+				Collations: []sqlserverflex.MssqlDatabaseCollation{},
+			}), nil
+		}),
+		ListCompatibilityExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListCompatibilityRequest) (*sqlserverflex.ListCompatibilityResponse, error) {
+			s.listDBCompatibilitiesCalled = true
+			if s.listDBCompatibilitiesFails {
+				return nil, fmt.Errorf("list compatibilities failed")
+			}
+			return utils.Ptr(sqlserverflex.ListCompatibilityResponse{
+				Compatibilities: []sqlserverflex.MssqlDatabaseCompatibility{},
+			}), nil
+		}),
 	}
-	return utils.Ptr(sqlserverflex.ListFlavorsResponse{
-		Flavors: utils.Ptr([]sqlserverflex.InstanceFlavorEntry{}),
-	}), nil
-}
-
-func (c *sqlServerFlexClientMocked) ListVersionsExecute(_ context.Context, _, _ string) (*sqlserverflex.ListVersionsResponse, error) {
-	c.listVersionsCalled = true
-	if c.listVersionsFails {
-		return nil, fmt.Errorf("list versions failed")
-	}
-	return utils.Ptr(sqlserverflex.ListVersionsResponse{
-		Versions: utils.Ptr([]string{}),
-	}), nil
-}
-
-func (c *sqlServerFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListStoragesResponse, error) {
-	c.listStoragesCalled = true
-	if c.listStoragesFails {
-		return nil, fmt.Errorf("list storages failed")
-	}
-	return utils.Ptr(sqlserverflex.ListStoragesResponse{
-		StorageClasses: utils.Ptr([]string{}),
-		StorageRange: &sqlserverflex.StorageRange{
-			Min: utils.Ptr(int64(10)),
-			Max: utils.Ptr(int64(100)),
-		},
-	}), nil
-}
-
-func (c *sqlServerFlexClientMocked) ListRolesExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListRolesResponse, error) {
-	c.listUserRolesCalled = true
-	if c.listUserRolesFails {
-		return nil, fmt.Errorf("list roles failed")
-	}
-	return utils.Ptr(sqlserverflex.ListRolesResponse{
-		Roles: utils.Ptr([]string{}),
-	}), nil
-}
-
-func (c *sqlServerFlexClientMocked) ListCollationsExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListCollationsResponse, error) {
-	c.listDBCollationsCalled = true
-	if c.listDBCollationsFails {
-		return nil, fmt.Errorf("list collations failed")
-	}
-	return utils.Ptr(sqlserverflex.ListCollationsResponse{
-		Collations: utils.Ptr([]sqlserverflex.MssqlDatabaseCollation{}),
-	}), nil
-}
-
-func (c *sqlServerFlexClientMocked) ListCompatibilityExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListCompatibilityResponse, error) {
-	c.listDBCompatibilitiesCalled = true
-	if c.listDBCompatibilitiesFails {
-		return nil, fmt.Errorf("list compatibilities failed")
-	}
-	return utils.Ptr(sqlserverflex.ListCompatibilityResponse{
-		Compatibilities: utils.Ptr([]sqlserverflex.MssqlDatabaseCompatibility{}),
-	}), nil
 }
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -436,7 +430,7 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			params := testparams.NewTestParams()
-			client := &sqlServerFlexClientMocked{
+			settings := mockSettings{
 				listFlavorsFails:           tt.listFlavorsFails,
 				listVersionsFails:          tt.listVersionsFails,
 				listStoragesFails:          tt.listStoragesFails,
@@ -445,7 +439,7 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 				listDBCompatibilitiesFails: tt.listDBCompatibilitiesFails,
 			}
 
-			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, client)
+			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, newAPIMock(&settings))
 			if err != nil && tt.isValid {
 				t.Fatalf("error building and executing request: %v", err)
 			}
@@ -456,14 +450,14 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 				return
 			}
 
-			if tt.expectListFlavorsCalled != client.listFlavorsCalled {
-				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, client.listFlavorsCalled)
+			if tt.expectListFlavorsCalled != settings.listFlavorsCalled {
+				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, settings.listFlavorsCalled)
 			}
-			if tt.expectListVersionsCalled != client.listVersionsCalled {
-				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, client.listVersionsCalled)
+			if tt.expectListVersionsCalled != settings.listVersionsCalled {
+				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, settings.listVersionsCalled)
 			}
-			if tt.expectListStoragesCalled != client.listStoragesCalled {
-				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, client.listStoragesCalled)
+			if tt.expectListStoragesCalled != settings.listStoragesCalled {
+				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, settings.listStoragesCalled)
 			}
 		})
 	}
@@ -495,12 +489,12 @@ func TestOutputResult(t *testing.T) {
 			name: "all input set",
 			args: args{
 				model:             fixtureInputModelAllTrue(),
-				flavors:           &sqlserverflex.ListFlavorsResponse{Flavors: &[]sqlserverflex.InstanceFlavorEntry{}},
-				versions:          &sqlserverflex.ListVersionsResponse{Versions: &[]string{}},
-				storages:          &sqlserverflex.ListStoragesResponse{StorageClasses: &[]string{}},
-				userRoles:         &sqlserverflex.ListRolesResponse{Roles: &[]string{}},
-				dbCollations:      &sqlserverflex.ListCollationsResponse{Collations: &[]sqlserverflex.MssqlDatabaseCollation{}},
-				dbCompatibilities: &sqlserverflex.ListCompatibilityResponse{Compatibilities: &[]sqlserverflex.MssqlDatabaseCompatibility{}},
+				flavors:           &sqlserverflex.ListFlavorsResponse{Flavors: []sqlserverflex.InstanceFlavorEntry{}},
+				versions:          &sqlserverflex.ListVersionsResponse{Versions: []string{}},
+				storages:          &sqlserverflex.ListStoragesResponse{StorageClasses: []string{}},
+				userRoles:         &sqlserverflex.ListRolesResponse{Roles: []string{}},
+				dbCollations:      &sqlserverflex.ListCollationsResponse{Collations: []sqlserverflex.MssqlDatabaseCollation{}},
+				dbCompatibilities: &sqlserverflex.ListCompatibilityResponse{Compatibilities: []sqlserverflex.MssqlDatabaseCompatibility{}},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -31,8 +31,8 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 
 	InstanceId string
-	Username   *string
-	Roles      *[]string
+	Username   string
+	Roles      []string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -70,7 +70,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -116,8 +116,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		InstanceId:      flags.FlagToStringValue(p, cmd, instanceIdFlag),
-		Username:        flags.FlagToStringPointer(p, cmd, usernameFlag),
-		Roles:           flags.FlagToStringSlicePointer(p, cmd, rolesFlag),
+		Username:        flags.FlagToStringValue(p, cmd, usernameFlag),
+		Roles:           flags.FlagToStringSliceValue(p, cmd, rolesFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -125,7 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiCreateUserRequest {
-	req := apiClient.CreateUser(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.CreateUser(ctx, model.ProjectId, model.InstanceId, model.Region)
 
 	req = req.CreateUserPayload(sqlserverflex.CreateUserPayload{
 		Username: model.Username,
@@ -142,8 +142,8 @@ func outputResult(p *print.Printer, model *inputModel, instanceLabel string, use
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
-		if user.Roles != nil && len(*user.Roles) != 0 {
-			p.Outputf("Roles: [%v]\n", strings.Join(*user.Roles, ", "))
+		if len(user.Roles) != 0 {
+			p.Outputf("Roles: [%v]\n", strings.Join(user.Roles, ", "))
 		}
 		if user.Host != nil && *user.Host != "" {
 			p.Outputf("Host: %s\n", *user.Host)

--- a/internal/cmd/beta/sqlserverflex/user/create/create_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testRegion = "eu01"
@@ -45,8 +45,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		InstanceId: testInstanceId,
-		Username:   utils.Ptr("johndoe"),
-		Roles:      utils.Ptr([]string{"read"}),
+		Username:   "johndoe",
+		Roles:      []string{"read"},
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -55,10 +55,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiCreateUserRequest)) sqlserverflex.ApiCreateUserRequest {
-	request := testClient.CreateUser(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.CreateUser(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.CreateUserPayload(sqlserverflex.CreateUserPayload{
-		Username: utils.Ptr("johndoe"),
-		Roles:    utils.Ptr([]string{"read"}),
+		Username: "johndoe",
+		Roles:    []string{"read"},
 	})
 
 	for _, mod := range mods {
@@ -159,10 +159,10 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "no username specified",
 			model: fixtureInputModel(func(model *inputModel) {
-				model.Username = nil
+				model.Username = ""
 			}),
 			expectedRequest: fixtureRequest().CreateUserPayload(sqlserverflex.CreateUserPayload{
-				Roles: utils.Ptr([]string{"read"}),
+				Roles: []string{"read"},
 			}),
 		},
 	}
@@ -173,7 +173,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/user/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/user/delete/delete.go
@@ -16,7 +16,7 @@ import (
 	sqlserverflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/sqlserverflex/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -59,13 +59,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := sqlserverflexUtils.GetUserName(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+			userLabel, err := sqlserverflexUtils.GetUserName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user name: %v", err)
 				userLabel = model.UserId
@@ -118,6 +118,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiDeleteUserRequest {
-	req := apiClient.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }

--- a/internal/cmd/beta/sqlserverflex/user/delete/delete_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/delete/delete_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = "my-user-id"
@@ -61,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiDeleteUserRequest)) sqlserverflex.ApiDeleteUserRequest {
-	request := testClient.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -177,7 +178,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/user/describe/describe.go
+++ b/internal/cmd/beta/sqlserverflex/user/describe/describe.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -106,7 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiGetUserRequest {
-	req := apiClient.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }
 
@@ -120,9 +120,9 @@ func outputResult(p *print.Printer, outputFormat string, user *sqlserverflex.Use
 		table.AddRow("ID", utils.PtrString(user.Id))
 		table.AddSeparator()
 		table.AddRow("USERNAME", utils.PtrString(user.Username))
-		if user.Roles != nil && len(*user.Roles) != 0 {
+		if len(user.Roles) != 0 {
 			table.AddSeparator()
-			table.AddRow("ROLES", strings.Join(*user.Roles, "\n"))
+			table.AddRow("ROLES", strings.Join(user.Roles, "\n"))
 		}
 		if user.DefaultDatabase != nil && *user.DefaultDatabase != "" {
 			table.AddSeparator()

--- a/internal/cmd/beta/sqlserverflex/user/describe/describe_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -17,7 +17,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = "my-user-id"
@@ -62,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiGetUserRequest)) sqlserverflex.ApiGetUserRequest {
-	request := testClient.GetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.GetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -178,7 +179,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/user/list/list.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -71,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 			users := resp.GetItems()
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = *model.InstanceId
@@ -123,7 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiListUsersRequest {
-	req := apiClient.ListUsers(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.ListUsers(ctx, model.ProjectId, *model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/list/list_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/list/list_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -18,7 +18,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -54,7 +55,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiListUsersRequest)) sqlserverflex.ApiListUsersRequest {
-	request := testClient.ListUsers(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.ListUsers(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -157,7 +158,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
+++ b/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -60,13 +60,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := sqlserverflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := sqlserverflexUtils.GetUserName(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+			userLabel, err := sqlserverflexUtils.GetUserName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user name: %v", err)
 				userLabel = model.UserId
@@ -119,7 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *sqlserverflex.APIClient) sqlserverflex.ApiResetUserRequest {
-	req := apiClient.ResetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.ResetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }
 

--- a/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password_test.go
+++ b/internal/cmd/beta/sqlserverflex/user/reset-password/reset_password_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -17,7 +17,8 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &sqlserverflex.APIClient{}
+var testClient = &sqlserverflex.APIClient{DefaultAPI: &sqlserverflex.DefaultAPIService{}}
+
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = "my-user-id"
@@ -62,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *sqlserverflex.ApiResetUserRequest)) sqlserverflex.ApiResetUserRequest {
-	request := testClient.ResetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.ResetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -178,7 +179,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, sqlserverflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/sqlserverflex/client/client.go
+++ b/internal/pkg/services/sqlserverflex/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*sqlserverflex.APIClient, error) {

--- a/internal/pkg/services/sqlserverflex/utils/utils.go
+++ b/internal/pkg/services/sqlserverflex/utils/utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 const (
@@ -16,21 +16,21 @@ const (
 
 // enforce implementation of interfaces
 var (
-	_ SQLServerFlexClient = &sqlserverflex.APIClient{}
+	_ SQLServerFlexClient = sqlserverflex.APIClient{}.DefaultAPI
 )
 
 type SQLServerFlexClient interface {
-	ListVersionsExecute(ctx context.Context, projectId string, region string) (*sqlserverflex.ListVersionsResponse, error)
-	GetInstanceExecute(ctx context.Context, projectId, instanceId string, region string) (*sqlserverflex.GetInstanceResponse, error)
-	GetUserExecute(ctx context.Context, projectId, instanceId, userId string, region string) (*sqlserverflex.GetUserResponse, error)
+	ListVersions(ctx context.Context, projectId string, region string) sqlserverflex.ApiListVersionsRequest
+	GetInstance(ctx context.Context, projectId, instanceId string, region string) sqlserverflex.ApiGetInstanceRequest
+	GetUser(ctx context.Context, projectId, instanceId, userId string, region string) sqlserverflex.ApiGetUserRequest
 }
 
-func ValidateFlavorId(flavorId string, flavors *[]sqlserverflex.InstanceFlavorEntry) error {
+func ValidateFlavorId(flavorId string, flavors []sqlserverflex.InstanceFlavorEntry) error {
 	if flavors == nil {
 		return fmt.Errorf("nil flavors")
 	}
 
-	for _, f := range *flavors {
+	for _, f := range flavors {
 		if f.Id != nil && strings.EqualFold(*f.Id, flavorId) {
 			return nil
 		}
@@ -57,7 +57,7 @@ func ValidateStorage(storageClass *string, storageSize *int64, storages *sqlserv
 		return nil
 	}
 
-	for _, sc := range *storages.StorageClasses {
+	for _, sc := range storages.StorageClasses {
 		if strings.EqualFold(*storageClass, sc) {
 			return nil
 		}
@@ -69,13 +69,13 @@ func ValidateStorage(storageClass *string, storageSize *int64, storages *sqlserv
 	}
 }
 
-func LoadFlavorId(cpu, ram int64, flavors *[]sqlserverflex.InstanceFlavorEntry) (*string, error) {
+func LoadFlavorId(cpu, ram int32, flavors []sqlserverflex.InstanceFlavorEntry) (*string, error) {
 	if flavors == nil {
 		return nil, fmt.Errorf("nil flavors")
 	}
 
 	availableFlavors := ""
-	for _, f := range *flavors {
+	for _, f := range flavors {
 		if f.Id == nil || f.Cpu == nil || f.Memory == nil {
 			continue
 		}
@@ -91,7 +91,7 @@ func LoadFlavorId(cpu, ram int64, flavors *[]sqlserverflex.InstanceFlavorEntry) 
 }
 
 func GetInstanceName(ctx context.Context, apiClient SQLServerFlexClient, projectId, instanceId, region string) (string, error) {
-	resp, err := apiClient.GetInstanceExecute(ctx, projectId, instanceId, region)
+	resp, err := apiClient.GetInstance(ctx, projectId, instanceId, region).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get SQLServer Flex instance: %w", err)
 	}
@@ -99,7 +99,7 @@ func GetInstanceName(ctx context.Context, apiClient SQLServerFlexClient, project
 }
 
 func GetUserName(ctx context.Context, apiClient SQLServerFlexClient, projectId, instanceId, userId, region string) (string, error) {
-	resp, err := apiClient.GetUserExecute(ctx, projectId, instanceId, userId, region)
+	resp, err := apiClient.GetUser(ctx, projectId, instanceId, userId, region).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get SQLServer Flex user: %w", err)
 	}

--- a/internal/pkg/services/sqlserverflex/utils/utils_test.go
+++ b/internal/pkg/services/sqlserverflex/utils/utils_test.go
@@ -9,16 +9,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 )
 
 var (
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
 	testUserId     = uuid.NewString()
-
-	// enforce implementation of interfaces
-	_ SQLServerFlexClient = &sqlServerFlexClientMocked{}
 )
 
 const (
@@ -27,7 +24,7 @@ const (
 	testRegion       = "eu01"
 )
 
-type sqlServerFlexClientMocked struct {
+type mockSettings struct {
 	listVersionsFails    bool
 	listVersionsResp     *sqlserverflex.ListVersionsResponse
 	getInstanceFails     bool
@@ -38,32 +35,33 @@ type sqlServerFlexClientMocked struct {
 	listRestoreJobsResp  *sqlserverflex.ListRestoreJobsResponse
 }
 
-func (m *sqlServerFlexClientMocked) ListVersionsExecute(_ context.Context, _, _ string) (*sqlserverflex.ListVersionsResponse, error) {
-	if m.listVersionsFails {
-		return nil, fmt.Errorf("could not list versions")
+func newApiMock(s *mockSettings) sqlserverflex.DefaultAPI {
+	return &sqlserverflex.DefaultAPIServiceMock{
+		ListVersionsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListVersionsRequest) (*sqlserverflex.ListVersionsResponse, error) {
+			if s.listVersionsFails {
+				return nil, fmt.Errorf("could not list versions")
+			}
+			return s.listVersionsResp, nil
+		}),
+		GetInstanceExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiGetInstanceRequest) (*sqlserverflex.GetInstanceResponse, error) {
+			if s.getInstanceFails {
+				return nil, fmt.Errorf("could not get instance")
+			}
+			return s.getInstanceResp, nil
+		}),
+		GetUserExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiGetUserRequest) (*sqlserverflex.GetUserResponse, error) {
+			if s.getUserFails {
+				return nil, fmt.Errorf("could not get user")
+			}
+			return s.getUserResp, nil
+		}),
+		ListRestoreJobsExecuteMock: utils.Ptr(func(_ sqlserverflex.ApiListRestoreJobsRequest) (*sqlserverflex.ListRestoreJobsResponse, error) {
+			if s.listRestoreJobsFails {
+				return nil, fmt.Errorf("could not list versions")
+			}
+			return s.listRestoreJobsResp, nil
+		}),
 	}
-	return m.listVersionsResp, nil
-}
-
-func (m *sqlServerFlexClientMocked) ListRestoreJobsExecute(_ context.Context, _, _, _ string) (*sqlserverflex.ListRestoreJobsResponse, error) {
-	if m.listRestoreJobsFails {
-		return nil, fmt.Errorf("could not list versions")
-	}
-	return m.listRestoreJobsResp, nil
-}
-
-func (m *sqlServerFlexClientMocked) GetInstanceExecute(_ context.Context, _, _, _ string) (*sqlserverflex.GetInstanceResponse, error) {
-	if m.getInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
-	}
-	return m.getInstanceResp, nil
-}
-
-func (m *sqlServerFlexClientMocked) GetUserExecute(_ context.Context, _, _, _, _ string) (*sqlserverflex.GetUserResponse, error) {
-	if m.getUserFails {
-		return nil, fmt.Errorf("could not get user")
-	}
-	return m.getUserResp, nil
 }
 
 func TestValidateStorage(t *testing.T) {
@@ -79,7 +77,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(10)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -99,7 +97,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(1)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -112,7 +110,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(200)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -125,7 +123,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(5)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -138,7 +136,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(20)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -151,7 +149,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(10)),
 			storages: &sqlserverflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "bar-3"},
+				StorageClasses: []string{"bar-1", "bar-2", "bar-3"},
 				StorageRange: &sqlserverflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -178,13 +176,13 @@ func TestValidateFlavorId(t *testing.T) {
 	tests := []struct {
 		description string
 		flavorId    string
-		flavors     *[]sqlserverflex.InstanceFlavorEntry
+		flavors     []sqlserverflex.InstanceFlavorEntry
 		isValid     bool
 	}{
 		{
 			description: "base",
 			flavorId:    "foo",
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{Id: utils.Ptr("bar-1")},
 				{Id: utils.Ptr("bar-2")},
 				{Id: utils.Ptr("foo")},
@@ -200,13 +198,13 @@ func TestValidateFlavorId(t *testing.T) {
 		{
 			description: "no flavors",
 			flavorId:    "foo",
-			flavors:     &[]sqlserverflex.InstanceFlavorEntry{},
+			flavors:     []sqlserverflex.InstanceFlavorEntry{},
 			isValid:     false,
 		},
 		{
 			description: "nil flavor id",
 			flavorId:    "foo",
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{Id: utils.Ptr("bar-1")},
 				{Id: nil},
 				{Id: utils.Ptr("foo")},
@@ -216,7 +214,7 @@ func TestValidateFlavorId(t *testing.T) {
 		{
 			description: "invalid flavor",
 			flavorId:    "foo",
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{Id: utils.Ptr("bar-1")},
 				{Id: utils.Ptr("bar-2")},
 				{Id: utils.Ptr("bar-3")},
@@ -241,9 +239,9 @@ func TestValidateFlavorId(t *testing.T) {
 func TestLoadFlavorId(t *testing.T) {
 	tests := []struct {
 		description    string
-		cpu            int64
-		ram            int64
-		flavors        *[]sqlserverflex.InstanceFlavorEntry
+		cpu            int32
+		ram            int32
+		flavors        []sqlserverflex.InstanceFlavorEntry
 		isValid        bool
 		expectedOutput *string
 	}{
@@ -251,21 +249,21 @@ func TestLoadFlavorId(t *testing.T) {
 			description: "base",
 			cpu:         2,
 			ram:         4,
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     utils.Ptr("foo"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid:        true,
@@ -282,14 +280,14 @@ func TestLoadFlavorId(t *testing.T) {
 			description: "no flavors",
 			cpu:         2,
 			ram:         4,
-			flavors:     &[]sqlserverflex.InstanceFlavorEntry{},
+			flavors:     []sqlserverflex.InstanceFlavorEntry{},
 			isValid:     false,
 		},
 		{
 			description: "flavors with details missing",
 			cpu:         2,
 			ram:         4,
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{
 					Id:     utils.Ptr("bar-1"),
 					Cpu:    nil,
@@ -297,13 +295,13 @@ func TestLoadFlavorId(t *testing.T) {
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     utils.Ptr("foo"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid:        true,
@@ -313,21 +311,21 @@ func TestLoadFlavorId(t *testing.T) {
 			description: "match with nil id",
 			cpu:         2,
 			ram:         4,
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     nil,
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid: false,
@@ -336,16 +334,16 @@ func TestLoadFlavorId(t *testing.T) {
 			description: "invalid settings",
 			cpu:         2,
 			ram:         4,
-			flavors: &[]sqlserverflex.InstanceFlavorEntry{
+			flavors: []sqlserverflex.InstanceFlavorEntry{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid: false,
@@ -404,12 +402,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &sqlServerFlexClientMocked{
+			settings := &mockSettings{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), client, testProjectId, testInstanceId, testRegion)
+			output, err := GetInstanceName(context.Background(), newApiMock(settings), testProjectId, testInstanceId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -454,12 +452,12 @@ func TestGetUserName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &sqlServerFlexClientMocked{
+			settings := &mockSettings{
 				getUserFails: tt.getUserFails,
 				getUserResp:  tt.getUserResp,
 			}
 
-			output, err := GetUserName(context.Background(), client, testProjectId, testInstanceId, testUserId, testRegion)
+			output, err := GetUserName(context.Background(), newApiMock(settings), testProjectId, testInstanceId, testUserId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
