### PR TITLE
fix(server): switch to flag for service account email

### DIFF
--- a/docs/stackit_server_service-account_attach.md
+++ b/docs/stackit_server_service-account_attach.md
@@ -7,21 +7,22 @@ Attach a service account to a server
 Attach a service account to a server
 
 ```
-stackit server service-account attach SERVICE_ACCOUNT_EMAIL [flags]
+stackit server service-account attach [flags]
 ```
 
 ### Examples
 
 ```
   Attach a service account with mail "xxx@sa.stackit.cloud" to a server with ID "yyy"
-  $ stackit server service-account attach xxx@sa.stackit.cloud --server-id yyy
+  $ stackit server service-account attach --service-account-email xxx@sa.stackit.cloud --server-id yyy
 ```
 
 ### Options
 
 ```
-  -h, --help               Help for "stackit server service-account attach"
-  -s, --server-id string   Server ID
+  -h, --help                           Help for "stackit server service-account attach"
+  -s, --server-id string               Server ID
+  -a, --service-account-email string   Service Account Email
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_server_service-account_detach.md
+++ b/docs/stackit_server_service-account_detach.md
@@ -7,21 +7,22 @@ Detach a service account from a server
 Detach a service account from a server
 
 ```
-stackit server service-account detach SERVICE_ACCOUNT_EMAIL [flags]
+stackit server service-account detach [flags]
 ```
 
 ### Examples
 
 ```
   Detach a service account with mail "xxx@sa.stackit.cloud" from a server "yyy"
-  $ stackit server service-account detach xxx@sa.stackit.cloud --server-id yyy
+  $ stackit server service-account detach --service-account-email xxx@sa.stackit.cloud --server-id yyy
 ```
 
 ### Options
 
 ```
-  -h, --help               Help for "stackit server service-account detach"
-  -s, --server-id string   Server id
+  -h, --help                           Help for "stackit server service-account detach"
+  -s, --server-id string               Server id
+  -a, --service-account-email string   Service Account Email
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -38,7 +38,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   "attach",
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(
 				`Attach a service account with mail "xxx@sa.stackit.cloud" to a server with ID "yyy"`,

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -106,7 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = inputArgs[0]
 		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
-		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or as a positional argument`, serviceAccFlag)
+		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}
 
 	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -3,6 +3,7 @@ package attach
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -23,6 +24,8 @@ const (
 	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL"
 
 	serverIdFlag = "server-id"
+
+	serviceAccFlag = "service-account-email"
 )
 
 type inputModel struct {
@@ -33,14 +36,14 @@ type inputModel struct {
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("attach %s", serviceAccMailArg),
+		Use:   fmt.Sprintf("attach"),
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
-		Args:  args.SingleArg(serviceAccMailArg, nil),
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2027-01
 		Example: examples.Build(
 			examples.NewExample(
 				`Attach a service account with mail "xxx@sa.stackit.cloud" to a server with ID "yyy"`,
-				"$ stackit server service-account attach xxx@sa.stackit.cloud --server-id yyy",
+				"$ stackit server service-account attach --service-account-email xxx@sa.stackit.cloud --server-id yyy",
 			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,16 +88,29 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
-
+	cmd.Flags().StringP(serviceAccFlag, "a", "", "Service Account Email")
 	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
 	cobra.CheckErr(err)
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
-	serviceAccMail := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
 		return nil, &errors.ProjectIdError{}
+	}
+
+	var serviceAccMail string
+	if cmd.Flags().Changed(serviceAccFlag) {
+		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
+	} else if len(inputArgs) > 0 {
+		serviceAccMail = inputArgs[0]
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
+	} else {
+		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or as a positional argument`, serviceAccFlag)
+	}
+
+	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {
+		return nil, fmt.Errorf("invalid service account email format: %q", serviceAccMail)
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
 
 	serverIdFlag = "server-id"
 
@@ -39,7 +39,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   "attach",
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
 		Example: examples.Build(
 			examples.NewExample(
 				`Attach a service account with mail "xxx@sa.stackit.cloud" to a server with ID "yyy"`,
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed on 2026-12-03. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("attach"),
+		Use:   "attach",
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
 		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -88,7 +88,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
-	cmd.Flags().StringP(serviceAccFlag, "a", "", "Service Account Email")
+	cmd.Flags().VarP(flags.EmailFlag(), serviceAccFlag, "a", "Service Account Email")
 	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
 	cobra.CheckErr(err)
 }

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed on 2026-12-03. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12-31
 
 	serverIdFlag = "server-id"
 

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -103,7 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("Using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use the '--%s' flag instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -3,7 +3,6 @@ package attach
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -107,10 +106,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
-	}
-
-	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {
-		return nil, fmt.Errorf("invalid service account email format: %q", serviceAccMail)
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/service-account/attach/attach.go
+++ b/internal/cmd/server/service-account/attach/attach.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL"
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
 
 	serverIdFlag = "server-id"
 
@@ -39,7 +39,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   fmt.Sprintf("attach"),
 		Short: "Attach a service account to a server",
 		Long:  "Attach a service account to a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2027-01
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
 		Example: examples.Build(
 			examples.NewExample(
 				`Attach a service account with mail "xxx@sa.stackit.cloud" to a server with ID "yyy"`,

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -106,7 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = inputArgs[0]
 		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
-		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or as a positional argument`, serviceAccFlag)
+		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}
 
 	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
 
 	serverIdFlag = "server-id"
 
@@ -39,7 +39,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   "detach",
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
 		Example: examples.Build(
 			examples.NewExample(
 				`Detach a service account with mail "xxx@sa.stackit.cloud" from a server "yyy"`,
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed on 2026-12-03. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -3,7 +3,6 @@ package detach
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -107,10 +106,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
-	}
-
-	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {
-		return nil, fmt.Errorf("invalid service account email format: %q", serviceAccMail)
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL"
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
 
 	serverIdFlag = "server-id"
 
@@ -39,7 +39,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   fmt.Sprintf("detach"),
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2027-01
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03
 		Example: examples.Build(
 			examples.NewExample(
 				`Detach a service account with mail "xxx@sa.stackit.cloud" from a server "yyy"`,

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -3,6 +3,7 @@ package detach
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -23,6 +24,8 @@ const (
 	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL"
 
 	serverIdFlag = "server-id"
+
+	serviceAccFlag = "service-account-email"
 )
 
 type inputModel struct {
@@ -33,14 +36,14 @@ type inputModel struct {
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("detach %s", serviceAccMailArg),
+		Use:   fmt.Sprintf("detach"),
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
-		Args:  args.SingleArg(serviceAccMailArg, nil),
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2027-01
 		Example: examples.Build(
 			examples.NewExample(
 				`Detach a service account with mail "xxx@sa.stackit.cloud" from a server "yyy"`,
-				"$ stackit server service-account detach xxx@sa.stackit.cloud --server-id yyy",
+				"$ stackit server service-account detach --service-account-email xxx@sa.stackit.cloud --server-id yyy",
 			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,16 +88,29 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server id")
-
+	cmd.Flags().StringP(serviceAccFlag, "a", "", "Service Account Email")
 	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
 	cobra.CheckErr(err)
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
-	serviceAccMail := inputArgs[0]
 	globalFlags := globalflags.Parse(p, cmd)
 	if globalFlags.ProjectId == "" {
 		return nil, &errors.ProjectIdError{}
+	}
+
+	var serviceAccMail string
+	if cmd.Flags().Changed(serviceAccFlag) {
+		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
+	} else if len(inputArgs) > 0 {
+		serviceAccMail = inputArgs[0]
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
+	} else {
+		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or as a positional argument`, serviceAccFlag)
+	}
+
+	if serviceAccMail == "" || !strings.Contains(serviceAccMail, "@") {
+		return nil, fmt.Errorf("invalid service account email format: %q", serviceAccMail)
 	}
 
 	model := inputModel{

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed in 2027-01. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("using a positional argument for the service account email is deprecated and will be removed on 2026-12-03. Please use '--%s' instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
+	serviceAccMailArg = "SERVICE_ACCOUNT_EMAIL" // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12-31
 
 	serverIdFlag = "server-id"
 

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -38,7 +38,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Use:   "detach",
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
-		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed after 2026-12
+		Args:  args.SingleOptionalArg(serviceAccMailArg, nil),
 		Example: examples.Build(
 			examples.NewExample(
 				`Detach a service account with mail "xxx@sa.stackit.cloud" from a server "yyy"`,

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -103,7 +103,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		serviceAccMail = flags.FlagToStringValue(p, cmd, serviceAccFlag)
 	} else if len(inputArgs) > 0 {
 		serviceAccMail = inputArgs[0]
-		p.Warn("using a positional argument for the service account email is deprecated and will be removed after 2026-12. Please use '--%s' instead.\n", serviceAccFlag)
+		p.Warn("Using a positional argument for the service account email is deprecated and will be removed after 2026-12-31. Please use the '--%s' flag instead.\n", serviceAccFlag)
 	} else {
 		return nil, fmt.Errorf(`service account must be specified by using either the --%s flag or (deprecated) as a positional argument`, serviceAccFlag)
 	}

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -36,7 +36,7 @@ type inputModel struct {
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("detach"),
+		Use:   "detach",
 		Short: "Detach a service account from a server",
 		Long:  "Detach a service account from a server",
 		Args:  args.SingleOptionalArg(serviceAccMailArg, nil), // Deprecated: positional argument is not used anymore, use the flag instead, will be removed 2026-12-03

--- a/internal/cmd/server/service-account/detach/detach.go
+++ b/internal/cmd/server/service-account/detach/detach.go
@@ -88,7 +88,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server id")
-	cmd.Flags().StringP(serviceAccFlag, "a", "", "Service Account Email")
+	cmd.Flags().VarP(flags.EmailFlag(), serviceAccFlag, "a", "Service Account Email")
 	err := flags.MarkFlagsRequired(cmd, serverIdFlag)
 	cobra.CheckErr(err)
 }

--- a/internal/pkg/flags/email.go
+++ b/internal/pkg/flags/email.go
@@ -1,0 +1,37 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type emailFlag struct {
+	value string
+}
+
+// Ensure the implementation satisfies the expected interface
+var _ pflag.Value = &emailFlag{}
+
+// EmailFlag returns a flag which must be a valid Email.
+func EmailFlag() *emailFlag {
+	return &emailFlag{}
+}
+
+func (f *emailFlag) String() string {
+	return f.value
+}
+
+func (f *emailFlag) Set(value string) error {
+	isEmail := value != "" && strings.Contains(value, "@")
+	if !isEmail {
+		return fmt.Errorf("invalid email address: %s", value)
+	}
+	f.value = value
+	return nil
+}
+
+func (f *emailFlag) Type() string {
+	return "string"
+}

--- a/internal/pkg/flags/email_test.go
+++ b/internal/pkg/flags/email_test.go
@@ -1,0 +1,61 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestEmailFlag(t *testing.T) {
+	tests := []struct {
+		description string
+		value       string
+		isValid     bool
+	}{
+		{
+			description: "valid",
+			value:       "test@test",
+			isValid:     true,
+		},
+		{
+			description: "empty",
+			value:       "",
+			isValid:     false,
+		},
+		{
+			description: "invalid",
+			value:       "invalid-uuid",
+			isValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			flag := EmailFlag()
+			cmd := &cobra.Command{
+				Use: "test",
+				RunE: func(_ *cobra.Command, _ []string) error {
+					return nil
+				},
+			}
+			cmd.Flags().Var(flag, "test-flag", "test")
+
+			err := cmd.Flags().Set("test-flag", tt.value)
+
+			if !tt.isValid && err == nil {
+				t.Fatalf("did not fail on invalid input")
+			}
+			if !tt.isValid {
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("failed on valid input: %v", err)
+			}
+			value := FlagToStringValue(nil, cmd, "test-flag")
+			if value != tt.value {
+				t.Fatalf("flag did not return set value")
+			}
+		})
+	}
+}

--- a/internal/pkg/flags/email_test.go
+++ b/internal/pkg/flags/email_test.go
@@ -24,7 +24,7 @@ func TestEmailFlag(t *testing.T) {
 		},
 		{
 			description: "invalid",
-			value:       "invalid-uuid",
+			value:       "invalid-email",
 			isValid:     false,
 		},
 	}


### PR DESCRIPTION
## Description

Align server service-account attach/detach with other subcommands (e.g. server network-interface attach/detach).

relates to STACKITCLI-346

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
