### PR TITLE
fix(iaas): update examples and fix the payload for boot volumes

### DIFF
--- a/docs/stackit_server_create.md
+++ b/docs/stackit_server_create.md
@@ -47,7 +47,6 @@ stackit server create [flags]
       --boot-volume-source-id string           ID of the source object of boot volume. It can be either an image or volume ID
       --boot-volume-source-type string         Type of the source object of boot volume. It can be either  'image' or 'volume'
   -h, --help                                   Help for "stackit server create"
-      --image-id string                        The image ID to be used for an ephemeral disk on the server. Either 'image-id' or 'boot-volume-...' flags are required
       --keypair-name string                    The name of the SSH keypair used during the server creation
       --labels stringToString                  Labels are key-value string pairs which can be attached to a server. E.g. '--labels key1=value1,key2=value2,...' (default [])
       --machine-type string                    Name of the type of the machine for the server. Possible values are documented in https://docs.stackit.cloud/products/compute-engine/server/basics/machine-types/

--- a/docs/stackit_server_create.md
+++ b/docs/stackit_server_create.md
@@ -13,35 +13,26 @@ stackit server create [flags]
 ### Examples
 
 ```
-  Create a server from an image with id xxx
-  $ stackit server create --machine-type t1.1 --name server1 --image-id xxx
-
-  Create a server with labels from an image with id xxx
-  $ stackit server create --machine-type t1.1 --name server1 --image-id xxx --labels key=value,foo=bar
-
-  Create a server with a boot volume
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64
+  Create a server with a boot volume with source type image
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64
 
   Create a server with a boot volume from an existing volume
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type volume
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type volume
 
   Create a server with a keypair
-  $ stackit server create --machine-type t1.1 --name server1 --image-id xxx --keypair-name example
-
-  Create a server with a network
-  $ stackit server create --machine-type t1.1 --name server1 --image-id xxx --network-id yyy
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --keypair-name example
 
   Create a server with a network interface
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-interface-ids yyy
+  $ stackit server create --machine-type g2i.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-interface-ids yyy
 
   Create a server with an attached volume
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --volumes yyy
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --volumes zzz
 
   Create a server with user data (cloud-init)
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml
 
   Create a server with provisioned agent
-  $ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-id yyy --agent-provisioning-policy ALWAYS
+  $ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --agent-provisioning-policy ALWAYS
 ```
 
 ### Options

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -182,6 +182,11 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive(imageIdFlag, bootVolumeSourceTypeFlag)
 	cmd.MarkFlagsMutuallyExclusive(networkIdFlag, networkInterfaceIdsFlag)
 	cmd.MarkFlagsOneRequired(networkIdFlag, networkInterfaceIdsFlag)
+
+	// hide image-id flag from help command to prevent users from using it alone which leads to errors
+	// instead of using image-id alone, boot-volume flags can be used with type image
+	cobra.CheckErr(cmd.Flags().MarkHidden(imageIdFlag))
+
 	cobra.CheckErr(err)
 }
 

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -183,7 +183,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive(networkIdFlag, networkInterfaceIdsFlag)
 	cmd.MarkFlagsOneRequired(networkIdFlag, networkInterfaceIdsFlag)
 
-	// hide image-id flag from help command to prevent users from using it alone which leads to errors
+	// hide image-id flag from help command to prevent users from using it alone which leads to errors, because it works only with small images
 	// instead of using image-id alone, boot-volume flags can be used with type image
 	cobra.CheckErr(cmd.Flags().MarkHidden(imageIdFlag))
 

--- a/internal/cmd/server/create/create.go
+++ b/internal/cmd/server/create/create.go
@@ -76,44 +76,32 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(
-				`Create a server from an image with id xxx`,
-				`$ stackit server create --machine-type t1.1 --name server1 --image-id xxx`,
-			),
-			examples.NewExample(
-				`Create a server with labels from an image with id xxx`,
-				`$ stackit server create --machine-type t1.1 --name server1 --image-id xxx --labels key=value,foo=bar`,
-			),
-			examples.NewExample(
-				`Create a server with a boot volume`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64`,
+				`Create a server with a boot volume with source type image`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64`,
 			),
 			examples.NewExample(
 				`Create a server with a boot volume from an existing volume`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type volume`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type volume`,
 			),
 			examples.NewExample(
 				`Create a server with a keypair`,
-				`$ stackit server create --machine-type t1.1 --name server1 --image-id xxx --keypair-name example`,
-			),
-			examples.NewExample(
-				`Create a server with a network`,
-				`$ stackit server create --machine-type t1.1 --name server1 --image-id xxx --network-id yyy`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --keypair-name example`,
 			),
 			examples.NewExample(
 				`Create a server with a network interface`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-interface-ids yyy`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-interface-ids yyy`,
 			),
 			examples.NewExample(
 				`Create a server with an attached volume`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --volumes yyy`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --volumes zzz`,
 			),
 			examples.NewExample(
 				`Create a server with user data (cloud-init)`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --user-data @path/to/file.yaml`,
 			),
 			examples.NewExample(
 				`Create a server with provisioned agent`,
-				`$ stackit server create --machine-type t1.1 --name server1 --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --network-id yyy --agent-provisioning-policy ALWAYS`,
+				`$ stackit server create --machine-type g2i.1 --name server1 --network-id yyy --boot-volume-source-id xxx --boot-volume-source-type image --boot-volume-size 64 --agent-provisioning-policy ALWAYS`,
 			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -306,7 +294,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 		}
 	}
 
-	if model.BootVolumePerformanceClass != nil || model.BootVolumeSize != nil || model.BootVolumeDeleteOnTermination != nil {
+	if model.BootVolumePerformanceClass != nil || model.BootVolumeSize != nil || model.BootVolumeDeleteOnTermination != nil || (model.BootVolumeSourceId != "" && model.BootVolumeSourceType != "") {
 		payload.BootVolume = &iaas.BootVolume{
 			PerformanceClass:    model.BootVolumePerformanceClass,
 			Size:                model.BootVolumeSize,


### PR DESCRIPTION
## Description

relates to STACKITCLI-404

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
