### PR TITLE
chore(kms): migrate kms to new multi version sdk

### DIFF
--- a/docs/stackit_kms_key_create.md
+++ b/docs/stackit_kms_key_create.md
@@ -35,14 +35,14 @@ stackit kms key create [flags]
 ### Options
 
 ```
-      --algorithm string     En-/Decryption / signing algorithm. Possible values: ["aes_256_gcm" "rsa_2048_oaep_sha256" "rsa_3072_oaep_sha256" "rsa_4096_oaep_sha256" "rsa_4096_oaep_sha512" "hmac_sha256" "hmac_sha384" "hmac_sha512" "ecdsa_p256_sha256" "ecdsa_p384_sha384" "ecdsa_p521_sha512"]
+      --algorithm string     En-/Decryption / signing algorithm. (possible values: [aes_256_gcm, rsa_2048_oaep_sha256, rsa_3072_oaep_sha256, rsa_4096_oaep_sha256, rsa_4096_oaep_sha512, hmac_sha256, hmac_sha384, hmac_sha512, ecdsa_p256_sha256, ecdsa_p384_sha384, ecdsa_p521_sha512])
       --description string   Optional description of the key
   -h, --help                 Help for "stackit kms key create"
       --import-only          States whether versions can be created or only imported
       --keyring-id string    ID of the KMS key ring
       --name string          The display name to distinguish multiple keys
-      --protection string    The underlying system that is responsible for protecting the key material. Possible values: ["symmetric_encrypt_decrypt" "asymmetric_encrypt_decrypt" "message_authentication_code" "asymmetric_sign_verify"]
-      --purpose string       Purpose of the key. Possible values: ["symmetric_encrypt_decrypt" "asymmetric_encrypt_decrypt" "message_authentication_code" "asymmetric_sign_verify"]
+      --protection string    The underlying system that is responsible for protecting the key material. (possible values: [software])
+      --purpose string       Purpose of the key. (possible values: [symmetric_encrypt_decrypt, asymmetric_encrypt_decrypt, message_authentication_code, asymmetric_sign_verify])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_kms_wrapping-key_create.md
+++ b/docs/stackit_kms_wrapping-key_create.md
@@ -23,13 +23,13 @@ stackit kms wrapping-key create [flags]
 ### Options
 
 ```
-      --algorithm string     En-/Decryption / signing algorithm. Possible values: ["rsa_2048_oaep_sha256" "rsa_3072_oaep_sha256" "rsa_4096_oaep_sha256" "rsa_4096_oaep_sha512" "rsa_2048_oaep_sha256_aes_256_key_wrap" "rsa_3072_oaep_sha256_aes_256_key_wrap" "rsa_4096_oaep_sha256_aes_256_key_wrap" "rsa_4096_oaep_sha512_aes_256_key_wrap"]
+      --algorithm string     En-/Decryption / signing algorithm. (possible values: [rsa_2048_oaep_sha256, rsa_3072_oaep_sha256, rsa_4096_oaep_sha256, rsa_4096_oaep_sha512, rsa_2048_oaep_sha256_aes_256_key_wrap, rsa_3072_oaep_sha256_aes_256_key_wrap, rsa_4096_oaep_sha256_aes_256_key_wrap, rsa_4096_oaep_sha512_aes_256_key_wrap])
       --description string   Optional description of the wrapping key
   -h, --help                 Help for "stackit kms wrapping-key create"
       --keyring-id string    ID of the KMS key ring
       --name string          The display name to distinguish multiple wrapping keys
-      --protection string    The underlying system that is responsible for protecting the wrapping key material. Possible values: ["wrap_symmetric_key" "wrap_asymmetric_key"]
-      --purpose string       Purpose of the wrapping key. Possible values: ["wrap_symmetric_key" "wrap_asymmetric_key"]
+      --protection string    The underlying system that is responsible for protecting the key material. (possible values: [software])
+      --purpose string       Purpose of the key. (possible values: [wrap_symmetric_key, wrap_asymmetric_key])
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,8 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0
-	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0
+	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.35.0
@@ -266,7 +266,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0
-	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0
+	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/logme v0.25.6
 	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.25.6
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2
+	github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/logme v0.25.6
 	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.25.6

--- a/go.sum
+++ b/go.sum
@@ -614,6 +614,8 @@ github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1 h1:7ZSrwps/zI41rl+
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1/go.mod h1:ZIvwBZwEMFO+YfJLCNXqabslI0Fp9zxV7ZBwlZjk7uE=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2 h1:2ulSL2IkIAKND59eAjbEhVkOoBMyvm48ojwz1a3t0U0=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2/go.mod h1:cuIaMMiHeHQsbvy7BOFMutoV3QtN+ZBx7Tg3GmYUw7s=
+github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0 h1:OrUaDypQNr1nOXZfVQXCwUpN4YhR5y0vtvYi9/Ogoi4=
+github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0/go.mod h1:pVaCmb1ZHAPGVRlSlBlVOjThp9Tb2sX9+nRX0M+d1KU=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0 h1:DxrN85V738CRLynu6MULQHO+OXyYnkhVPgoZKULfFIs=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.8.0/go.mod h1:ClPE4TOM1FeaJiwTXvApq4gWaSgTLq6nU3PPHAIQDN4=
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.25.6 h1:4x30lC+YBmo7XpsAzTn0W+C/oP5flnLVgIh5u3O/P0o=

--- a/go.sum
+++ b/go.sum
@@ -612,8 +612,6 @@ github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0 h1:H4V3H8qSKOaOalIr
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0/go.mod h1:Ts06id0KejUlQWbpR+/rm+tKng6QkTuFV1VQTPJ4dA4=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1 h1:7ZSrwps/zI41rl+xYkG4osld8cyAwssyl/UZ/Iu/F2g=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1/go.mod h1:ZIvwBZwEMFO+YfJLCNXqabslI0Fp9zxV7ZBwlZjk7uE=
-github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2 h1:2ulSL2IkIAKND59eAjbEhVkOoBMyvm48ojwz1a3t0U0=
-github.com/stackitcloud/stackit-sdk-go/services/kms v1.3.2/go.mod h1:cuIaMMiHeHQsbvy7BOFMutoV3QtN+ZBx7Tg3GmYUw7s=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0 h1:OrUaDypQNr1nOXZfVQXCwUpN4YhR5y0vtvYi9/Ogoi4=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0/go.mod h1:pVaCmb1ZHAPGVRlSlBlVOjThp9Tb2sX9+nRX0M+d1KU=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0 h1:1dvL7tX91ziklayQmOupniE3jM4D5Nbtc0auNcx2p18=
@@ -656,10 +654,10 @@ github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZ
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0/go.mod h1:jMlBoXqrPNX5nXbo6oT7exalqilw1jiLPoIp4Cn0CdI=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0 h1:QoKyQPe8FqDqJLNgE5uRlZ/y1c1GUxjV1DDLu5QEBD8=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0/go.mod h1:KhVYCR58wETqdI7Quwhe3OR3BhB2T/b7DzaMsfDnr8g=
-github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0 h1:LMgbzhPunuelsIsfyEj/5O/aYfNcg/eGHsnZ7AZOhYg=
-github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0/go.mod h1:toIjQk1dhxdUFVyCWJJja0w/0nFpDid8MWX0ukQfvfo=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0 h1:PwjQeupEnXxhu+uWCUzO/hUfL4yqNblOcZbP2jvaQtU=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
+github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0 h1:LMgbzhPunuelsIsfyEj/5O/aYfNcg/eGHsnZ7AZOhYg=
+github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0/go.mod h1:toIjQk1dhxdUFVyCWJJja0w/0nFpDid8MWX0ukQfvfo=
 github.com/stbenjam/no-sprintf-host-port v0.3.1 h1:AyX7+dxI4IdLBPtDbsGAyqiTSLpCP9hWRrXQDU4Cm/g=
 github.com/stbenjam/no-sprintf-host-port v0.3.1/go.mod h1:ODbZesTCHMVKthBHskvUUexdcNHAQRXk9NpSsL8p/HQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/cmd/kms/key/create/create.go
+++ b/internal/cmd/kms/key/create/create.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms/wait"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/kms/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
@@ -26,24 +26,38 @@ import (
 const (
 	keyRingIdFlag = "keyring-id"
 
-	algorithmFlag   = "algorithm"
 	descriptionFlag = "description"
 	displayNameFlag = "name"
 	importOnlyFlag  = "import-only"
-	purposeFlag     = "purpose"
-	protectionFlag  = "protection"
+)
+
+var (
+	algorithmFlag = flags.StringEnumFlag(
+		"algorithm",
+		kms.AllowedAlgorithmEnumValues,
+		"En-/Decryption / signing algorithm.",
+	)
+	purposeFlag = flags.StringEnumFlag(
+		"purpose",
+		kms.AllowedPurposeEnumValues,
+		"Purpose of the key.",
+	)
+	protectionFlag = flags.StringEnumFlag(
+		"protection",
+		kms.AllowedProtectionEnumValues,
+		"The underlying system that is responsible for protecting the key material.")
 )
 
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	KeyRingId string
 
-	Algorithm   *string
+	Algorithm   kms.Algorithm
 	Description *string
 	Name        *string
 	ImportOnly  bool // Default false
-	Purpose     *string
-	Protection  *string
+	Purpose     kms.Purpose
+	Protection  kms.Protection
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -91,7 +105,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, _ := buildRequest(ctx, model, apiClient)
+			req, _ := buildRequest(ctx, model, apiClient.DefaultAPI)
 			resp, err := req.Execute()
 			if err != nil {
 				return fmt.Errorf("create KMS key: %w", err)
@@ -100,7 +114,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating key", func() error {
-					_, err = wait.CreateOrUpdateKeyWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, *resp.Id).WaitWithContext(ctx)
+					_, err = wait.CreateOrUpdateKeyWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, resp.Id).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -124,12 +138,12 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		KeyRingId:       flags.FlagToStringValue(p, cmd, keyRingIdFlag),
-		Algorithm:       flags.FlagToStringPointer(p, cmd, algorithmFlag),
+		Algorithm:       algorithmFlag.Get(),
 		Name:            flags.FlagToStringPointer(p, cmd, displayNameFlag),
 		Description:     flags.FlagToStringPointer(p, cmd, descriptionFlag),
 		ImportOnly:      flags.FlagToBoolValue(p, cmd, importOnlyFlag),
-		Purpose:         flags.FlagToStringPointer(p, cmd, purposeFlag),
-		Protection:      flags.FlagToStringPointer(p, cmd, protectionFlag),
+		Purpose:         purposeFlag.Get(),
+		Protection:      protectionFlag.Get(),
 	}
 
 	p.DebugInputModel(model)
@@ -144,12 +158,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient kmsKeyClient
 	req := apiClient.CreateKey(ctx, model.ProjectId, model.Region, model.KeyRingId)
 
 	req = req.CreateKeyPayload(kms.CreateKeyPayload{
-		DisplayName: model.Name,
+		DisplayName: utils.PtrString(model.Name),
 		Description: model.Description,
-		Algorithm:   kms.CreateKeyPayloadGetAlgorithmAttributeType(model.Algorithm),
-		Purpose:     kms.CreateKeyPayloadGetPurposeAttributeType(model.Purpose),
+		Algorithm:   model.Algorithm,
+		Purpose:     model.Purpose,
 		ImportOnly:  &model.ImportOnly,
-		Protection:  kms.CreateKeyPayloadGetProtectionAttributeType(model.Protection),
+		Protection:  model.Protection,
 	})
 	return req, nil
 }
@@ -164,32 +178,15 @@ func outputResult(p *print.Printer, model *inputModel, resp *kms.Key) error {
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s the KMS key %q. Key ID: %s\n", operationState, utils.PtrString(resp.DisplayName), utils.PtrString(resp.Id))
+		p.Outputf("%s the KMS key %q. Key ID: %s\n", operationState, resp.DisplayName, resp.Id)
 		return nil
 	})
 }
 
 func configureFlags(cmd *cobra.Command) {
-	// Algorithm
-	var algorithmFlagOptions []string
-	for _, val := range kms.AllowedAlgorithmEnumValues {
-		algorithmFlagOptions = append(algorithmFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", algorithmFlagOptions...), algorithmFlag, fmt.Sprintf("En-/Decryption / signing algorithm. Possible values: %q", algorithmFlagOptions))
-
-	// Purpose
-	var purposeFlagOptions []string
-	for _, val := range kms.AllowedPurposeEnumValues {
-		purposeFlagOptions = append(purposeFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", purposeFlagOptions...), purposeFlag, fmt.Sprintf("Purpose of the key. Possible values: %q", purposeFlagOptions))
-
-	// Protection
-	var protectionFlagOptions []string
-	for _, val := range kms.AllowedProtectionEnumValues {
-		protectionFlagOptions = append(protectionFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", protectionFlagOptions...), protectionFlag, fmt.Sprintf("The underlying system that is responsible for protecting the key material. Possible values: %q", purposeFlagOptions))
+	algorithmFlag.Register(cmd)
+	purposeFlag.Register(cmd)
+	protectionFlag.Register(cmd)
 
 	// All further non Enum Flags
 	cmd.Flags().Var(flags.UUIDFlag(), keyRingIdFlag, "ID of the KMS key ring")
@@ -197,6 +194,6 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(descriptionFlag, "", "Optional description of the key")
 	cmd.Flags().Bool(importOnlyFlag, false, "States whether versions can be created or only imported")
 
-	err := flags.MarkFlagsRequired(cmd, keyRingIdFlag, algorithmFlag, purposeFlag, displayNameFlag, protectionFlag)
+	err := flags.MarkFlagsRequired(cmd, keyRingIdFlag, algorithmFlag.Name(), purposeFlag.Name(), displayNameFlag, protectionFlag.Name())
 	cobra.CheckErr(err)
 }

--- a/internal/cmd/kms/key/create/create_test.go
+++ b/internal/cmd/kms/key/create/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -18,19 +18,19 @@ import (
 
 const (
 	testRegion      = "eu01"
-	testAlgorithm   = "rsa_2048_oaep_sha256"
+	testAlgorithm   = kms.ALGORITHM_RSA_2048_OAEP_SHA256
 	testDisplayName = "my-key"
-	testPurpose     = "asymmetric_encrypt_decrypt"
+	testPurpose     = kms.PURPOSE_ASYMMETRIC_ENCRYPT_DECRYPT
 	testDescription = "my key description"
 	testImportOnly  = "true"
-	testProtection  = "software"
+	testProtection  = kms.PROTECTION_SOFTWARE
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 )
@@ -41,12 +41,12 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		globalflags.ProjectIdFlag: testProjectId,
 		globalflags.RegionFlag:    testRegion,
 		keyRingIdFlag:             testKeyRingId,
-		algorithmFlag:             testAlgorithm,
+		algorithmFlag.Name():      string(testAlgorithm),
 		displayNameFlag:           testDisplayName,
-		purposeFlag:               testPurpose,
+		purposeFlag.Name():        string(testPurpose),
 		descriptionFlag:           testDescription,
 		importOnlyFlag:            testImportOnly,
-		protectionFlag:            testProtection,
+		protectionFlag.Name():     string(testProtection),
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -63,12 +63,12 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		KeyRingId:   testKeyRingId,
-		Algorithm:   utils.Ptr(testAlgorithm),
+		Algorithm:   testAlgorithm,
 		Name:        utils.Ptr(testDisplayName),
-		Purpose:     utils.Ptr(testPurpose),
+		Purpose:     testPurpose,
 		Description: utils.Ptr(testDescription),
 		ImportOnly:  true, // Watch out: ImportOnly is not testImportOnly!
-		Protection:  utils.Ptr(testProtection),
+		Protection:  testProtection,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -78,14 +78,14 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiCreateKeyRequest)) kms.ApiCreateKeyRequest {
-	request := testClient.CreateKey(testCtx, testProjectId, testRegion, testKeyRingId)
+	request := testClient.DefaultAPI.CreateKey(testCtx, testProjectId, testRegion, testKeyRingId)
 	request = request.CreateKeyPayload(kms.CreateKeyPayload{
-		Algorithm:   kms.CreateKeyPayloadGetAlgorithmAttributeType(utils.Ptr(testAlgorithm)),
-		DisplayName: utils.Ptr(testDisplayName),
-		Purpose:     kms.CreateKeyPayloadGetPurposeAttributeType(utils.Ptr(testPurpose)),
+		Algorithm:   testAlgorithm,
+		DisplayName: testDisplayName,
+		Purpose:     testPurpose,
 		Description: utils.Ptr(testDescription),
 		ImportOnly:  utils.Ptr(true),
-		Protection:  kms.CreateKeyPayloadGetProtectionAttributeType(utils.Ptr(testProtection)),
+		Protection:  testProtection,
 	})
 
 	for _, mod := range mods {
@@ -162,14 +162,14 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "algorithm missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, algorithmFlag)
+				delete(flagValues, algorithmFlag.Name())
 			}),
 			isValid: false,
 		},
 		{
 			description: "protection missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, protectionFlag)
+				delete(flagValues, protectionFlag.Name())
 			}),
 			isValid: false,
 		},
@@ -183,7 +183,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "purpose missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, purposeFlag)
+				delete(flagValues, purposeFlag.Name())
 			}),
 			isValid: false,
 		},
@@ -255,26 +255,26 @@ func TestBuildRequest(t *testing.T) {
 				model.ImportOnly = false
 			}),
 			expectedRequest: fixtureRequest().CreateKeyPayload(kms.CreateKeyPayload{
-				Algorithm:   kms.CreateKeyPayloadGetAlgorithmAttributeType(utils.Ptr(testAlgorithm)),
-				DisplayName: utils.Ptr(testDisplayName),
-				Purpose:     kms.CreateKeyPayloadGetPurposeAttributeType(utils.Ptr(testPurpose)),
+				Algorithm:   testAlgorithm,
+				DisplayName: testDisplayName,
+				Purpose:     testPurpose,
 				Description: nil,
 				ImportOnly:  utils.Ptr(false),
-				Protection:  kms.CreateKeyPayloadGetProtectionAttributeType(utils.Ptr(testProtection)),
+				Protection:  testProtection,
 			}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
+			request, err := buildRequest(testCtx, tt.model, testClient.DefaultAPI)
 			if err != nil {
 				t.Fatalf("error building request: %v", err)
 			}
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/key/delete/delete.go
+++ b/internal/cmd/kms/key/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 )
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			keyName, err := kmsUtils.GetKeyName(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			keyName, err := kmsUtils.GetKeyName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key name: %v", err)
 				keyName = model.KeyId
@@ -79,7 +79,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Don't wait for a month until the deletion was performed.
 			// Just print the deletion date.
-			resp, err := apiClient.GetKeyExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			resp, err := apiClient.DefaultAPI.GetKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key: %v", err)
 			}
@@ -111,7 +111,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiDeleteKeyRequest {
-	req := apiClient.DeleteKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+	req := apiClient.DefaultAPI.DeleteKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 	return req
 }
 
@@ -128,7 +128,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *kms.Key) error {
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Deletion of KMS key %s scheduled successfully for the deletion date: %s\n", utils.PtrString(resp.DisplayName), utils.PtrString(resp.DeletionDate))
+		p.Outputf("Deletion of KMS key %s scheduled successfully for the deletion date: %s\n", resp.DisplayName, utils.PtrString(resp.DeletionDate))
 		return nil
 	})
 }

--- a/internal/cmd/kms/key/delete/delete_test.go
+++ b/internal/cmd/kms/key/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -72,7 +72,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiDeleteKeyRequest)) kms.ApiDeleteKeyRequest {
-	request := testClient.DeleteKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
+	request := testClient.DefaultAPI.DeleteKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -241,7 +241,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/key/describe/describe.go
+++ b/internal/cmd/kms/key/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -91,7 +91,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiGetKeyRequest {
-	return apiClient.GetKey(ctx, model.ProjectId, model.Region, model.KeyRingID, model.KeyID)
+	return apiClient.DefaultAPI.GetKey(ctx, model.ProjectId, model.Region, model.KeyRingID, model.KeyID)
 }
 
 func outputResult(p *print.Printer, outputFormat string, key *kms.Key) error {
@@ -100,29 +100,29 @@ func outputResult(p *print.Printer, outputFormat string, key *kms.Key) error {
 	}
 	return p.OutputResult(outputFormat, key, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(key.Id))
+		table.AddRow("ID", key.Id)
 		table.AddSeparator()
-		table.AddRow("DISPLAY NAME", utils.PtrString(key.DisplayName))
+		table.AddRow("DISPLAY NAME", key.DisplayName)
 		table.AddSeparator()
-		table.AddRow("CREATED AT", utils.PtrString(key.CreatedAt))
+		table.AddRow("CREATED AT", key.CreatedAt)
 		table.AddSeparator()
-		table.AddRow("STATE", utils.PtrString(key.State))
+		table.AddRow("STATE", key.State)
 		table.AddSeparator()
 		table.AddRow("DESCRIPTION", utils.PtrString(key.Description))
 		table.AddSeparator()
-		table.AddRow("ACCESS SCOPE", utils.PtrString(key.AccessScope))
+		table.AddRow("ACCESS SCOPE", key.AccessScope)
 		table.AddSeparator()
-		table.AddRow("ALGORITHM", utils.PtrString(key.Algorithm))
+		table.AddRow("ALGORITHM", key.Algorithm)
 		table.AddSeparator()
 		table.AddRow("DELETION DATE", utils.PtrString(key.DeletionDate))
 		table.AddSeparator()
-		table.AddRow("IMPORT ONLY", utils.PtrString(key.ImportOnly))
+		table.AddRow("IMPORT ONLY", key.ImportOnly)
 		table.AddSeparator()
-		table.AddRow("KEYRING ID", utils.PtrString(key.KeyRingId))
+		table.AddRow("KEYRING ID", key.KeyRingId)
 		table.AddSeparator()
-		table.AddRow("PROTECTION", utils.PtrString(key.Protection))
+		table.AddRow("PROTECTION", key.Protection)
 		table.AddSeparator()
-		table.AddRow("PURPOSE", utils.PtrString(key.Purpose))
+		table.AddRow("PURPOSE", key.Purpose)
 
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/kms/key/describe/describe_test.go
+++ b/internal/cmd/kms/key/describe/describe_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -20,7 +20,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &kms.APIClient{}
+var testClient = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testKeyRingID = uuid.NewString()
 var testKeyID = uuid.NewString()
@@ -131,10 +131,10 @@ func TestParseInput(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	got := buildRequest(testCtx, fixtureInputModel(), testClient)
-	want := testClient.GetKey(testCtx, testProjectId, testRegion, testKeyRingID, testKeyID)
+	want := testClient.DefaultAPI.GetKey(testCtx, testProjectId, testRegion, testKeyRingID, testKeyID)
 	diff := cmp.Diff(got, want,
 		cmp.AllowUnexported(want),
-		cmpopts.EquateComparable(testCtx),
+		cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 	)
 	if diff != "" {
 		t.Fatalf("buildRequest() mismatch (-want +got):\n%s", diff)
@@ -158,18 +158,18 @@ func TestOutputResult(t *testing.T) {
 			description: "table format",
 			outputFmt:   "table",
 			keyRing: &kms.Key{
-				AccessScope:  utils.Ptr(kms.ACCESSSCOPE_PUBLIC),
-				Algorithm:    utils.Ptr(kms.ALGORITHM_AES_256_GCM),
-				CreatedAt:    utils.Ptr(testTime),
+				AccessScope:  kms.ACCESSSCOPE_PUBLIC,
+				Algorithm:    kms.ALGORITHM_AES_256_GCM,
+				CreatedAt:    testTime,
 				DeletionDate: nil,
 				Description:  utils.Ptr("very secure and secret key"),
-				DisplayName:  utils.Ptr("Test Key"),
-				Id:           utils.Ptr(testKeyID),
-				ImportOnly:   utils.Ptr(true),
-				KeyRingId:    utils.Ptr(testKeyRingID),
-				Protection:   utils.Ptr(kms.PROTECTION_SOFTWARE),
-				Purpose:      utils.Ptr(kms.PURPOSE_SYMMETRIC_ENCRYPT_DECRYPT),
-				State:        utils.Ptr(kms.KEYSTATE_ACTIVE),
+				DisplayName:  "Test Key",
+				Id:           testKeyID,
+				ImportOnly:   true,
+				KeyRingId:    testKeyRingID,
+				Protection:   kms.PROTECTION_SOFTWARE,
+				Purpose:      kms.PURPOSE_SYMMETRIC_ENCRYPT_DECRYPT,
+				State:        kms.KEYSTATE_ACTIVE,
 			},
 			expected: fmt.Sprintf(`
  ID            │ %-37s

--- a/internal/cmd/kms/key/importKey/importKey.go
+++ b/internal/cmd/kms/key/importKey/importKey.go
@@ -15,7 +15,7 @@ import (
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
@@ -35,8 +35,8 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 	KeyRingId     string
 	KeyId         string
-	WrappedKey    *string
-	WrappingKeyId *string
+	WrappedKey    string
+	WrappingKeyId string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -68,12 +68,12 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			keyName, err := kmsUtils.GetKeyName(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			keyName, err := kmsUtils.GetKeyName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key name: %v", err)
 				keyName = model.KeyId
 			}
-			keyRingName, err := kmsUtils.GetKeyRingName(ctx, apiClient, model.ProjectId, model.KeyRingId, model.Region)
+			keyRingName, err := kmsUtils.GetKeyRingName(ctx, apiClient.DefaultAPI, model.ProjectId, model.KeyRingId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key ring name: %v", err)
 				keyRingName = model.KeyRingId
@@ -86,7 +86,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, _ := buildRequest(ctx, model, apiClient)
+			req, _ := buildRequest(ctx, model, apiClient.DefaultAPI)
 			resp, err := req.Execute()
 			if err != nil {
 				return fmt.Errorf("import KMS key: %w", err)
@@ -108,9 +108,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	}
 
 	// WrappedKey needs to be base64 encoded
-	var wrappedKey = flags.FlagToStringPointer(p, cmd, wrappedKeyFlag)
-	_, err := base64.StdEncoding.DecodeString(*wrappedKey)
-	if err != nil || *wrappedKey == "" {
+	var wrappedKey = flags.FlagToStringValue(p, cmd, wrappedKeyFlag)
+	_, err := base64.StdEncoding.DecodeString(wrappedKey)
+	if err != nil || wrappedKey == "" {
 		return nil, &cliErr.FlagValidationError{
 			Flag:    wrappedKeyFlag,
 			Details: "The 'wrappedKey' argument is required and needs to be base64 encoded (whether provided inline or via file).",
@@ -122,7 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		KeyId:           keyId,
 		KeyRingId:       flags.FlagToStringValue(p, cmd, keyRingIdFlag),
 		WrappedKey:      wrappedKey,
-		WrappingKeyId:   flags.FlagToStringPointer(p, cmd, wrappingKeyIdFlag),
+		WrappingKeyId:   flags.FlagToStringValue(p, cmd, wrappingKeyIdFlag),
 	}
 
 	p.DebugInputModel(model)

--- a/internal/cmd/kms/key/importKey/importKey_test.go
+++ b/internal/cmd/kms/key/importKey/importKey_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx           = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient        = &kms.APIClient{}
+	testClient        = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId     = uuid.NewString()
 	testKeyRingId     = uuid.NewString()
 	testKeyId         = uuid.NewString()
@@ -67,8 +67,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		KeyRingId:     testKeyRingId,
 		KeyId:         testKeyId,
-		WrappedKey:    &testWrappedKey,
-		WrappingKeyId: &testWrappingKeyId,
+		WrappedKey:    testWrappedKey,
+		WrappingKeyId: testWrappingKeyId,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -78,10 +78,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiImportKeyRequest)) kms.ApiImportKeyRequest {
-	request := testClient.ImportKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
+	request := testClient.DefaultAPI.ImportKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
 	request = request.ImportKeyPayload(kms.ImportKeyPayload{
-		WrappedKey:    &testWrappedKey,
-		WrappingKeyId: &testWrappingKeyId,
+		WrappedKey:    testWrappedKey,
+		WrappingKeyId: testWrappingKeyId,
 	})
 
 	for _, mod := range mods {
@@ -296,14 +296,14 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
+			request, err := buildRequest(testCtx, tt.model, testClient.DefaultAPI)
 			if err != nil {
 				t.Fatalf("error building request: %v", err)
 			}
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/key/list/list.go
+++ b/internal/cmd/kms/key/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -87,7 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiListKeysRequest {
-	req := apiClient.ListKeys(ctx, model.ProjectId, model.Region, model.KeyRingId)
+	req := apiClient.DefaultAPI.ListKeys(ctx, model.ProjectId, model.Region, model.KeyRingId)
 	return req
 }
 
@@ -103,7 +103,7 @@ func outputResult(p *print.Printer, outputFormat, projectId, keyRingId string, r
 		return fmt.Errorf("response was nil / empty")
 	}
 
-	keys := *resp.Keys
+	keys := resp.Keys
 
 	return p.OutputResult(outputFormat, keys, func() error {
 		if len(keys) == 0 {
@@ -115,12 +115,12 @@ func outputResult(p *print.Printer, outputFormat, projectId, keyRingId string, r
 
 		for _, key := range keys {
 			table.AddRow(
-				utils.PtrString(key.Id),
-				utils.PtrString(key.DisplayName),
-				utils.PtrString(key.Purpose),
-				utils.PtrString(key.Algorithm),
+				key.Id,
+				key.DisplayName,
+				key.Purpose,
+				key.Algorithm,
 				utils.PtrString(key.DeletionDate),
-				utils.PtrString(key.State),
+				key.State,
 			)
 		}
 

--- a/internal/cmd/kms/key/list/list_test.go
+++ b/internal/cmd/kms/key/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 )
@@ -59,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiListKeysRequest)) kms.ApiListKeysRequest {
-	request := testClient.ListKeys(testCtx, testProjectId, testRegion, testKeyRingId)
+	request := testClient.DefaultAPI.ListKeys(testCtx, testProjectId, testRegion, testKeyRingId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -189,7 +189,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -223,14 +223,14 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			description: "default output",
-			resp:        &kms.KeyList{Keys: &[]kms.Key{}},
+			resp:        &kms.KeyList{Keys: []kms.Key{}},
 			projectId:   uuid.NewString(),
 			keyRingId:   uuid.NewString(),
 			wantErr:     false,
 		},
 		{
 			description:  "json output",
-			resp:         &kms.KeyList{Keys: &[]kms.Key{}},
+			resp:         &kms.KeyList{Keys: []kms.Key{}},
 			projectId:    uuid.NewString(),
 			keyRingId:    uuid.NewString(),
 			outputFormat: print.JSONOutputFormat,
@@ -238,7 +238,7 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			description:  "yaml output",
-			resp:         &kms.KeyList{Keys: &[]kms.Key{}},
+			resp:         &kms.KeyList{Keys: []kms.Key{}},
 			projectId:    uuid.NewString(),
 			keyRingId:    uuid.NewString(),
 			outputFormat: print.YAMLOutputFormat,

--- a/internal/cmd/kms/key/restore/restore.go
+++ b/internal/cmd/kms/key/restore/restore.go
@@ -17,7 +17,7 @@ import (
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 )
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			keyName, err := kmsUtils.GetKeyName(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			keyName, err := kmsUtils.GetKeyName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key name: %v", err)
 				keyName = model.KeyId
@@ -78,7 +78,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Grab the key after the restore was applied to display the new state to the user.
-			resp, err := apiClient.GetKeyExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			resp, err := apiClient.DefaultAPI.GetKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key: %v", err)
 			}
@@ -110,7 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiRestoreKeyRequest {
-	req := apiClient.RestoreKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+	req := apiClient.DefaultAPI.RestoreKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 	return req
 }
 
@@ -127,7 +127,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *kms.Key) error {
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Successfully restored KMS key %q\n", utils.PtrString(resp.DisplayName))
+		p.Outputf("Successfully restored KMS key %q\n", resp.DisplayName)
 		return nil
 	})
 }

--- a/internal/cmd/kms/key/restore/restore_test.go
+++ b/internal/cmd/kms/key/restore/restore_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -72,7 +72,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiRestoreKeyRequest)) kms.ApiRestoreKeyRequest {
-	request := testClient.RestoreKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
+	request := testClient.DefaultAPI.RestoreKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -241,7 +241,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/key/rotate/rotate.go
+++ b/internal/cmd/kms/key/rotate/rotate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			keyName, err := kmsUtils.GetKeyName(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+			keyName, err := kmsUtils.GetKeyName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key name: %v", err)
 				keyName = model.KeyId
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiRotateKeyRequest {
-	req := apiClient.RotateKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+	req := apiClient.DefaultAPI.RotateKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 	return req
 }
 
@@ -121,7 +121,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *kms.Version) erro
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Rotated key %s\n", utils.PtrString(resp.KeyId))
+		p.Outputf("Rotated key %s\n", resp.KeyId)
 		return nil
 	})
 }

--- a/internal/cmd/kms/key/rotate/rotate_test.go
+++ b/internal/cmd/kms/key/rotate/rotate_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -72,7 +72,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiRotateKeyRequest)) kms.ApiRotateKeyRequest {
-	request := testClient.RotateKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
+	request := testClient.DefaultAPI.RotateKey(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -241,7 +241,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/keyring/create/create.go
+++ b/internal/cmd/kms/keyring/create/create.go
@@ -13,14 +13,13 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms/wait"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/kms/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -70,7 +69,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, _ := buildRequest(ctx, model, apiClient)
+			req, _ := buildRequest(ctx, model, apiClient.DefaultAPI)
 
 			keyRing, err := req.Execute()
 			if err != nil {
@@ -78,16 +77,16 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Prevent potential nil pointer dereference
-			if keyRing == nil || keyRing.Id == nil {
+			if keyRing == nil {
 				return fmt.Errorf("API call succeeded but returned an invalid response (missing key ring ID)")
 			}
 
-			keyRingId := *keyRing.Id
+			keyRingId := keyRing.Id
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating key ring", func() error {
-					_, err = wait.CreateKeyRingWaitHandler(ctx, apiClient, model.ProjectId, model.Region, keyRingId).WaitWithContext(ctx)
+					_, err = wait.CreateKeyRingWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, keyRingId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -134,7 +133,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient kmsKeyringCl
 	req := apiClient.CreateKeyRing(ctx, model.ProjectId, model.Region)
 
 	req = req.CreateKeyRingPayload(kms.CreateKeyRingPayload{
-		DisplayName: &model.KeyringName,
+		DisplayName: model.KeyringName,
 
 		// Description should be empty by default and only be overwritten with the descriptionFlag if it was passed.
 		Description: &model.Description,
@@ -152,7 +151,7 @@ func outputResult(p *print.Printer, model *inputModel, resp *kms.KeyRing) error 
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s key ring. KMS key ring ID: %s\n", operationState, utils.PtrString(resp.Id))
+		p.Outputf("%s key ring. KMS key ring ID: %s\n", operationState, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/kms/keyring/create/create_test.go
+++ b/internal/cmd/kms/keyring/create/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -26,7 +26,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 )
 
@@ -63,9 +63,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiCreateKeyRingRequest)) kms.ApiCreateKeyRingRequest {
-	request := testClient.CreateKeyRing(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateKeyRing(testCtx, testProjectId, testRegion)
 	request = request.CreateKeyRingPayload(kms.CreateKeyRingPayload{
-		DisplayName: utils.Ptr(testKeyRingName),
+		DisplayName: testKeyRingName,
 		Description: utils.Ptr(testDescription),
 	})
 
@@ -189,14 +189,14 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
+			request, err := buildRequest(testCtx, tt.model, testClient.DefaultAPI)
 			if err != nil {
 				t.Fatalf("error building request: %v", err)
 			}
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/keyring/delete/delete.go
+++ b/internal/cmd/kms/keyring/delete/delete.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
@@ -54,7 +54,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			keyRingLabel, err := kmsUtils.GetKeyRingName(ctx, apiClient, model.ProjectId, model.KeyRingId, model.Region)
+			keyRingLabel, err := kmsUtils.GetKeyRingName(ctx, apiClient.DefaultAPI, model.ProjectId, model.KeyRingId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key ring name: %v", err)
 				keyRingLabel = model.KeyRingId
@@ -101,6 +101,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiDeleteKeyRingRequest {
-	req := apiClient.DeleteKeyRing(ctx, model.ProjectId, model.Region, model.KeyRingId)
+	req := apiClient.DefaultAPI.DeleteKeyRing(ctx, model.ProjectId, model.Region, model.KeyRingId)
 	return req
 }

--- a/internal/cmd/kms/keyring/delete/delete_test.go
+++ b/internal/cmd/kms/keyring/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -22,7 +22,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 )
@@ -68,7 +68,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiDeleteKeyRingRequest)) kms.ApiDeleteKeyRingRequest {
-	request := testClient.DeleteKeyRing(testCtx, testProjectId, testRegion, testKeyRingId)
+	request := testClient.DefaultAPI.DeleteKeyRing(testCtx, testProjectId, testRegion, testKeyRingId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -203,7 +203,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/keyring/describe/describe.go
+++ b/internal/cmd/kms/keyring/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -80,7 +80,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiGetKeyRingRequest {
-	return apiClient.GetKeyRing(ctx, model.ProjectId, model.Region, model.KeyRingID)
+	return apiClient.DefaultAPI.GetKeyRing(ctx, model.ProjectId, model.Region, model.KeyRingID)
 }
 
 func outputResult(p *print.Printer, outputFormat string, keyRing *kms.KeyRing) error {
@@ -89,13 +89,13 @@ func outputResult(p *print.Printer, outputFormat string, keyRing *kms.KeyRing) e
 	}
 	return p.OutputResult(outputFormat, keyRing, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(keyRing.Id))
+		table.AddRow("ID", keyRing.Id)
 		table.AddSeparator()
-		table.AddRow("DISPLAY NAME", utils.PtrString(keyRing.DisplayName))
+		table.AddRow("DISPLAY NAME", keyRing.DisplayName)
 		table.AddSeparator()
-		table.AddRow("CREATED AT", utils.PtrString(keyRing.CreatedAt))
+		table.AddRow("CREATED AT", keyRing.CreatedAt)
 		table.AddSeparator()
-		table.AddRow("STATE", utils.PtrString(keyRing.State))
+		table.AddRow("STATE", keyRing.State)
 		table.AddSeparator()
 		table.AddRow("DESCRIPTION", utils.PtrString(keyRing.Description))
 

--- a/internal/cmd/kms/keyring/describe/describe_test.go
+++ b/internal/cmd/kms/keyring/describe/describe_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -20,7 +20,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &kms.APIClient{}
+var testClient = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testKeyRingID = uuid.NewString()
 var testTime = time.Time{}
@@ -114,10 +114,10 @@ func TestParseInput(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	got := buildRequest(testCtx, fixtureInputModel(), testClient)
-	want := testClient.GetKeyRing(testCtx, testProjectId, testRegion, testKeyRingID)
+	want := testClient.DefaultAPI.GetKeyRing(testCtx, testProjectId, testRegion, testKeyRingID)
 	diff := cmp.Diff(got, want,
 		cmp.AllowUnexported(want),
-		cmpopts.EquateComparable(testCtx),
+		cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 	)
 	if diff != "" {
 		t.Fatalf("buildRequest() mismatch (-want +got):\n%s", diff)
@@ -141,11 +141,11 @@ func TestOutputResult(t *testing.T) {
 			description: "table format",
 			outputFmt:   "table",
 			keyRing: &kms.KeyRing{
-				Id:          utils.Ptr(testKeyRingID),
-				DisplayName: utils.Ptr("Test Key Ring"),
-				CreatedAt:   utils.Ptr(testTime),
+				Id:          testKeyRingID,
+				DisplayName: "Test Key Ring",
+				CreatedAt:   testTime,
 				Description: utils.Ptr("This is a test key ring."),
-				State:       utils.Ptr(kms.KEYRINGSTATE_ACTIVE),
+				State:       kms.KEYRINGSTATE_ACTIVE,
 			},
 			expected: fmt.Sprintf(`
  ID           │ %-37s

--- a/internal/cmd/kms/keyring/list/list.go
+++ b/internal/cmd/kms/keyring/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -16,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type inputModel struct {
@@ -79,7 +78,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiListKeyRingsRequest {
-	req := apiClient.ListKeyRings(ctx, model.ProjectId, model.Region)
+	req := apiClient.DefaultAPI.ListKeyRings(ctx, model.ProjectId, model.Region)
 	return req
 }
 
@@ -88,7 +87,7 @@ func outputResult(p *print.Printer, outputFormat, projectId string, resp *kms.Ke
 		return fmt.Errorf("response was nil / empty")
 	}
 
-	keyRings := *resp.KeyRings
+	keyRings := resp.KeyRings
 
 	return p.OutputResult(outputFormat, keyRings, func() error {
 		if len(keyRings) == 0 {
@@ -102,9 +101,9 @@ func outputResult(p *print.Printer, outputFormat, projectId string, resp *kms.Ke
 		for i := range keyRings {
 			keyRing := keyRings[i]
 			table.AddRow(
-				utils.PtrString(keyRing.Id),
-				utils.PtrString(keyRing.DisplayName),
-				utils.PtrString(keyRing.State),
+				keyRing.Id,
+				keyRing.DisplayName,
+				keyRing.State,
 			)
 		}
 

--- a/internal/cmd/kms/keyring/list/list_test.go
+++ b/internal/cmd/kms/keyring/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 )
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiListKeyRingsRequest)) kms.ApiListKeyRingsRequest {
-	request := testClient.ListKeyRings(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListKeyRings(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -162,7 +162,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -197,21 +197,21 @@ func TestOutputResult(t *testing.T) {
 		{
 			description:  "default output",
 			projectId:    uuid.NewString(),
-			resp:         &kms.KeyRingList{KeyRings: &[]kms.KeyRing{}},
+			resp:         &kms.KeyRingList{KeyRings: []kms.KeyRing{}},
 			projectLabel: "my-project",
 			wantErr:      false,
 		},
 		{
 			description:  "json output",
 			projectId:    uuid.NewString(),
-			resp:         &kms.KeyRingList{KeyRings: &[]kms.KeyRing{}},
+			resp:         &kms.KeyRingList{KeyRings: []kms.KeyRing{}},
 			outputFormat: print.JSONOutputFormat,
 			wantErr:      false,
 		},
 		{
 			description:  "yaml output",
 			projectId:    uuid.NewString(),
-			resp:         &kms.KeyRingList{KeyRings: &[]kms.KeyRing{}},
+			resp:         &kms.KeyRingList{KeyRings: []kms.KeyRing{}},
 			outputFormat: print.YAMLOutputFormat,
 			wantErr:      false,
 		},

--- a/internal/cmd/kms/version/destroy/destroy.go
+++ b/internal/cmd/kms/version/destroy/destroy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -17,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -68,7 +67,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the key version in its state afterwards
-			resp, err := apiClient.GetVersionExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+			resp, err := apiClient.DefaultAPI.GetVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key version: %v", err)
 			}
@@ -108,7 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiDestroyVersionRequest {
-	return apiClient.DestroyVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+	return apiClient.DefaultAPI.DestroyVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
 }
 
 func configureFlags(cmd *cobra.Command) {
@@ -125,7 +124,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *kms.Version) erro
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Destroyed version %d of the key %q\n", utils.PtrValue(resp.Number), utils.PtrValue(resp.KeyId))
+		p.Outputf("Destroyed version %d of the key %q\n", resp.Number, resp.KeyId)
 		return nil
 	})
 }

--- a/internal/cmd/kms/version/destroy/destroy_test.go
+++ b/internal/cmd/kms/version/destroy/destroy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -25,7 +25,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -76,7 +76,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiDestroyVersionRequest)) kms.ApiDestroyVersionRequest {
-	request := testClient.DestroyVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
+	request := testClient.DefaultAPI.DestroyVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -269,7 +269,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/version/disable/disable.go
+++ b/internal/cmd/kms/version/disable/disable.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms/wait"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/kms/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -19,7 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -72,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Disabling key version", func() error {
-					_, err = wait.DisableKeyVersionWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).WaitWithContext(ctx)
+					_, err = wait.DisableKeyVersionWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -81,7 +80,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the key version in its state afterwards
-			resp, err := apiClient.GetVersionExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+			resp, err := apiClient.DefaultAPI.GetVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key version: %v", err)
 			}
@@ -121,7 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiDisableVersionRequest {
-	return apiClient.DisableVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+	return apiClient.DefaultAPI.DisableVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
 }
 
 func configureFlags(cmd *cobra.Command) {
@@ -142,7 +141,7 @@ func outputResult(p *print.Printer, outputFormat string, async bool, resp *kms.V
 		if async {
 			operationState = "Triggered disable of"
 		}
-		p.Outputf("%s version %d of the key %q\n", operationState, utils.PtrValue(resp.Number), utils.PtrValue(resp.KeyId))
+		p.Outputf("%s version %d of the key %q\n", operationState, resp.Number, resp.KeyId)
 		return nil
 	})
 }

--- a/internal/cmd/kms/version/disable/disable_test.go
+++ b/internal/cmd/kms/version/disable/disable_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -25,7 +25,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -76,7 +76,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiDisableVersionRequest)) kms.ApiDisableVersionRequest {
-	request := testClient.DisableVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
+	request := testClient.DefaultAPI.DisableVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -269,7 +269,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/version/enable/enable.go
+++ b/internal/cmd/kms/version/enable/enable.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms/wait"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/kms/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -19,7 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -72,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Enabling key version", func() error {
-					_, err = wait.EnableKeyVersionWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).WaitWithContext(ctx)
+					_, err = wait.EnableKeyVersionWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -81,7 +80,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the key version in its state afterwards
-			resp, err := apiClient.GetVersionExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+			resp, err := apiClient.DefaultAPI.GetVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key version: %v", err)
 			}
@@ -121,7 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiEnableVersionRequest {
-	return apiClient.EnableVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+	return apiClient.DefaultAPI.EnableVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
 }
 
 func configureFlags(cmd *cobra.Command) {
@@ -142,7 +141,7 @@ func outputResult(p *print.Printer, outputFormat string, async bool, resp *kms.V
 		if async {
 			operationState = "Triggered enable of"
 		}
-		p.Outputf("%s version %d of the key %q\n", operationState, utils.PtrValue(resp.Number), utils.PtrValue(resp.KeyId))
+		p.Outputf("%s version %d of the key %q\n", operationState, resp.Number, resp.KeyId)
 		return nil
 	})
 }

--- a/internal/cmd/kms/version/enable/enable_test.go
+++ b/internal/cmd/kms/version/enable/enable_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -25,7 +25,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -76,7 +76,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiEnableVersionRequest)) kms.ApiEnableVersionRequest {
-	request := testClient.EnableVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
+	request := testClient.DefaultAPI.EnableVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -269,7 +269,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/version/list/list.go
+++ b/internal/cmd/kms/version/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -90,14 +90,14 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiListVersionsRequest {
-	return apiClient.ListVersions(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
+	return apiClient.DefaultAPI.ListVersions(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId)
 }
 
 func outputResult(p *print.Printer, outputFormat, projectId, keyId string, resp *kms.VersionList) error {
 	if resp == nil || resp.Versions == nil {
 		return fmt.Errorf("response is nil / empty")
 	}
-	versions := *resp.Versions
+	versions := resp.Versions
 
 	return p.OutputResult(outputFormat, versions, func() error {
 		if len(versions) == 0 {
@@ -109,11 +109,11 @@ func outputResult(p *print.Printer, outputFormat, projectId, keyId string, resp 
 
 		for _, version := range versions {
 			table.AddRow(
-				utils.PtrString(version.KeyId),
-				utils.PtrString(version.Number),
-				utils.PtrString(version.CreatedAt),
+				version.KeyId,
+				version.Number,
+				version.CreatedAt,
 				utils.PtrString(version.DestroyDate),
-				utils.PtrString(version.State),
+				version.State,
 			)
 		}
 

--- a/internal/cmd/kms/version/list/list_test.go
+++ b/internal/cmd/kms/version/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -62,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiListVersionsRequest)) kms.ApiListVersionsRequest {
-	request := testClient.ListVersions(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
+	request := testClient.DefaultAPI.ListVersions(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -219,7 +219,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -252,19 +252,19 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			description:  "default output",
-			resp:         &kms.VersionList{Versions: &[]kms.Version{}},
+			resp:         &kms.VersionList{Versions: []kms.Version{}},
 			projectLabel: "my-project",
 			wantErr:      false,
 		},
 		{
 			description:  "json output",
-			resp:         &kms.VersionList{Versions: &[]kms.Version{}},
+			resp:         &kms.VersionList{Versions: []kms.Version{}},
 			outputFormat: print.JSONOutputFormat,
 			wantErr:      false,
 		},
 		{
 			description:  "yaml output",
-			resp:         &kms.VersionList{Versions: &[]kms.Version{}},
+			resp:         &kms.VersionList{Versions: []kms.Version{}},
 			outputFormat: print.YAMLOutputFormat,
 			wantErr:      false,
 		},

--- a/internal/cmd/kms/version/restore/restore.go
+++ b/internal/cmd/kms/version/restore/restore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -17,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -68,7 +67,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Grab the key after the restore was applied to display the new state to the user.
-			resp, err := apiClient.GetVersionExecute(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+			resp, err := apiClient.DefaultAPI.GetVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get key version: %v", err)
 			}
@@ -108,7 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiRestoreVersionRequest {
-	return apiClient.RestoreVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
+	return apiClient.DefaultAPI.RestoreVersion(ctx, model.ProjectId, model.Region, model.KeyRingId, model.KeyId, model.VersionNumber)
 }
 
 func configureFlags(cmd *cobra.Command) {
@@ -125,7 +124,7 @@ func outputResult(p *print.Printer, outputFormat string, resp *kms.Version) erro
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Restored version %d of the key %q\n", utils.PtrValue(resp.Number), utils.PtrValue(resp.KeyId))
+		p.Outputf("Restored version %d of the key %q\n", resp.Number, resp.KeyId)
 		return nil
 	})
 }

--- a/internal/cmd/kms/version/restore/restore_test.go
+++ b/internal/cmd/kms/version/restore/restore_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -25,7 +25,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 	testKeyId     = uuid.NewString()
@@ -76,7 +76,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiRestoreVersionRequest)) kms.ApiRestoreVersionRequest {
-	request := testClient.RestoreVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
+	request := testClient.DefaultAPI.RestoreVersion(testCtx, testProjectId, testRegion, testKeyRingId, testKeyId, testVersionNumber)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -269,7 +269,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/wrappingkey/create/create.go
+++ b/internal/cmd/kms/wrappingkey/create/create.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms/wait"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/kms/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
@@ -26,22 +26,36 @@ import (
 const (
 	keyRingIdFlag = "keyring-id"
 
-	algorithmFlag   = "algorithm"
 	descriptionFlag = "description"
 	displayNameFlag = "name"
-	purposeFlag     = "purpose"
-	protectionFlag  = "protection"
+)
+
+var (
+	algorithmFlag = flags.StringEnumFlag(
+		"algorithm",
+		kms.AllowedWrappingAlgorithmEnumValues,
+		"En-/Decryption / signing algorithm.",
+	)
+	purposeFlag = flags.StringEnumFlag(
+		"purpose",
+		kms.AllowedWrappingPurposeEnumValues,
+		"Purpose of the key.",
+	)
+	protectionFlag = flags.StringEnumFlag(
+		"protection",
+		kms.AllowedProtectionEnumValues,
+		"The underlying system that is responsible for protecting the key material.")
 )
 
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	KeyRingId string
 
-	Algorithm   *string
+	Algorithm   kms.WrappingAlgorithm
 	Description *string
 	Name        *string
-	Purpose     *string
-	Protection  *string
+	Purpose     kms.WrappingPurpose
+	Protection  kms.Protection
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -77,7 +91,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, _ := buildRequest(ctx, model, apiClient)
+			req, _ := buildRequest(ctx, model, apiClient.DefaultAPI)
 			wrappingKey, err := req.Execute()
 			if err != nil {
 				return fmt.Errorf("create KMS wrapping key: %w", err)
@@ -86,7 +100,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating wrapping key", func() error {
-					_, err = wait.CreateWrappingKeyWaitHandler(ctx, apiClient, model.ProjectId, model.Region, *wrappingKey.KeyRingId, *wrappingKey.Id).WaitWithContext(ctx)
+					_, err = wait.CreateWrappingKeyWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, wrappingKey.KeyRingId, wrappingKey.Id).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -111,11 +125,11 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		KeyRingId:       flags.FlagToStringValue(p, cmd, keyRingIdFlag),
-		Algorithm:       flags.FlagToStringPointer(p, cmd, algorithmFlag),
+		Algorithm:       algorithmFlag.Get(),
 		Name:            flags.FlagToStringPointer(p, cmd, displayNameFlag),
 		Description:     flags.FlagToStringPointer(p, cmd, descriptionFlag),
-		Purpose:         flags.FlagToStringPointer(p, cmd, purposeFlag),
-		Protection:      flags.FlagToStringPointer(p, cmd, protectionFlag),
+		Purpose:         purposeFlag.Get(),
+		Protection:      protectionFlag.Get(),
 	}
 
 	p.DebugInputModel(model)
@@ -130,11 +144,11 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient kmsWrappingK
 	req := apiClient.CreateWrappingKey(ctx, model.ProjectId, model.Region, model.KeyRingId)
 
 	req = req.CreateWrappingKeyPayload(kms.CreateWrappingKeyPayload{
-		DisplayName: model.Name,
+		DisplayName: utils.PtrString(model.Name),
 		Description: model.Description,
-		Algorithm:   kms.CreateWrappingKeyPayloadGetAlgorithmAttributeType(model.Algorithm),
-		Purpose:     kms.CreateWrappingKeyPayloadGetPurposeAttributeType(model.Purpose),
-		Protection:  kms.CreateWrappingKeyPayloadGetProtectionAttributeType(model.Protection),
+		Algorithm:   model.Algorithm,
+		Purpose:     model.Purpose,
+		Protection:  model.Protection,
 	})
 	return req, nil
 }
@@ -149,39 +163,21 @@ func outputResult(p *print.Printer, model *inputModel, resp *kms.WrappingKey) er
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s wrapping key. Wrapping key ID: %s\n", operationState, utils.PtrString(resp.Id))
+		p.Outputf("%s wrapping key. Wrapping key ID: %s\n", operationState, resp.Id)
 		return nil
 	})
 }
 
 func configureFlags(cmd *cobra.Command) {
-	// Algorithm
-	var algorithmFlagOptions []string
-	for _, val := range kms.AllowedWrappingAlgorithmEnumValues {
-		algorithmFlagOptions = append(algorithmFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", algorithmFlagOptions...), algorithmFlag, fmt.Sprintf("En-/Decryption / signing algorithm. Possible values: %q", algorithmFlagOptions))
-
-	// Purpose
-	var purposeFlagOptions []string
-	for _, val := range kms.AllowedWrappingPurposeEnumValues {
-		purposeFlagOptions = append(purposeFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", purposeFlagOptions...), purposeFlag, fmt.Sprintf("Purpose of the wrapping key. Possible values: %q", purposeFlagOptions))
-
-	// Protection
-	// backend was deprectaed in /v1beta, but protection is a required attribute with value "software"
-	var protectionFlagOptions []string
-	for _, val := range kms.AllowedProtectionEnumValues {
-		protectionFlagOptions = append(protectionFlagOptions, string(val))
-	}
-	cmd.Flags().Var(flags.EnumFlag(false, "", protectionFlagOptions...), protectionFlag, fmt.Sprintf("The underlying system that is responsible for protecting the wrapping key material. Possible values: %q", purposeFlagOptions))
+	algorithmFlag.Register(cmd)
+	purposeFlag.Register(cmd)
+	protectionFlag.Register(cmd)
 
 	// All further non Enum Flags
 	cmd.Flags().Var(flags.UUIDFlag(), keyRingIdFlag, "ID of the KMS key ring")
 	cmd.Flags().String(displayNameFlag, "", "The display name to distinguish multiple wrapping keys")
 	cmd.Flags().String(descriptionFlag, "", "Optional description of the wrapping key")
 
-	err := flags.MarkFlagsRequired(cmd, keyRingIdFlag, algorithmFlag, purposeFlag, displayNameFlag, protectionFlag)
+	err := flags.MarkFlagsRequired(cmd, keyRingIdFlag, algorithmFlag.Name(), purposeFlag.Name(), displayNameFlag, protectionFlag.Name())
 	cobra.CheckErr(err)
 }

--- a/internal/cmd/kms/wrappingkey/create/create_test.go
+++ b/internal/cmd/kms/wrappingkey/create/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -18,18 +18,18 @@ import (
 
 const (
 	testRegion      = "eu01"
-	testAlgorithm   = "rsa_2048_oaep_sha256"
+	testAlgorithm   = kms.WRAPPINGALGORITHM_RSA_2048_OAEP_SHA256
 	testDisplayName = "my-key"
-	testPurpose     = "wrap_asymmetric_key"
+	testPurpose     = kms.WRAPPINGPURPOSE_WRAP_ASYMMETRIC_KEY
 	testDescription = "my key description"
-	testProtection  = "software"
+	testProtection  = kms.PROTECTION_SOFTWARE
 )
 
 type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 )
@@ -40,11 +40,11 @@ func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]st
 		globalflags.ProjectIdFlag: testProjectId,
 		globalflags.RegionFlag:    testRegion,
 		keyRingIdFlag:             testKeyRingId,
-		algorithmFlag:             testAlgorithm,
+		algorithmFlag.Name():      string(testAlgorithm),
 		displayNameFlag:           testDisplayName,
-		purposeFlag:               testPurpose,
+		purposeFlag.Name():        string(testPurpose),
 		descriptionFlag:           testDescription,
-		protectionFlag:            testProtection,
+		protectionFlag.Name():     string(testProtection),
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -61,11 +61,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		KeyRingId:   testKeyRingId,
-		Algorithm:   utils.Ptr(testAlgorithm),
+		Algorithm:   testAlgorithm,
 		Name:        utils.Ptr(testDisplayName),
-		Purpose:     utils.Ptr(testPurpose),
+		Purpose:     testPurpose,
 		Description: utils.Ptr(testDescription),
-		Protection:  utils.Ptr(testProtection),
+		Protection:  testProtection,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -75,13 +75,13 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiCreateWrappingKeyRequest)) kms.ApiCreateWrappingKeyRequest {
-	request := testClient.CreateWrappingKey(testCtx, testProjectId, testRegion, testKeyRingId)
+	request := testClient.DefaultAPI.CreateWrappingKey(testCtx, testProjectId, testRegion, testKeyRingId)
 	request = request.CreateWrappingKeyPayload(kms.CreateWrappingKeyPayload{
-		Algorithm:   kms.CreateWrappingKeyPayloadGetAlgorithmAttributeType(utils.Ptr(testAlgorithm)),
-		DisplayName: utils.Ptr(testDisplayName),
-		Purpose:     kms.CreateWrappingKeyPayloadGetPurposeAttributeType(utils.Ptr(testPurpose)),
+		Algorithm:   testAlgorithm,
+		DisplayName: testDisplayName,
+		Purpose:     testPurpose,
 		Description: utils.Ptr(testDescription),
-		Protection:  kms.CreateWrappingKeyPayloadGetProtectionAttributeType(utils.Ptr(testProtection)),
+		Protection:  testProtection,
 	})
 
 	for _, mod := range mods {
@@ -156,7 +156,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "algorithm missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, algorithmFlag)
+				delete(flagValues, algorithmFlag.Name())
 			}),
 			isValid: false,
 		},
@@ -170,14 +170,14 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "purpose missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, purposeFlag)
+				delete(flagValues, purposeFlag.Name())
 			}),
 			isValid: false,
 		},
 		{
 			description: "protection missing (required)",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, protectionFlag)
+				delete(flagValues, protectionFlag.Name())
 			}),
 			isValid: false,
 		},
@@ -248,24 +248,24 @@ func TestBuildRequest(t *testing.T) {
 				model.Description = nil
 			}),
 			expectedRequest: fixtureRequest().CreateWrappingKeyPayload(kms.CreateWrappingKeyPayload{
-				Algorithm:   kms.CreateWrappingKeyPayloadGetAlgorithmAttributeType(utils.Ptr(testAlgorithm)),
-				DisplayName: utils.Ptr(testDisplayName),
-				Purpose:     kms.CreateWrappingKeyPayloadGetPurposeAttributeType(utils.Ptr(testPurpose)),
-				Protection:  kms.CreateWrappingKeyPayloadGetProtectionAttributeType(utils.Ptr(testProtection)),
+				Algorithm:   testAlgorithm,
+				DisplayName: testDisplayName,
+				Purpose:     testPurpose,
+				Protection:  testProtection,
 			}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
+			request, err := buildRequest(testCtx, tt.model, testClient.DefaultAPI)
 			if err != nil {
 				t.Fatalf("error building request: %v", err)
 			}
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/wrappingkey/delete/delete.go
+++ b/internal/cmd/kms/wrappingkey/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	kmsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 )
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			wrappingKeyName, err := kmsUtils.GetWrappingKeyName(ctx, apiClient, model.ProjectId, model.Region, model.KeyRingId, model.WrappingKeyId)
+			wrappingKeyName, err := kmsUtils.GetWrappingKeyName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.KeyRingId, model.WrappingKeyId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get wrapping key name: %v", err)
 				wrappingKeyName = model.WrappingKeyId
@@ -108,7 +108,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiDeleteWrappingKeyRequest {
-	req := apiClient.DeleteWrappingKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.WrappingKeyId)
+	req := apiClient.DefaultAPI.DeleteWrappingKey(ctx, model.ProjectId, model.Region, model.KeyRingId, model.WrappingKeyId)
 	return req
 }
 

--- a/internal/cmd/kms/wrappingkey/delete/delete_test.go
+++ b/internal/cmd/kms/wrappingkey/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -22,7 +22,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx           = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient        = &kms.APIClient{}
+	testClient        = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId     = uuid.NewString()
 	testKeyRingId     = uuid.NewString()
 	testWrappingKeyId = uuid.NewString()
@@ -71,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiDeleteWrappingKeyRequest)) kms.ApiDeleteWrappingKeyRequest {
-	request := testClient.DeleteWrappingKey(testCtx, testProjectId, testRegion, testKeyRingId, testWrappingKeyId)
+	request := testClient.DefaultAPI.DeleteWrappingKey(testCtx, testProjectId, testRegion, testKeyRingId, testWrappingKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -232,7 +232,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/kms/wrappingkey/describe/describe.go
+++ b/internal/cmd/kms/wrappingkey/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -91,7 +91,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiGetWrappingKeyRequest {
-	return apiClient.GetWrappingKey(ctx, model.ProjectId, model.Region, model.KeyRingID, model.WrappingKeyID)
+	return apiClient.DefaultAPI.GetWrappingKey(ctx, model.ProjectId, model.Region, model.KeyRingID, model.WrappingKeyID)
 }
 
 func outputResult(p *print.Printer, outputFormat string, wrappingKey *kms.WrappingKey) error {
@@ -100,29 +100,29 @@ func outputResult(p *print.Printer, outputFormat string, wrappingKey *kms.Wrappi
 	}
 	return p.OutputResult(outputFormat, wrappingKey, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(wrappingKey.Id))
+		table.AddRow("ID", wrappingKey.Id)
 		table.AddSeparator()
-		table.AddRow("DISPLAY NAME", utils.PtrString(wrappingKey.DisplayName))
+		table.AddRow("DISPLAY NAME", wrappingKey.DisplayName)
 		table.AddSeparator()
-		table.AddRow("CREATED AT", utils.PtrString(wrappingKey.CreatedAt))
+		table.AddRow("CREATED AT", wrappingKey.CreatedAt)
 		table.AddSeparator()
-		table.AddRow("STATE", utils.PtrString(wrappingKey.State))
+		table.AddRow("STATE", wrappingKey.State)
 		table.AddSeparator()
 		table.AddRow("DESCRIPTION", utils.PtrString(wrappingKey.Description))
 		table.AddSeparator()
-		table.AddRow("ACCESS SCOPE", utils.PtrString(wrappingKey.AccessScope))
+		table.AddRow("ACCESS SCOPE", wrappingKey.AccessScope)
 		table.AddSeparator()
-		table.AddRow("ALGORITHM", utils.PtrString(wrappingKey.Algorithm))
+		table.AddRow("ALGORITHM", wrappingKey.Algorithm)
 		table.AddSeparator()
-		table.AddRow("EXPIRES AT", utils.PtrString(wrappingKey.ExpiresAt))
+		table.AddRow("EXPIRES AT", wrappingKey.ExpiresAt)
 		table.AddSeparator()
-		table.AddRow("KEYRING ID", utils.PtrString(wrappingKey.KeyRingId))
+		table.AddRow("KEYRING ID", wrappingKey.KeyRingId)
 		table.AddSeparator()
-		table.AddRow("PROTECTION", utils.PtrString(wrappingKey.Protection))
+		table.AddRow("PROTECTION", wrappingKey.Protection)
 		table.AddSeparator()
 		table.AddRow("PUBLIC KEY", utils.PtrString(wrappingKey.PublicKey))
 		table.AddSeparator()
-		table.AddRow("PURPOSE", utils.PtrString(wrappingKey.Purpose))
+		table.AddRow("PURPOSE", wrappingKey.Purpose)
 
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/kms/wrappingkey/describe/describe_test.go
+++ b/internal/cmd/kms/wrappingkey/describe/describe_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -20,7 +20,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &kms.APIClient{}
+var testClient = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testKeyRingID = uuid.NewString()
 var testWrappingKeyID = uuid.NewString()
@@ -123,10 +123,10 @@ func TestParseInput(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	got := buildRequest(testCtx, fixtureInputModel(), testClient)
-	want := testClient.GetWrappingKey(testCtx, testProjectId, testRegion, testKeyRingID, testWrappingKeyID)
+	want := testClient.DefaultAPI.GetWrappingKey(testCtx, testProjectId, testRegion, testKeyRingID, testWrappingKeyID)
 	diff := cmp.Diff(got, want,
 		cmp.AllowUnexported(want),
-		cmpopts.EquateComparable(testCtx),
+		cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 	)
 	if diff != "" {
 		t.Fatalf("buildRequest() mismatch (-want +got):\n%s", diff)
@@ -149,18 +149,18 @@ func TestOutputResult(t *testing.T) {
 			description: "table format",
 			outputFmt:   "table",
 			keyRing: &kms.WrappingKey{
-				Id:          utils.Ptr(testWrappingKeyID),
-				DisplayName: utils.Ptr("Test Key Ring"),
-				CreatedAt:   utils.Ptr(testTime),
+				Id:          testWrappingKeyID,
+				DisplayName: "Test Key Ring",
+				CreatedAt:   testTime,
 				Description: utils.Ptr("This is a test key ring."),
-				State:       utils.Ptr(kms.WRAPPINGKEYSTATE_ACTIVE),
-				AccessScope: utils.Ptr(kms.ACCESSSCOPE_PUBLIC),
-				Algorithm:   utils.Ptr(kms.WRAPPINGALGORITHM__2048_OAEP_SHA256),
-				ExpiresAt:   utils.Ptr(testTime),
-				KeyRingId:   utils.Ptr(testKeyRingID),
-				Protection:  utils.Ptr(kms.PROTECTION_SOFTWARE),
+				State:       kms.WRAPPINGKEYSTATE_ACTIVE,
+				AccessScope: kms.ACCESSSCOPE_PUBLIC,
+				Algorithm:   kms.WRAPPINGALGORITHM_RSA_2048_OAEP_SHA256,
+				ExpiresAt:   testTime,
+				KeyRingId:   testKeyRingID,
+				Protection:  kms.PROTECTION_SOFTWARE,
 				PublicKey:   utils.Ptr("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQ...\n-----END PUBLIC KEY-----"),
-				Purpose:     utils.Ptr(kms.WRAPPINGPURPOSE_ASYMMETRIC_KEY),
+				Purpose:     kms.WRAPPINGPURPOSE_WRAP_ASYMMETRIC_KEY,
 			},
 			expected: fmt.Sprintf(`
  ID           │ %-46s

--- a/internal/cmd/kms/wrappingkey/list/list.go
+++ b/internal/cmd/kms/wrappingkey/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -17,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/kms/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -87,7 +86,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command) (*inputModel, error) {
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *kms.APIClient) kms.ApiListWrappingKeysRequest {
-	req := apiClient.ListWrappingKeys(ctx, model.ProjectId, model.Region, model.KeyRingId)
+	req := apiClient.DefaultAPI.ListWrappingKeys(ctx, model.ProjectId, model.Region, model.KeyRingId)
 	return req
 }
 
@@ -102,7 +101,7 @@ func outputResult(p *print.Printer, outputFormat, keyRingId string, resp *kms.Wr
 		return fmt.Errorf("response is nil / empty")
 	}
 
-	wrappingKeys := *resp.WrappingKeys
+	wrappingKeys := resp.WrappingKeys
 
 	return p.OutputResult(outputFormat, wrappingKeys, func() error {
 		if len(wrappingKeys) == 0 {
@@ -115,12 +114,12 @@ func outputResult(p *print.Printer, outputFormat, keyRingId string, resp *kms.Wr
 		for i := range wrappingKeys {
 			wrappingKey := wrappingKeys[i]
 			table.AddRow(
-				utils.PtrString(wrappingKey.Id),
-				utils.PtrString(wrappingKey.DisplayName),
-				utils.PtrString(wrappingKey.Purpose),
-				utils.PtrString(wrappingKey.Algorithm),
-				utils.PtrString(wrappingKey.ExpiresAt),
-				utils.PtrString(wrappingKey.State),
+				wrappingKey.Id,
+				wrappingKey.DisplayName,
+				wrappingKey.Purpose,
+				wrappingKey.Algorithm,
+				wrappingKey.ExpiresAt,
+				wrappingKey.State,
 			)
 		}
 

--- a/internal/cmd/kms/wrappingkey/list/list_test.go
+++ b/internal/cmd/kms/wrappingkey/list/list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &kms.APIClient{}
+	testClient    = &kms.APIClient{DefaultAPI: &kms.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 	testKeyRingId = uuid.NewString()
 )
@@ -59,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *kms.ApiListWrappingKeysRequest)) kms.ApiListWrappingKeysRequest {
-	request := testClient.ListWrappingKeys(testCtx, testProjectId, testRegion, testKeyRingId)
+	request := testClient.DefaultAPI.ListWrappingKeys(testCtx, testProjectId, testRegion, testKeyRingId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -194,7 +194,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, kms.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -220,19 +220,19 @@ func TestOutputResult(t *testing.T) {
 		},
 		{
 			description:  "default output",
-			resp:         &kms.WrappingKeyList{WrappingKeys: &[]kms.WrappingKey{}},
+			resp:         &kms.WrappingKeyList{WrappingKeys: []kms.WrappingKey{}},
 			projectLabel: "my-project",
 			wantErr:      false,
 		},
 		{
 			description:  "json output",
-			resp:         &kms.WrappingKeyList{WrappingKeys: &[]kms.WrappingKey{}},
+			resp:         &kms.WrappingKeyList{WrappingKeys: []kms.WrappingKey{}},
 			outputFormat: print.JSONOutputFormat,
 			wantErr:      false,
 		},
 		{
 			description:  "yaml output",
-			resp:         &kms.WrappingKeyList{WrappingKeys: &[]kms.WrappingKey{}},
+			resp:         &kms.WrappingKeyList{WrappingKeys: []kms.WrappingKey{}},
 			outputFormat: print.YAMLOutputFormat,
 			wantErr:      false,
 		},

--- a/internal/pkg/services/kms/client/client.go
+++ b/internal/pkg/services/kms/client/client.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*kms.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.KMSCustomEndpointKey), false, genericclient.CreateApiClient[*kms.APIClient](kms.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.KMSCustomEndpointKey), false, kms.NewAPIClient)
 }

--- a/internal/pkg/services/kms/utils/utils.go
+++ b/internal/pkg/services/kms/utils/utils.go
@@ -5,30 +5,24 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 )
 
-type KMSClient interface {
-	GetKeyExecute(ctx context.Context, projectId string, regionId string, keyRingId string, keyId string) (*kms.Key, error)
-	GetKeyRingExecute(ctx context.Context, projectId string, regionId string, keyRingId string) (*kms.KeyRing, error)
-	GetWrappingKeyExecute(ctx context.Context, projectId string, regionId string, keyRingId string, wrappingKeyId string) (*kms.WrappingKey, error)
-}
-
-func GetKeyName(ctx context.Context, apiClient KMSClient, projectId, region, keyRingId, keyId string) (string, error) {
-	resp, err := apiClient.GetKeyExecute(ctx, projectId, region, keyRingId, keyId)
+func GetKeyName(ctx context.Context, apiClient kms.DefaultAPI, projectId, region, keyRingId, keyId string) (string, error) {
+	resp, err := apiClient.GetKey(ctx, projectId, region, keyRingId, keyId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get KMS Key: %w", err)
 	}
 
-	if resp == nil || resp.DisplayName == nil {
+	if resp == nil {
 		return "", fmt.Errorf("response is nil / empty")
 	}
 
-	return *resp.DisplayName, nil
+	return resp.DisplayName, nil
 }
 
-func GetKeyDeletionDate(ctx context.Context, apiClient KMSClient, projectId, region, keyRingId, keyId string) (time.Time, error) {
-	resp, err := apiClient.GetKeyExecute(ctx, projectId, region, keyRingId, keyId)
+func GetKeyDeletionDate(ctx context.Context, apiClient kms.DefaultAPI, projectId, region, keyRingId, keyId string) (time.Time, error) {
+	resp, err := apiClient.GetKey(ctx, projectId, region, keyRingId, keyId).Execute()
 	if err != nil {
 		return time.Now(), fmt.Errorf("get KMS Key: %w", err)
 	}
@@ -40,28 +34,28 @@ func GetKeyDeletionDate(ctx context.Context, apiClient KMSClient, projectId, reg
 	return *resp.DeletionDate, nil
 }
 
-func GetKeyRingName(ctx context.Context, apiClient KMSClient, projectId, id, region string) (string, error) {
-	resp, err := apiClient.GetKeyRingExecute(ctx, projectId, region, id)
+func GetKeyRingName(ctx context.Context, apiClient kms.DefaultAPI, projectId, id, region string) (string, error) {
+	resp, err := apiClient.GetKeyRing(ctx, projectId, region, id).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get KMS key ring: %w", err)
 	}
 
-	if resp == nil || resp.DisplayName == nil {
+	if resp == nil {
 		return "", fmt.Errorf("response is nil / empty")
 	}
 
-	return *resp.DisplayName, nil
+	return resp.DisplayName, nil
 }
 
-func GetWrappingKeyName(ctx context.Context, apiClient KMSClient, projectId, region, keyRingId, wrappingKeyId string) (string, error) {
-	resp, err := apiClient.GetWrappingKeyExecute(ctx, projectId, region, keyRingId, wrappingKeyId)
+func GetWrappingKeyName(ctx context.Context, apiClient kms.DefaultAPI, projectId, region, keyRingId, wrappingKeyId string) (string, error) {
+	resp, err := apiClient.GetWrappingKey(ctx, projectId, region, keyRingId, wrappingKeyId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get KMS Wrapping Key: %w", err)
 	}
 
-	if resp == nil || resp.DisplayName == nil {
+	if resp == nil {
 		return "", fmt.Errorf("response is nil / empty")
 	}
 
-	return *resp.DisplayName, nil
+	return resp.DisplayName, nil
 }

--- a/internal/pkg/services/kms/utils/utils_test.go
+++ b/internal/pkg/services/kms/utils/utils_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 var (
@@ -33,26 +35,27 @@ type kmsClientMocked struct {
 	getWrappingKeyResp  *kms.WrappingKey
 }
 
-// Implement the KMSClient interface methods for the mock.
-func (m *kmsClientMocked) GetKeyExecute(_ context.Context, _, _, _, _ string) (*kms.Key, error) {
-	if m.getKeyFails {
-		return nil, fmt.Errorf("could not get key")
+func (m *kmsClientMocked) newMock() kms.DefaultAPI {
+	return kms.DefaultAPIServiceMock{
+		GetKeyExecuteMock: utils.Ptr(func(_ kms.ApiGetKeyRequest) (*kms.Key, error) {
+			if m.getKeyFails {
+				return nil, fmt.Errorf("could not get key")
+			}
+			return m.getKeyResp, nil
+		}),
+		GetKeyRingExecuteMock: utils.Ptr(func(_ kms.ApiGetKeyRingRequest) (*kms.KeyRing, error) {
+			if m.getKeyRingFails {
+				return nil, fmt.Errorf("could not get key ring")
+			}
+			return m.getKeyRingResp, nil
+		}),
+		GetWrappingKeyExecuteMock: utils.Ptr(func(_ kms.ApiGetWrappingKeyRequest) (*kms.WrappingKey, error) {
+			if m.getWrappingKeyFails {
+				return nil, fmt.Errorf("could not get wrapping key")
+			}
+			return m.getWrappingKeyResp, nil
+		}),
 	}
-	return m.getKeyResp, nil
-}
-
-func (m *kmsClientMocked) GetKeyRingExecute(_ context.Context, _, _, _ string) (*kms.KeyRing, error) {
-	if m.getKeyRingFails {
-		return nil, fmt.Errorf("could not get key ring")
-	}
-	return m.getKeyRingResp, nil
-}
-
-func (m *kmsClientMocked) GetWrappingKeyExecute(_ context.Context, _, _, _, _ string) (*kms.WrappingKey, error) {
-	if m.getWrappingKeyFails {
-		return nil, fmt.Errorf("could not get wrapping key")
-	}
-	return m.getWrappingKeyResp, nil
 }
 
 func TestGetKeyName(t *testing.T) {
@@ -68,7 +71,7 @@ func TestGetKeyName(t *testing.T) {
 		{
 			description: "base",
 			getKeyResp: &kms.Key{
-				DisplayName: &keyName,
+				DisplayName: keyName,
 			},
 			isValid:        true,
 			expectedOutput: testKeyName,
@@ -87,7 +90,7 @@ func TestGetKeyName(t *testing.T) {
 				getKeyResp:  tt.getKeyResp,
 			}
 
-			output, err := GetKeyName(context.Background(), client, testProjectId, testRegion, testKeyRingId, testKeyId)
+			output, err := GetKeyName(context.Background(), client.newMock(), testProjectId, testRegion, testKeyRingId, testKeyId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input: %v", err)
@@ -138,7 +141,7 @@ func TestGetKeyDeletionDate(t *testing.T) {
 				getKeyResp:  tt.getKeyResp,
 			}
 
-			output, err := GetKeyDeletionDate(context.Background(), client, testProjectId, testRegion, testKeyRingId, testKeyId)
+			output, err := GetKeyDeletionDate(context.Background(), client.newMock(), testProjectId, testRegion, testKeyRingId, testKeyId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input: %v", err)
@@ -170,7 +173,7 @@ func TestGetKeyRingName(t *testing.T) {
 		{
 			description: "base",
 			getKeyRingResp: &kms.KeyRing{
-				DisplayName: &keyRingName,
+				DisplayName: keyRingName,
 			},
 			isValid:        true,
 			expectedOutput: testKeyRingName,
@@ -189,7 +192,7 @@ func TestGetKeyRingName(t *testing.T) {
 				getKeyRingResp:  tt.getKeyRingResp,
 			}
 
-			output, err := GetKeyRingName(context.Background(), client, testProjectId, testKeyRingId, testRegion)
+			output, err := GetKeyRingName(context.Background(), client.newMock(), testProjectId, testKeyRingId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input: %v", err)
@@ -219,7 +222,7 @@ func TestGetWrappingKeyName(t *testing.T) {
 		{
 			description: "base",
 			getWrappingKeyResp: &kms.WrappingKey{
-				DisplayName: &wrappingKeyName,
+				DisplayName: wrappingKeyName,
 			},
 			isValid:        true,
 			expectedOutput: testWrappingKeyName,
@@ -238,7 +241,7 @@ func TestGetWrappingKeyName(t *testing.T) {
 				getWrappingKeyResp:  tt.getWrappingKeyResp,
 			}
 
-			output, err := GetWrappingKeyName(context.Background(), client, testProjectId, testRegion, testKeyRingId, testWrappingKeyId)
+			output, err := GetWrappingKeyName(context.Background(), client.newMock(), testProjectId, testRegion, testKeyRingId, testWrappingKeyId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input: %v", err)


### PR DESCRIPTION
STACKITCLI-364

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
