### PR TITLE
chore(git): migrate to new SDK structure

### DIFF
--- a/docs/stackit_git_instance.md
+++ b/docs/stackit_git_instance.md
@@ -33,5 +33,5 @@ stackit git instance [flags]
 * [stackit git instance create](./stackit_git_instance_create.md)	 - Creates STACKIT Git instance
 * [stackit git instance delete](./stackit_git_instance_delete.md)	 - Deletes STACKIT Git instance
 * [stackit git instance describe](./stackit_git_instance_describe.md)	 - Describes STACKIT Git instance
-* [stackit git instance list](./stackit_git_instance_list.md)	 - Lists all instances of STACKIT Git.
+* [stackit git instance list](./stackit_git_instance_list.md)	 - Lists all instances of STACKIT Git
 

--- a/docs/stackit_git_instance_list.md
+++ b/docs/stackit_git_instance_list.md
@@ -1,6 +1,6 @@
 ## stackit git instance list
 
-Lists all instances of STACKIT Git.
+Lists all instances of STACKIT Git
 
 ### Synopsis
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6
 	github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3
-	github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3
+	github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1
 	github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,8 @@ github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6 h1:GBRb49x5Nax/oQQaa
 github.com/stackitcloud/stackit-sdk-go/services/dns v0.17.6/go.mod h1:IX9iL3MigDZUmzwswTJMfYvyi118KAHrFMfjJUy5NYk=
 github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3 h1:TxChb2qbO82JiQEBYClSSD5HZxqKeKJ6dIvkEUCJmbs=
 github.com/stackitcloud/stackit-sdk-go/services/edge v0.4.3/go.mod h1:KVWvQHb7CQLD9DzA4Np3WmakiCCsrHaCXvFEnOQ7nPk=
-github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3 h1:VIjkSofZz9utOOkBdNZCIb07P/JdKc1kHV1P8Rq9dLc=
-github.com/stackitcloud/stackit-sdk-go/services/git v0.10.3/go.mod h1:EJk1Ss9GTel2NPIu/w3+x9XcQcEd2k3ibea5aQDzVhQ=
+github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0 h1:VZBneGprCmHqckcSMPs3puBlK8rBpLMtYKmBktwdoVE=
+github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0/go.mod h1:YZEL+gaK+ELn5E9VtK8yvz5RcmCBH+JkRpf6YbNVSbM=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0 h1:H4V3H8qSKOaOalIrf4nAPDHhXnHYGs6SDGuK8Zj41Zo=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0/go.mod h1:Ts06id0KejUlQWbpR+/rm+tKng6QkTuFV1VQTPJ4dA4=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1 h1:7ZSrwps/zI41rl+xYkG4osld8cyAwssyl/UZ/Iu/F2g=
@@ -654,8 +654,6 @@ github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZ
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0/go.mod h1:jMlBoXqrPNX5nXbo6oT7exalqilw1jiLPoIp4Cn0CdI=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0 h1:QoKyQPe8FqDqJLNgE5uRlZ/y1c1GUxjV1DDLu5QEBD8=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0/go.mod h1:KhVYCR58wETqdI7Quwhe3OR3BhB2T/b7DzaMsfDnr8g=
-github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.4.3 h1:AQrcr+qeIuZob+3TT2q1L4WOPtpsu5SEpkTnOUHDqfE=
-github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.4.3/go.mod h1:8BBGC69WFXWWmKgzSjgE4HvsI7pEgO0RN2cASwuPJ18=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0 h1:PwjQeupEnXxhu+uWCUzO/hUfL4yqNblOcZbP2jvaQtU=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
 github.com/stbenjam/no-sprintf-host-port v0.3.1 h1:AyX7+dxI4IdLBPtDbsGAyqiTSLpCP9hWRrXQDU4Cm/g=

--- a/internal/cmd/git/flavor/list/list.go
+++ b/internal/cmd/git/flavor/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/git/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type inputModel struct {
@@ -110,7 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClient) git.ApiListFlavorsRequest {
-	return apiClient.ListFlavors(ctx, model.ProjectId)
+	return apiClient.DefaultAPI.ListFlavors(ctx, model.ProjectId)
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, flavors []git.Flavor) error {
@@ -125,11 +124,11 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, flavors [
 		for i := range flavors {
 			flavor := (flavors)[i]
 			table.AddRow(
-				utils.PtrString(flavor.Id),
-				utils.PtrString(flavor.Description),
-				utils.PtrString(flavor.DisplayName),
-				utils.PtrString(flavor.Availability),
-				utils.PtrString(flavor.Sku),
+				flavor.Id,
+				flavor.Description,
+				flavor.DisplayName,
+				flavor.Availability,
+				flavor.Sku,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/git/flavor/list/list_test.go
+++ b/internal/cmd/git/flavor/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -19,7 +19,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &git.APIClient{}
+var testClient = &git.APIClient{DefaultAPI: &git.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 const (
@@ -50,7 +50,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *git.ApiListFlavorsRequest)) git.ApiListFlavorsRequest {
-	request := testClient.ListFlavors(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListFlavors(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -148,7 +148,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, git.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/git/instance/create/create.go
+++ b/internal/cmd/git/instance/create/create.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
-	"github.com/stackitcloud/stackit-sdk-go/services/git/wait"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -82,8 +83,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
-				err := spinner.Run(params.Printer, "Creating STACKIT git instance", func() error {
-					_, err = wait.CreateGitInstanceWaitHandler(ctx, apiClient, model.ProjectId, *result.Id).WaitWithContext(ctx)
+				err := spinner.Run(params.Printer, "Creating STACKIT Git instance", func() error {
+					_, err = wait.CreateGitInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, result.Id).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -130,14 +131,14 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClient) git.ApiCreateInstanceRequest {
-	return apiClient.CreateInstance(ctx, model.ProjectId).CreateInstancePayload(createPayload(model))
+	return apiClient.DefaultAPI.CreateInstance(ctx, model.ProjectId).CreateInstancePayload(createPayload(model))
 }
 
 func createPayload(model *inputModel) git.CreateInstancePayload {
 	return git.CreateInstancePayload{
-		Name:   &model.Name,
-		Flavor: git.CreateInstancePayloadGetFlavorAttributeType(&model.Flavor),
-		Acl:    &model.Acl,
+		Name:   model.Name,
+		Flavor: utils.Ptr(git.CreateInstancePayloadFlavor(model.Flavor)),
+		Acl:    model.Acl,
 	}
 }
 
@@ -145,16 +146,13 @@ func outputResult(p *print.Printer, outputFormat string, async bool, instanceNam
 	if resp == nil {
 		return fmt.Errorf("API resp is nil")
 	}
-	if resp.Id == nil {
-		return fmt.Errorf("API resp is missing instance id")
-	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
 		operationState := "Created"
 		if async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s instance %q with id %s\n", operationState, instanceName, *resp.Id)
+		p.Outputf("%s instance %q with id %s\n", operationState, instanceName, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/git/instance/create/create_test.go
+++ b/internal/cmd/git/instance/create/create_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -20,7 +20,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &git.APIClient{}
+	testClient    = &git.APIClient{DefaultAPI: &git.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 
 	testName   = "test-instance"
@@ -57,9 +57,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 func fixtureCreatePayload(mods ...func(payload *git.CreateInstancePayload)) (payload git.CreateInstancePayload) {
 	payload = git.CreateInstancePayload{
-		Name:   &testName,
-		Flavor: git.CreateInstancePayloadGetFlavorAttributeType(&testFlavor),
-		Acl:    &testAcl,
+		Name:   testName,
+		Flavor: utils.Ptr(git.CreateInstancePayloadFlavor(testFlavor)),
+		Acl:    testAcl,
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -68,7 +68,7 @@ func fixtureCreatePayload(mods ...func(payload *git.CreateInstancePayload)) (pay
 }
 
 func fixtureRequest(mods ...func(request *git.ApiCreateInstanceRequest)) git.ApiCreateInstanceRequest {
-	request := testClient.CreateInstance(testCtx, testProjectId)
+	request := testClient.DefaultAPI.CreateInstance(testCtx, testProjectId)
 
 	request = request.CreateInstancePayload(fixtureCreatePayload())
 
@@ -151,8 +151,8 @@ func TestBuildRequest(t *testing.T) {
 				model.Name = "new-name"
 			}),
 			expectedRequest: fixtureRequest(func(request *git.ApiCreateInstanceRequest) {
-				*request = (*request).CreateInstancePayload(fixtureCreatePayload(func(payload *git.CreateInstancePayload) {
-					payload.Name = utils.Ptr("new-name")
+				*request = request.CreateInstancePayload(fixtureCreatePayload(func(payload *git.CreateInstancePayload) {
+					payload.Name = "new-name"
 				}))
 			}),
 		},
@@ -164,7 +164,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
-				cmp.AllowUnexported(git.NullableString{}),
+				cmp.AllowUnexported(git.NullableString{}, git.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -201,7 +201,7 @@ func TestOutputResult(t *testing.T) {
 				outputFormat: "",
 				async:        false,
 				instanceName: "",
-				resp:         &git.Instance{Id: utils.Ptr(uuid.NewString())},
+				resp:         &git.Instance{Id: uuid.NewString()},
 			},
 			wantErr: false,
 		},
@@ -211,7 +211,7 @@ func TestOutputResult(t *testing.T) {
 				outputFormat: print.JSONOutputFormat,
 				async:        true,
 				instanceName: testName,
-				resp:         &git.Instance{Id: utils.Ptr(uuid.NewString())},
+				resp:         &git.Instance{Id: uuid.NewString()},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/git/instance/delete/delete.go
+++ b/internal/cmd/git/instance/delete/delete.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
-	"github.com/stackitcloud/stackit-sdk-go/services/git/wait"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
+	"github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				projectName = model.ProjectId
 			}
 
-			instanceName, err := gitUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceName, err := gitUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get stackit git intance name: %v", err)
 				instanceName = model.InstanceId
@@ -82,8 +82,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
-				err := spinner.Run(params.Printer, "Deleting STACKIT git instance", func() error {
-					_, err = wait.DeleteGitInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId).WaitWithContext(ctx)
+				err := spinner.Run(params.Printer, "Deleting STACKIT Git instance", func() error {
+					_, err = wait.DeleteGitInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -120,5 +120,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClient) git.ApiDeleteInstanceRequest {
-	return apiClient.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
+	return apiClient.DefaultAPI.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
 }

--- a/internal/cmd/git/instance/delete/delete_test.go
+++ b/internal/cmd/git/instance/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -18,7 +18,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx        = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient     = &git.APIClient{}
+	testClient     = &git.APIClient{DefaultAPI: &git.DefaultAPIService{}}
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
 )
@@ -45,7 +45,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *git.ApiDeleteInstanceRequest)) git.ApiDeleteInstanceRequest {
-	request := testClient.DeleteInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.DeleteInstance(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -172,7 +172,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, git.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/git/instance/describe/describe.go
+++ b/internal/cmd/git/instance/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -83,7 +83,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, cliArgs []string) (*inputM
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClient) git.ApiGetInstanceRequest {
-	return apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId)
+	return apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId)
 }
 
 func outputResult(p *print.Printer, outputFormat string, resp *git.Instance) error {
@@ -93,30 +93,19 @@ func outputResult(p *print.Printer, outputFormat string, resp *git.Instance) err
 
 	return p.OutputResult(outputFormat, resp, func() error {
 		table := tables.NewTable()
-		if id := resp.Id; id != nil {
-			table.AddRow("ID", *id)
-			table.AddSeparator()
-		}
-		if name := resp.Name; name != nil {
-			table.AddRow("NAME", *name)
-			table.AddSeparator()
-		}
-		if url := resp.Url; url != nil {
-			table.AddRow("URL", *url)
-			table.AddSeparator()
-		}
-		if version := resp.Version; version != nil {
-			table.AddRow("VERSION", *version)
-			table.AddSeparator()
-		}
-		if state := resp.State; state != nil {
-			table.AddRow("STATE", *state)
-			table.AddSeparator()
-		}
-		if created := resp.Created; created != nil {
-			table.AddRow("CREATED", *created)
-			table.AddSeparator()
-		}
+
+		table.AddRow("ID", resp.Id)
+		table.AddSeparator()
+		table.AddRow("NAME", resp.Name)
+		table.AddSeparator()
+		table.AddRow("URL", resp.Url)
+		table.AddSeparator()
+		table.AddRow("VERSION", resp.Version)
+		table.AddSeparator()
+		table.AddRow("STATE", resp.State)
+		table.AddSeparator()
+		table.AddRow("CREATED", resp.Created)
+		table.AddSeparator()
 
 		if err := table.Display(p); err != nil {
 			return fmt.Errorf("render table: %w", err)

--- a/internal/cmd/git/instance/describe/describe_test.go
+++ b/internal/cmd/git/instance/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -18,7 +18,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx        = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient     = &git.APIClient{}
+	testClient     = &git.APIClient{DefaultAPI: &git.DefaultAPIService{}}
 	testProjectId  = uuid.NewString()
 	testInstanceId = []string{uuid.NewString()}
 )
@@ -45,7 +45,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *git.ApiGetInstanceRequest)) git.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId[0])
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId[0])
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -183,7 +183,7 @@ func TestBuildRequest(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, git.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/git/instance/list/list.go
+++ b/internal/cmd/git/instance/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/git/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type inputModel struct {
@@ -31,7 +30,7 @@ const limitFlag = "limit"
 func NewCmd(params *types.CmdParams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists all instances of STACKIT Git.",
+		Short: "Lists all instances of STACKIT Git",
 		Long:  "Lists all instances of STACKIT Git for the current project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
@@ -110,7 +109,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *git.APIClient) git.ApiListInstancesRequest {
-	return apiClient.ListInstances(ctx, model.ProjectId)
+	return apiClient.DefaultAPI.ListInstances(ctx, model.ProjectId)
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, instances []git.Instance) error {
@@ -125,12 +124,12 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, instances
 		for i := range instances {
 			instance := (instances)[i]
 			table.AddRow(
-				utils.PtrString(instance.Id),
-				utils.PtrString(instance.Name),
-				utils.PtrString(instance.Url),
-				utils.PtrString(instance.Version),
-				utils.PtrString(instance.State),
-				utils.PtrString(instance.Created),
+				instance.Id,
+				instance.Name,
+				instance.Url,
+				instance.Version,
+				instance.State,
+				instance.Created,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/git/instance/list/list_test.go
+++ b/internal/cmd/git/instance/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -19,7 +19,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &git.APIClient{}
+var testClient = &git.APIClient{DefaultAPI: &git.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 const (
@@ -50,7 +50,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *git.ApiListInstancesRequest)) git.ApiListInstancesRequest {
-	request := testClient.ListInstances(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListInstances(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -148,7 +148,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, git.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/pkg/services/git/client/client.go
+++ b/internal/pkg/services/git/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*git.APIClient, error) {

--- a/internal/pkg/services/git/utils/utils.go
+++ b/internal/pkg/services/git/utils/utils.go
@@ -4,20 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 )
 
-type GitClient interface {
-	GetInstanceExecute(ctx context.Context, projectId string, instanceId string) (*git.Instance, error)
-}
-
-func GetInstanceName(ctx context.Context, apiClient GitClient, projectId, instanceId string) (string, error) {
-	resp, err := apiClient.GetInstanceExecute(ctx, projectId, instanceId)
+func GetInstanceName(ctx context.Context, apiClient git.DefaultAPI, projectId, instanceId string) (string, error) {
+	resp, err := apiClient.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get instance: %w", err)
 	}
-	if resp.Name == nil {
-		return "", nil
-	}
-	return *resp.Name, nil
+	return resp.Name, nil
 }

--- a/internal/pkg/services/git/utils/utils_test.go
+++ b/internal/pkg/services/git/utils/utils_test.go
@@ -5,21 +5,26 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/git"
+	git "github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
-type GitClientMocked struct {
+type mockSettings struct {
 	GetInstanceFails bool
 	GetInstanceResp  *git.Instance
 }
 
-func (m *GitClientMocked) GetInstanceExecute(_ context.Context, _, _ string) (*git.Instance, error) {
-	if m.GetInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
+func newAPIMock(settings *mockSettings) git.DefaultAPI {
+	return &git.DefaultAPIServiceMock{
+		GetInstanceExecuteMock: utils.Ptr(func(_ git.ApiGetInstanceRequest) (*git.Instance, error) {
+			if settings.GetInstanceFails {
+				return nil, fmt.Errorf("could not get instance details")
+			}
+
+			return settings.GetInstanceResp, nil
+		}),
 	}
-	return m.GetInstanceResp, nil
 }
 
 func TestGetinstanceName(t *testing.T) {
@@ -31,10 +36,12 @@ func TestGetinstanceName(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "successful retrieval",
-			instanceResp: &git.Instance{Name: utils.Ptr("test-instance")},
-			want:         "test-instance",
-			wantErr:      false,
+			name: "successful retrieval",
+			instanceResp: &git.Instance{
+				Name: "test-instance",
+			},
+			want:    "test-instance",
+			wantErr: false,
 		},
 		{
 			name:        "error on retrieval",
@@ -50,10 +57,10 @@ func TestGetinstanceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := &GitClientMocked{
+			client := newAPIMock(&mockSettings{
 				GetInstanceFails: tt.instanceErr,
 				GetInstanceResp:  tt.instanceResp,
-			}
+			})
 			got, err := GetInstanceName(context.Background(), client, "", "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetInstanceName() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## Description

relates to STACKITCLI-363

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
