### PR TITLE
feat(object-storage): fix credentials create nil pointer

### DIFF
--- a/internal/cmd/object-storage/credentials/create/create.go
+++ b/internal/cmd/object-storage/credentials/create/create.go
@@ -134,7 +134,7 @@ func outputResult(p *print.Printer, outputFormat, credentialsGroupLabel string, 
 
 	return p.OutputResult(outputFormat, resp, func() error {
 		expireDate := "Never"
-		if resp.Expires.IsSet() && *resp.Expires.Get() != "" {
+		if resp.Expires.IsSet() && resp.Expires.Get() != nil && *resp.Expires.Get() != "" {
 			expireDate = *resp.Expires.Get()
 		}
 

--- a/internal/cmd/object-storage/credentials/create/create_test.go
+++ b/internal/cmd/object-storage/credentials/create/create_test.go
@@ -238,6 +238,15 @@ func TestOutputResult(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "minimal",
+			args: args{
+				createAccessKeyResponse: &objectstorage.CreateAccessKeyResponse{
+					Expires: *objectstorage.NewNullableString(nil),
+				},
+			},
+			wantErr: false,
+		},
 	}
 	params := testparams.NewTestParams()
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

see title

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
