### PR TITLE
chore(load balancer): remove local interface

### DIFF
--- a/internal/cmd/load-balancer/observability-credentials/update/update.go
+++ b/internal/cmd/load-balancer/observability-credentials/update/update.go
@@ -28,16 +28,6 @@ const (
 	credentialsRefArg = "CREDENTIALS_REF" //nolint:gosec // linter false positive
 )
 
-// enforce implementation of interfaces
-var (
-	_ loadBalancerClient = loadbalancer.APIClient{}.DefaultAPI
-)
-
-type loadBalancerClient interface {
-	UpdateCredentials(ctx context.Context, projectId, region, credentialsRef string) loadbalancer.ApiUpdateCredentialsRequest
-	GetCredentials(ctx context.Context, projectId string, region string, credentialsRef string) loadbalancer.ApiGetCredentialsRequest
-}
-
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	CredentialsRef string
@@ -138,7 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	}, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient loadBalancerClient) (loadbalancer.ApiUpdateCredentialsRequest, error) {
+func buildRequest(ctx context.Context, model *inputModel, apiClient loadbalancer.DefaultAPI) (loadbalancer.ApiUpdateCredentialsRequest, error) {
 	req := apiClient.UpdateCredentials(ctx, model.ProjectId, model.Region, model.CredentialsRef)
 
 	currentCredentials, err := apiClient.GetCredentials(ctx, model.ProjectId, model.Region, model.CredentialsRef).Execute()


### PR DESCRIPTION
## Description

Interface was missed to discard.

relates to STACKITCLI-365 and https://github.com/stackitcloud/stackit-cli/pull/1432

Testing: 
- stackit load-balancer observability-credentials add --username [user name] --display-name [display name]
- stackit load-balancer observability-credentials update credentials-rft8d --username test-name [new user name]

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
