### PR TITLE
chore(readme): fix mise command

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,7 @@
 The STACKIT CLI is available on all major platforms via [mise](https://mise.jdx.dev/):
 
 ```shell
-mise u -g github:/stackitcloud/stackit-cli
+mise u -g github:stackitcloud/stackit-cli
 ```
 
 ### macOS


### PR DESCRIPTION
## Description
Mise command specified in the INSTALLATION.md has an additional forward slash preventing installation.
