### PR TITLE
feat(intake): add force flag for deleting intake runners

### DIFF
--- a/docs/stackit_beta_intake_runner_delete.md
+++ b/docs/stackit_beta_intake_runner_delete.md
@@ -15,12 +15,16 @@ stackit beta intake runner delete RUNNER_ID [flags]
 ```
   Delete an Intake Runner with ID "xxx"
   $ stackit beta intake runner delete xxx
+
+  Delete an Intake Runner with ID "xxx", along with all associated Intakes and Intake Users that would stop the removal of the Intake
+  $ stackit beta intake runner delete xxx --force
 ```
 
 ### Options
 
 ```
-  -h, --help   Help for "stackit beta intake runner delete"
+      --force   When true, also removes all associated Intakes and Intake Users that would stop the removal of the Intake
+  -h, --help    Help for "stackit beta intake runner delete"
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/beta/intake/runner/delete/delete.go
+++ b/internal/cmd/beta/intake/runner/delete/delete.go
@@ -22,15 +22,15 @@ import (
 )
 
 const (
-	runnerIdArg = "RUNNER_ID"
-	forceFlag   = "force"
+	runnerIdArg     = "RUNNER_ID"
+	forceDeleteFlag = "force"
 )
 
 // inputModel struct holds all the input parameters for the command
 type inputModel struct {
 	*globalflags.GlobalFlagModel
-	RunnerId string
-	Force    bool
+	RunnerId    string
+	ForceDelete bool
 }
 
 // NewCmd creates a new cobra command for deleting an Intake Runner
@@ -62,7 +62,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			}
 
 			prompt := fmt.Sprintf("Are you sure you want to delete Intake Runner %q?", model.RunnerId)
-			if model.Force {
+			if model.ForceDelete {
 				prompt = fmt.Sprintf("%s This will also remove all Intakes and Intake Users that would stop the removal of the Intake", prompt)
 			}
 			err = p.Printer.PromptForConfirmation(prompt)
@@ -101,7 +101,7 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 }
 
 func configureFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(forceFlag, false, "When true, also removes all associated Intakes and Intake Users that would stop the removal of the Intake")
+	cmd.Flags().Bool(forceDeleteFlag, false, "When true, also removes all associated Intakes and Intake Users that would stop the removal of the Intake")
 }
 
 // parseInput parses the command arguments and flags into a standardized model
@@ -116,7 +116,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		RunnerId:        runnerId,
-		Force:           flags.FlagToBoolValue(p, cmd, forceFlag),
+		ForceDelete:     flags.FlagToBoolValue(p, cmd, forceDeleteFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -126,7 +126,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 // buildRequest creates the API request to delete an Intake Runner
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeRunnerRequest {
 	req := apiClient.DefaultAPI.DeleteIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
-	if model.Force {
+	if model.ForceDelete {
 		return req.Force(true)
 	}
 	return req

--- a/internal/cmd/beta/intake/runner/delete/delete.go
+++ b/internal/cmd/beta/intake/runner/delete/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
@@ -22,12 +23,14 @@ import (
 
 const (
 	runnerIdArg = "RUNNER_ID"
+	forceFlag   = "force"
 )
 
 // inputModel struct holds all the input parameters for the command
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	RunnerId string
+	Force    bool
 }
 
 // NewCmd creates a new cobra command for deleting an Intake Runner
@@ -41,6 +44,9 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			examples.NewExample(
 				`Delete an Intake Runner with ID "xxx"`,
 				`$ stackit beta intake runner delete xxx`),
+			examples.NewExample(
+				`Delete an Intake Runner with ID "xxx", along with all associated Intakes and Intake Users that would stop the removal of the Intake`,
+				`$ stackit beta intake runner delete xxx --force`),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -56,6 +62,9 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			}
 
 			prompt := fmt.Sprintf("Are you sure you want to delete Intake Runner %q?", model.RunnerId)
+			if model.Force {
+				prompt = fmt.Sprintf("%s This will also remove all Intakes and Intake Users that would stop the removal of the Intake", prompt)
+			}
 			err = p.Printer.PromptForConfirmation(prompt)
 			if err != nil {
 				return err
@@ -87,7 +96,12 @@ func NewCmd(p *types.CmdParams) *cobra.Command {
 			return nil
 		},
 	}
+	configureFlags(cmd)
 	return cmd
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool(forceFlag, false, "When true, also removes all associated Intakes and Intake Users that would stop the removal of the Intake")
 }
 
 // parseInput parses the command arguments and flags into a standardized model
@@ -102,6 +116,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		RunnerId:        runnerId,
+		Force:           flags.FlagToBoolValue(p, cmd, forceFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -111,5 +126,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 // buildRequest creates the API request to delete an Intake Runner
 func buildRequest(ctx context.Context, model *inputModel, apiClient *intake.APIClient) intake.ApiDeleteIntakeRunnerRequest {
 	req := apiClient.DefaultAPI.DeleteIntakeRunner(ctx, model.ProjectId, model.Region, model.RunnerId)
+	if model.Force {
+		return req.Force(true)
+	}
 	return req
 }

--- a/internal/cmd/beta/intake/runner/delete/delete_test.go
+++ b/internal/cmd/beta/intake/runner/delete/delete_test.go
@@ -98,11 +98,11 @@ func TestParseInput(t *testing.T) {
 			description: "with force",
 			argValues:   fixtureArgValues(),
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[forceFlag] = "true"
+				flagValues[forceDeleteFlag] = "true"
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Force = true
+				model.ForceDelete = true
 			}),
 		},
 		{
@@ -154,7 +154,7 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "with force",
 			model: fixtureInputModel(func(model *inputModel) {
-				model.Force = true
+				model.ForceDelete = true
 			}),
 			expectedRequest: fixtureRequest().Force(true),
 		},

--- a/internal/cmd/beta/intake/runner/delete/delete_test.go
+++ b/internal/cmd/beta/intake/runner/delete/delete_test.go
@@ -95,6 +95,17 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(),
 		},
 		{
+			description: "with force",
+			argValues:   fixtureArgValues(),
+			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
+				flagValues[forceFlag] = "true"
+			}),
+			isValid: true,
+			expectedModel: fixtureInputModel(func(model *inputModel) {
+				model.Force = true
+			}),
+		},
+		{
 			description: "no arg values",
 			argValues:   []string{},
 			flagValues:  fixtureFlagValues(),
@@ -139,6 +150,13 @@ func TestBuildRequest(t *testing.T) {
 			description:     "base",
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
+		},
+		{
+			description: "with force",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.Force = true
+			}),
+			expectedRequest: fixtureRequest().Force(true),
 		},
 	}
 


### PR DESCRIPTION
## Description

Adds a flag to enable calling delete intake runner API with force parameter.

relates to STACKITINT-1392

## Checklist

- [X] Issue was linked above
- [X] Code format was applied: `make fmt`
- [X] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [X] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
