### PR TITLE
chore(logs): sdk migration

### DIFF
--- a/docs/stackit_logs_access-token_create.md
+++ b/docs/stackit_logs_access-token_create.md
@@ -30,7 +30,7 @@ stackit logs access-token create [flags]
       --display-name string   Display name for the access token
   -h, --help                  Help for "stackit logs access-token create"
       --instance-id string    ID of the Logs instance
-      --lifetime int          Lifetime of the access token in days [1 - 180]
+      --lifetime int32        Lifetime of the access token in days [1 - 180]
       --permissions strings   Permissions of the access token ["read" "write"]
 ```
 

--- a/docs/stackit_logs_instance_create.md
+++ b/docs/stackit_logs_instance_create.md
@@ -26,11 +26,11 @@ stackit logs instance create [flags]
 ### Options
 
 ```
-      --acl strings           Access control list
-      --description string    Description
-      --display-name string   Display name
-  -h, --help                  Help for "stackit logs instance create"
-      --retention-days int    The days for how long the logs should be stored before being cleaned up
+      --acl strings            Access control list
+      --description string     Description
+      --display-name string    Display name
+  -h, --help                   Help for "stackit logs instance create"
+      --retention-days int32   The days for how long the logs should be stored before being cleaned up
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_logs_instance_update.md
+++ b/docs/stackit_logs_instance_update.md
@@ -26,11 +26,11 @@ stackit logs instance update INSTANCE_ID [flags]
 ### Options
 
 ```
-      --acl strings           Access control list
-      --description string    Description
-      --display-name string   Display name
-  -h, --help                  Help for "stackit logs instance update"
-      --retention-days int    The days for how long the logs should be stored before being cleaned up
+      --acl strings            Access control list
+      --description string     Description
+      --display-name string    Display name
+  -h, --help                   Help for "stackit logs instance update"
+      --retention-days int32   The days for how long the logs should be stored before being cleaned up
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -233,9 +233,9 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
-	golang.org/x/tools v0.43.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
+	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.13.0
 	github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1
-	github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2
+	github.com/stackitcloud/stackit-sdk-go/services/logs v0.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.1.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.11.0
@@ -233,9 +233,9 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
-	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
-	golang.org/x/tools v0.47.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
+	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0 h1:1dvL7tX9
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0/go.mod h1:+Ld3dn648I+YKcBV3fEkYpDSr3fel421+LurJGywSBs=
 github.com/stackitcloud/stackit-sdk-go/services/logme v1.0.1 h1:iteL61eMMPWT6872nF4Ko/tBU1IXemvS++XR09pj6NA=
 github.com/stackitcloud/stackit-sdk-go/services/logme v1.0.1/go.mod h1:JDOOYaGgcBts2x52nKPRMFgSZe7qqOFmfz1xIXCQgRY=
-github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2 h1:vr4atxFRT+EL+DqONMT5R44f7AzEMbePa9U7PEE0THU=
-github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2/go.mod h1:CAPsiTX7osAImfrG5RnIjaJ/Iz3QpoBKuH2fS346wuQ=
+github.com/stackitcloud/stackit-sdk-go/services/logs v0.10.0 h1:g7zpfQFFq3UhAWrMK9rPaZY6dLMAuMJf5g6+r7VRTXc=
+github.com/stackitcloud/stackit-sdk-go/services/logs v0.10.0/go.mod h1:tvRejL8w5KpGBbLFPQ+dXOJURgZ3OMbZmwxlKQrGMuA=
 github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0 h1:LFIH1wAp633ZAJw/7H3F4nq1DZe0Qu3rlDeXhobZEZA=
 github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0/go.mod h1:joa89Y1dyn0j22FstRcIKfW2ada3FDxNfttxSvq27uY=
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0 h1:SVd3WMmLAE0Jxk2SaRuM85DTOOXHycyMpZGx9vzqNkI=

--- a/internal/cmd/logs/access_token/create/create.go
+++ b/internal/cmd/logs/access_token/create/create.go
@@ -138,10 +138,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiCreateAccessTokenRequest {
 	req := apiClient.DefaultAPI.CreateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId)
-	permissions := make([]logs.PermissionsInner, len(model.Permissions))
-	for i, permission := range model.Permissions {
-		permissions[i] = logs.PermissionsInner(permission)
-	}
+	permissions := utils.Map(model.Permissions, func(t string) logs.PermissionsInner {
+		return logs.PermissionsInner(t)
+	})
 	return req.CreateAccessTokenPayload(logs.CreateAccessTokenPayload{
 		Description: model.Description,
 		DisplayName: model.DisplayName,

--- a/internal/cmd/logs/access_token/create/create.go
+++ b/internal/cmd/logs/access_token/create/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/logs/access_token/create/create.go
+++ b/internal/cmd/logs/access_token/create/create.go
@@ -35,7 +35,7 @@ type inputModel struct {
 	InstanceId  string
 	Description *string
 	DisplayName string
-	Lifetime    *int64
+	Lifetime    *int32
 	Permissions []string
 }
 
@@ -80,7 +80,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				projectLabel = model.ProjectId
 			}
 
-			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId)
+			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -110,7 +110,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.UUIDFlag(), instanceIdFlag, "ID of the Logs instance")
 	cmd.Flags().String(displayNameFlag, "", "Display name for the access token")
 	cmd.Flags().String(descriptionFlag, "", "Description of the access token")
-	cmd.Flags().Int64(lifetimeFlag, 0, "Lifetime of the access token in days [1 - 180]")
+	cmd.Flags().Int32(lifetimeFlag, 0, "Lifetime of the access token in days [1 - 180]")
 	cmd.Flags().StringSlice(permissionsFlag, []string{}, `Permissions of the access token ["read" "write"]`)
 
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag, displayNameFlag, permissionsFlag)
@@ -128,7 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		DisplayName:     flags.FlagToStringValue(p, cmd, displayNameFlag),
 		InstanceId:      flags.FlagToStringValue(p, cmd, instanceIdFlag),
 		Description:     flags.FlagToStringPointer(p, cmd, descriptionFlag),
-		Lifetime:        flags.FlagToInt64Pointer(p, cmd, lifetimeFlag),
+		Lifetime:        flags.FlagToInt32Pointer(p, cmd, lifetimeFlag),
 		Permissions:     flags.FlagToStringSliceValue(p, cmd, permissionsFlag),
 	}
 
@@ -137,13 +137,16 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiCreateAccessTokenRequest {
-	req := apiClient.CreateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId)
-
+	req := apiClient.DefaultAPI.CreateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId)
+	permissions := make([]logs.PermissionsInner, len(model.Permissions))
+	for i, permission := range model.Permissions {
+		permissions[i] = logs.PermissionsInner(permission)
+	}
 	return req.CreateAccessTokenPayload(logs.CreateAccessTokenPayload{
 		Description: model.Description,
-		DisplayName: &model.DisplayName,
+		DisplayName: model.DisplayName,
 		Lifetime:    model.Lifetime,
-		Permissions: &model.Permissions,
+		Permissions: permissions,
 	})
 }
 
@@ -152,7 +155,7 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, accessTo
 		return fmt.Errorf("access token cannot be nil")
 	}
 	return p.OutputResult(outputFormat, accessToken, func() error {
-		p.Outputf("Created access token for Logs instance %q.\n\nID: %s\nToken: %s\n", instanceLabel, utils.PtrValue(accessToken.Id), utils.PtrValue(accessToken.AccessToken))
+		p.Outputf("Created access token for Logs instance %q.\n\nID: %s\nToken: %s\n", instanceLabel, accessToken.Id, utils.PtrValue(accessToken.AccessToken))
 		return nil
 	})
 }

--- a/internal/cmd/logs/access_token/create/create.go
+++ b/internal/cmd/logs/access_token/create/create.go
@@ -138,14 +138,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiCreateAccessTokenRequest {
 	req := apiClient.DefaultAPI.CreateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId)
-	permissions := utils.Map(model.Permissions, func(t string) logs.PermissionsInner {
-		return logs.PermissionsInner(t)
-	})
 	return req.CreateAccessTokenPayload(logs.CreateAccessTokenPayload{
 		Description: model.Description,
 		DisplayName: model.DisplayName,
 		Lifetime:    model.Lifetime,
-		Permissions: permissions,
+		Permissions: utils.Map(model.Permissions, func(t string) logs.PermissionsInner {
+			return logs.PermissionsInner(t)
+		}),
 	})
 }
 

--- a/internal/cmd/logs/access_token/create/create_test.go
+++ b/internal/cmd/logs/access_token/create/create_test.go
@@ -192,9 +192,7 @@ func TestParseInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			testutils.TestParseInputWithOptions(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, nil, tt.isValid, []testutils.TestingOption{
-				testutils.WithCmpOptions(cmpopts.EquateEmpty()),
-			})
+			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
 		})
 	}
 }

--- a/internal/cmd/logs/access_token/create/create_test.go
+++ b/internal/cmd/logs/access_token/create/create_test.go
@@ -216,7 +216,6 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
-				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/create/create_test.go
+++ b/internal/cmd/logs/access_token/create/create_test.go
@@ -86,8 +86,8 @@ func fixturePayload(mods ...func(payload *logs.CreateAccessTokenPayload)) logs.C
 		Description: utils.Ptr(testDescription),
 		Lifetime:    utils.Ptr(int32(0)),
 		Permissions: []logs.PermissionsInner{
-			"read",
-			"write",
+			logs.PERMISSIONSINNER_READ,
+			logs.PERMISSIONSINNER_WRITE,
 		},
 	}
 	for _, mod := range mods {
@@ -215,8 +215,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
-				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {
@@ -244,8 +243,8 @@ func TestOutputResult(t *testing.T) {
 				accessToken: utils.Ptr(logs.AccessToken{
 					Id: uuid.NewString(),
 					Permissions: []logs.PermissionsInner{
-						"read",
-						"write",
+						logs.PERMISSIONSINNER_READ,
+						logs.PERMISSIONSINNER_WRITE,
 					},
 					DisplayName: "Token",
 					AccessToken: utils.Ptr("Secret access token"),

--- a/internal/cmd/logs/access_token/create/create_test.go
+++ b/internal/cmd/logs/access_token/create/create_test.go
@@ -26,7 +26,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx        = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient     = &logs.APIClient{}
+	testClient     = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
 )
@@ -59,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceId:  testInstanceId,
 		Description: utils.Ptr(testDescription),
 		DisplayName: testDisplayName,
-		Lifetime:    utils.Ptr(int64(0)),
+		Lifetime:    utils.Ptr(int32(0)),
 		Permissions: []string{
 			"read",
 			"write",
@@ -72,7 +72,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiCreateAccessTokenRequest)) logs.ApiCreateAccessTokenRequest {
-	request := testClient.CreateAccessToken(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.CreateAccessToken(testCtx, testProjectId, testRegion, testInstanceId)
 	request = request.CreateAccessTokenPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -82,13 +82,13 @@ func fixtureRequest(mods ...func(request *logs.ApiCreateAccessTokenRequest)) log
 
 func fixturePayload(mods ...func(payload *logs.CreateAccessTokenPayload)) logs.CreateAccessTokenPayload {
 	payload := logs.CreateAccessTokenPayload{
-		DisplayName: utils.Ptr(testDisplayName),
+		DisplayName: testDisplayName,
 		Description: utils.Ptr(testDescription),
-		Lifetime:    utils.Ptr(int64(0)),
-		Permissions: utils.Ptr([]string{
+		Lifetime:    utils.Ptr(int32(0)),
+		Permissions: []logs.PermissionsInner{
 			"read",
 			"write",
-		}),
+		},
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -192,7 +192,9 @@ func TestParseInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			testutils.TestParseInput(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, tt.isValid)
+			testutils.TestParseInputWithOptions(t, NewCmd, parseInput, tt.expectedModel, tt.argValues, tt.flagValues, nil, tt.isValid, []testutils.TestingOption{
+				testutils.WithCmpOptions(cmpopts.EquateEmpty()),
+			})
 		})
 	}
 }
@@ -216,6 +218,8 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
+				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -240,16 +244,16 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				instanceLabel: "",
 				accessToken: utils.Ptr(logs.AccessToken{
-					Id: utils.Ptr(uuid.NewString()),
-					Permissions: utils.Ptr([]string{
+					Id: uuid.NewString(),
+					Permissions: []logs.PermissionsInner{
 						"read",
 						"write",
-					}),
-					DisplayName: utils.Ptr("Token"),
+					},
+					DisplayName: "Token",
 					AccessToken: utils.Ptr("Secret access token"),
-					Creator:     utils.Ptr(uuid.NewString()),
-					Expires:     utils.Ptr(false),
-					Status:      utils.Ptr(logs.ACCESSTOKENSTATUS_ACTIVE),
+					Creator:     uuid.NewString(),
+					Expires:     false,
+					Status:      logs.ACCESSTOKENSTATUS_ACTIVE,
 				}),
 			},
 			wantErr: false,

--- a/internal/cmd/logs/access_token/create/create_test.go
+++ b/internal/cmd/logs/access_token/create/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/delete/delete.go
+++ b/internal/cmd/logs/access_token/delete/delete.go
@@ -58,7 +58,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the display name for confirmation
-			accessTokenLabel, err := logUtils.GetAccessTokenName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
+			accessTokenLabel, err := logUtils.GetAccessTokenName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get access token: %v", err)
 			}
@@ -113,5 +113,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiDeleteAccessTokenRequest {
-	return apiClient.DeleteAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
+	return apiClient.DefaultAPI.DeleteAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
 }

--- a/internal/cmd/logs/access_token/delete/delete.go
+++ b/internal/cmd/logs/access_token/delete/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"

--- a/internal/cmd/logs/access_token/delete/delete_test.go
+++ b/internal/cmd/logs/access_token/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/delete/delete_test.go
+++ b/internal/cmd/logs/access_token/delete/delete_test.go
@@ -197,7 +197,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete/delete_test.go
+++ b/internal/cmd/logs/access_token/delete/delete_test.go
@@ -21,7 +21,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId     = uuid.NewString()
 	testInstanceId    = uuid.NewString()
@@ -69,7 +69,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiDeleteAccessTokenRequest)) logs.ApiDeleteAccessTokenRequest {
-	request := testClient.DeleteAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
+	request := testClient.DefaultAPI.DeleteAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -197,7 +197,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete_all/delete_all.go
+++ b/internal/cmd/logs/access_token/delete_all/delete_all.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"

--- a/internal/cmd/logs/access_token/delete_all/delete_all.go
+++ b/internal/cmd/logs/access_token/delete_all/delete_all.go
@@ -7,16 +7,14 @@ import (
 	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/client"
 	logUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -55,7 +53,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId)
+			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -77,7 +75,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("delete all access token: nil result")
 			}
 
-			params.Printer.Outputf("Deleted %d access token(s)\n", len(utils.PtrValue(items.Tokens)))
+			params.Printer.Outputf("Deleted %d access token(s)\n", len(items.Tokens))
 			return nil
 		},
 	}
@@ -108,5 +106,5 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiDeleteAllAccessTokensRequest {
-	return apiClient.DeleteAllAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
+	return apiClient.DefaultAPI.DeleteAllAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
 }

--- a/internal/cmd/logs/access_token/delete_all/delete_all_test.go
+++ b/internal/cmd/logs/access_token/delete_all/delete_all_test.go
@@ -21,7 +21,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiDeleteAllAccessTokensRequest)) logs.ApiDeleteAllAccessTokensRequest {
-	request := testClient.DeleteAllAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.DeleteAllAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete_all/delete_all_test.go
+++ b/internal/cmd/logs/access_token/delete_all/delete_all_test.go
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete_all/delete_all_test.go
+++ b/internal/cmd/logs/access_token/delete_all/delete_all_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired.go
+++ b/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired.go
@@ -7,16 +7,14 @@ import (
 	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/client"
 	logUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -55,7 +53,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId)
+			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -77,7 +75,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("delete all expired access token: nil result")
 			}
 
-			params.Printer.Outputf("Deleted %d expired access token(s)\n", len(utils.PtrValue(items.Tokens)))
+			params.Printer.Outputf("Deleted %d expired access token(s)\n", len(items.Tokens))
 			return nil
 		},
 	}
@@ -107,6 +105,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiDeleteAllAccessTokensRequest {
-	return apiClient.DeleteAllExpiredAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
+func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiDeleteAllExpiredAccessTokensRequest {
+	return apiClient.DefaultAPI.DeleteAllExpiredAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
 }

--- a/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired.go
+++ b/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"

--- a/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
+++ b/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
+++ b/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
@@ -21,7 +21,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiDeleteAllExpiredAccessTokensRequest)) logs.ApiDeleteAllExpiredAccessTokensRequest {
-	request := testClient.DeleteAllExpiredAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.DeleteAllExpiredAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
+++ b/internal/cmd/logs/access_token/delete_all_expired/delete_all_expired_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/describe/describe.go
+++ b/internal/cmd/logs/access_token/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/logs/access_token/describe/describe.go
+++ b/internal/cmd/logs/access_token/describe/describe.go
@@ -101,7 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiGetAccessTokenRequest {
-	return apiClient.GetAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
+	return apiClient.DefaultAPI.GetAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
 }
 
 func outputResult(p *print.Printer, outputFormat string, token *logs.AccessToken) error {
@@ -110,21 +110,21 @@ func outputResult(p *print.Printer, outputFormat string, token *logs.AccessToken
 	}
 	return p.OutputResult(outputFormat, token, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(token.Id))
+		table.AddRow("ID", token.Id)
 		table.AddSeparator()
-		table.AddRow("DISPLAY NAME", utils.PtrString(token.DisplayName))
+		table.AddRow("DISPLAY NAME", token.DisplayName)
 		table.AddSeparator()
 		table.AddRow("DESCRIPTION", utils.PtrString(token.Description))
 		table.AddSeparator()
-		table.AddRow("PERMISSIONS", utils.PtrString(token.Permissions))
+		table.AddRow("PERMISSIONS", token.Permissions)
 		table.AddSeparator()
-		table.AddRow("CREATOR", utils.PtrString(token.Creator))
+		table.AddRow("CREATOR", token.Creator)
 		table.AddSeparator()
-		table.AddRow("STATE", utils.PtrString(token.Status))
+		table.AddRow("STATE", token.Status)
 		table.AddSeparator()
-		table.AddRow("EXPIRES", utils.PtrString(token.Expires))
+		table.AddRow("EXPIRES", token.Expires)
 		table.AddSeparator()
-		table.AddRow("VALID UNTIL", utils.PtrString(token.ValidUntil))
+		table.AddRow("VALID UNTIL", token.ValidUntil)
 		table.AddSeparator()
 
 		err := table.Display(p)

--- a/internal/cmd/logs/access_token/describe/describe_test.go
+++ b/internal/cmd/logs/access_token/describe/describe_test.go
@@ -199,7 +199,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/describe/describe_test.go
+++ b/internal/cmd/logs/access_token/describe/describe_test.go
@@ -224,8 +224,8 @@ func TestOutputResult(t *testing.T) {
 				accessToken: utils.Ptr(logs.AccessToken{
 					Id: uuid.NewString(),
 					Permissions: []logs.PermissionsInner{
-						"read",
-						"write",
+						logs.PERMISSIONSINNER_READ,
+						logs.PERMISSIONSINNER_WRITE,
 					},
 					DisplayName: "Token",
 					AccessToken: utils.Ptr("Secret access token"),

--- a/internal/cmd/logs/access_token/describe/describe_test.go
+++ b/internal/cmd/logs/access_token/describe/describe_test.go
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId     = uuid.NewString()
 	testInstanceId    = uuid.NewString()
@@ -71,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiGetAccessTokenRequest)) logs.ApiGetAccessTokenRequest {
-	request := testClient.GetAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
+	request := testClient.DefaultAPI.GetAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -199,7 +199,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -222,16 +222,16 @@ func TestOutputResult(t *testing.T) {
 			name: "base",
 			args: args{
 				accessToken: utils.Ptr(logs.AccessToken{
-					Id: utils.Ptr(uuid.NewString()),
-					Permissions: utils.Ptr([]string{
+					Id: uuid.NewString(),
+					Permissions: []logs.PermissionsInner{
 						"read",
 						"write",
-					}),
-					DisplayName: utils.Ptr("Token"),
+					},
+					DisplayName: "Token",
 					AccessToken: utils.Ptr("Secret access token"),
-					Creator:     utils.Ptr(uuid.NewString()),
-					Expires:     utils.Ptr(false),
-					Status:      utils.Ptr(logs.ACCESSTOKENSTATUS_ACTIVE),
+					Creator:     uuid.NewString(),
+					Expires:     false,
+					Status:      logs.ACCESSTOKENSTATUS_ACTIVE,
 				}),
 			},
 			wantErr: false,

--- a/internal/cmd/logs/access_token/describe/describe_test.go
+++ b/internal/cmd/logs/access_token/describe/describe_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/list/list.go
+++ b/internal/cmd/logs/access_token/list/list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/logs/access_token/list/list.go
+++ b/internal/cmd/logs/access_token/list/list.go
@@ -82,7 +82,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Truncate output
-			items := utils.PtrValue(resp.Tokens)
+			items := resp.Tokens
 			if model.Limit != nil && len(items) > int(*model.Limit) {
 				items = items[:*model.Limit]
 			}
@@ -127,7 +127,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiListAccessTokensRequest {
-	return apiClient.ListAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
+	return apiClient.DefaultAPI.ListAccessTokens(ctx, model.ProjectId, model.Region, model.InstanceId)
 }
 
 func outputResult(p *print.Printer, outputFormat string, tokens []logs.AccessToken, projectLabel string) error {
@@ -142,12 +142,12 @@ func outputResult(p *print.Printer, outputFormat string, tokens []logs.AccessTok
 
 		for _, token := range tokens {
 			table.AddRow(
-				utils.PtrString(token.Id),
-				utils.PtrString(token.DisplayName),
+				token.Id,
+				token.DisplayName,
 				utils.PtrString(token.Description),
-				utils.PtrString(token.Permissions),
+				token.Permissions,
 				utils.PtrString(token.ValidUntil),
-				utils.PtrString(token.Status),
+				token.Status,
 			)
 			table.AddSeparator()
 		}

--- a/internal/cmd/logs/access_token/list/list_test.go
+++ b/internal/cmd/logs/access_token/list/list_test.go
@@ -23,7 +23,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiListAccessTokensRequest)) logs.ApiListAccessTokensRequest {
-	request := testClient.ListAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.ListAccessTokens(testCtx, testProjectId, testRegion, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -171,7 +171,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -196,16 +196,16 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				accessTokens: []logs.AccessToken{
 					{
-						Id: utils.Ptr(uuid.NewString()),
-						Permissions: utils.Ptr([]string{
+						Id: uuid.NewString(),
+						Permissions: []logs.PermissionsInner{
 							"read",
 							"write",
-						}),
-						DisplayName: utils.Ptr("Token"),
+						},
+						DisplayName: "Token",
 						AccessToken: utils.Ptr("Secret access token"),
-						Creator:     utils.Ptr(uuid.NewString()),
-						Expires:     utils.Ptr(false),
-						Status:      utils.Ptr(logs.ACCESSTOKENSTATUS_ACTIVE),
+						Creator:     uuid.NewString(),
+						Expires:     false,
+						Status:      logs.ACCESSTOKENSTATUS_ACTIVE,
 					},
 				},
 			},

--- a/internal/cmd/logs/access_token/list/list_test.go
+++ b/internal/cmd/logs/access_token/list/list_test.go
@@ -171,7 +171,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -198,8 +198,8 @@ func TestOutputResult(t *testing.T) {
 					{
 						Id: uuid.NewString(),
 						Permissions: []logs.PermissionsInner{
-							"read",
-							"write",
+							logs.PERMISSIONSINNER_READ,
+							logs.PERMISSIONSINNER_WRITE,
 						},
 						DisplayName: "Token",
 						AccessToken: utils.Ptr("Secret access token"),

--- a/internal/cmd/logs/access_token/list/list_test.go
+++ b/internal/cmd/logs/access_token/list/list_test.go
@@ -171,7 +171,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/list/list_test.go
+++ b/internal/cmd/logs/access_token/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/access_token/update/update.go
+++ b/internal/cmd/logs/access_token/update/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 

--- a/internal/cmd/logs/access_token/update/update.go
+++ b/internal/cmd/logs/access_token/update/update.go
@@ -66,7 +66,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the display name for confirmation
-			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId)
+			instanceLabel, err := logUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get Logs instance: %v", err)
 			}
@@ -75,7 +75,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Get the display name for confirmation
-			accessTokenLabel, err := logUtils.GetAccessTokenName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
+			accessTokenLabel, err := logUtils.GetAccessTokenName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get access token: %v", err)
 			}
@@ -134,7 +134,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiUpdateAccessTokenRequest {
-	req := apiClient.UpdateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
+	req := apiClient.DefaultAPI.UpdateAccessToken(ctx, model.ProjectId, model.Region, model.InstanceId, model.AccessTokenId)
 
 	payload := logs.UpdateAccessTokenPayload{
 		DisplayName: model.DisplayName,

--- a/internal/cmd/logs/access_token/update/update_test.go
+++ b/internal/cmd/logs/access_token/update/update_test.go
@@ -265,8 +265,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
-				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/update/update_test.go
+++ b/internal/cmd/logs/access_token/update/update_test.go
@@ -25,7 +25,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx    = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient = &logs.APIClient{}
+	testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 
 	testProjectId     = uuid.NewString()
 	testInstanceId    = uuid.NewString()
@@ -77,7 +77,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiUpdateAccessTokenRequest)) logs.ApiUpdateAccessTokenRequest {
-	request := testClient.UpdateAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
+	request := testClient.DefaultAPI.UpdateAccessToken(testCtx, testProjectId, testRegion, testInstanceId, testAccessTokenId)
 	request = request.UpdateAccessTokenPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -266,6 +266,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/access_token/update/update_test.go
+++ b/internal/cmd/logs/access_token/update/update_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -95,12 +95,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if resp == nil {
 				return fmt.Errorf("create Logs instance: empty response from API")
 			}
-			instanceId := resp.Id
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating instance", func() error {
-					_, err = wait.CreateLogsInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, instanceId).WaitWithContext(ctx)
+					_, err = wait.CreateLogsInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, resp.Id).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
@@ -16,7 +16,7 @@ import (
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/client"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs/wait"
+	"github.com/stackitcloud/stackit-sdk-go/services/logs/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -37,7 +37,7 @@ type inputModel struct {
 
 	DisplayName   *string
 	RetentionDays *int32
-	ACL           *[]string
+	ACL           []string
 	Description   *string
 }
 
@@ -135,7 +135,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		DisplayName:     flags.FlagToStringPointer(p, cmd, displayNameFlag),
 		RetentionDays:   flags.FlagToInt32Pointer(p, cmd, retentionDaysFlag),
 		Description:     flags.FlagToStringPointer(p, cmd, descriptionFlag),
-		ACL:             flags.FlagToStringSlicePointer(p, cmd, aclFlag),
+		ACL:             flags.FlagToStringSliceValue(p, cmd, aclFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -148,7 +148,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APICli
 		DisplayName:   utils.PtrString(model.DisplayName),
 		Description:   model.Description,
 		RetentionDays: utils.PtrValue(model.RetentionDays),
-		Acl:           utils.GetSliceFromPointer(model.ACL),
+		Acl:           model.ACL,
 	})
 	return req
 }

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -95,9 +95,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if resp == nil {
 				return fmt.Errorf("create Logs instance: empty response from API")
 			}
-			if len(resp.Id) == 0 {
-				return fmt.Errorf("create Logs instance: instance id missing in response")
-			}
 			instanceId := resp.Id
 
 			// Wait for async operation, if async mode not enabled

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -3,7 +3,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"math"
 
 	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
@@ -37,7 +36,7 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 
 	DisplayName   *string
-	RetentionDays *int64
+	RetentionDays *int32
 	ACL           *[]string
 	Description   *string
 }
@@ -88,10 +87,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
-			if err != nil {
-				return err
-			}
+			req := buildRequest(ctx, model, apiClient)
 			resp, err := req.Execute()
 			if err != nil {
 				return fmt.Errorf("create Logs instance: %w", err)
@@ -126,7 +122,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(displayNameFlag, "", "Display name")
 	cmd.Flags().String(descriptionFlag, "", "Description")
 	cmd.Flags().StringSlice(aclFlag, []string{}, "Access control list")
-	cmd.Flags().Int64(retentionDaysFlag, 0, "The days for how long the logs should be stored before being cleaned up")
+	cmd.Flags().Int32(retentionDaysFlag, 0, "The days for how long the logs should be stored before being cleaned up")
 
 	err := flags.MarkFlagsRequired(cmd, displayNameFlag, retentionDaysFlag)
 	cobra.CheckErr(err)
@@ -141,7 +137,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		DisplayName:     flags.FlagToStringPointer(p, cmd, displayNameFlag),
-		RetentionDays:   flags.FlagToInt64Pointer(p, cmd, retentionDaysFlag),
+		RetentionDays:   flags.FlagToInt32Pointer(p, cmd, retentionDaysFlag),
 		Description:     flags.FlagToStringPointer(p, cmd, descriptionFlag),
 		ACL:             flags.FlagToStringSlicePointer(p, cmd, aclFlag),
 	}
@@ -150,25 +146,15 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) (logs.ApiCreateLogsInstanceRequest, error) {
+func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiCreateLogsInstanceRequest {
 	req := apiClient.DefaultAPI.CreateLogsInstance(ctx, model.ProjectId, model.Region)
-
-	var retentionDays int32
-	if model.RetentionDays != nil {
-		val := *model.RetentionDays
-		if val < 0 || val > math.MaxInt32 {
-			return req, fmt.Errorf("metrics frequency value %d overflows int32", val)
-		}
-		retentionDays = int32(val)
-	}
-
 	req = req.CreateLogsInstancePayload(logs.CreateLogsInstancePayload{
 		DisplayName:   utils.PtrString(model.DisplayName),
 		Description:   model.Description,
-		RetentionDays: retentionDays,
-		Acl:           utils.PtrValue(model.ACL),
+		RetentionDays: utils.PtrValue(model.RetentionDays),
+		Acl:           utils.GetSliceFromPointer(model.ACL),
 	})
-	return req, nil
+	return req
 }
 
 func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp *logs.LogsInstance) error {

--- a/internal/cmd/logs/instance/create/create.go
+++ b/internal/cmd/logs/instance/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"math"
 
 	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
@@ -87,7 +88,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient)
 			if err != nil {
 				return err
 			}
@@ -98,15 +99,15 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if resp == nil {
 				return fmt.Errorf("create Logs instance: empty response from API")
 			}
-			if resp.Id == nil {
+			if len(resp.Id) == 0 {
 				return fmt.Errorf("create Logs instance: instance id missing in response")
 			}
-			instanceId := *resp.Id
+			instanceId := resp.Id
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating instance", func() error {
-					_, err = wait.CreateLogsInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.Region, instanceId).WaitWithContext(ctx)
+					_, err = wait.CreateLogsInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, instanceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -149,16 +150,25 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiCreateLogsInstanceRequest {
-	req := apiClient.CreateLogsInstance(ctx, model.ProjectId, model.Region)
+func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) (logs.ApiCreateLogsInstanceRequest, error) {
+	req := apiClient.DefaultAPI.CreateLogsInstance(ctx, model.ProjectId, model.Region)
+
+	var retentionDays int32
+	if model.RetentionDays != nil {
+		val := *model.RetentionDays
+		if val < 0 || val > math.MaxInt32 {
+			return req, fmt.Errorf("metrics frequency value %d overflows int32", val)
+		}
+		retentionDays = int32(val)
+	}
 
 	req = req.CreateLogsInstancePayload(logs.CreateLogsInstancePayload{
-		DisplayName:   model.DisplayName,
+		DisplayName:   utils.PtrString(model.DisplayName),
 		Description:   model.Description,
-		RetentionDays: model.RetentionDays,
-		Acl:           model.ACL,
+		RetentionDays: retentionDays,
+		Acl:           utils.PtrValue(model.ACL),
 	})
-	return req
+	return req, nil
 }
 
 func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp *logs.LogsInstance) error {
@@ -173,7 +183,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, resp
 		if model.Async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.Id))
+		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -166,13 +166,11 @@ func TestBuildRequest(t *testing.T) {
 		description     string
 		model           *inputModel
 		expectedRequest logs.ApiCreateLogsInstanceRequest
-		isValid         bool
 	}{
 		{
 			description:     "base case",
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
-			isValid:         true,
 		},
 		{
 			description: "no optional values",
@@ -186,7 +184,6 @@ func TestBuildRequest(t *testing.T) {
 				Description:   nil,
 				Acl:           nil,
 			}),
-			isValid: true,
 		},
 	}
 

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -192,8 +192,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
-				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -62,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		DisplayName:   utils.Ptr(testDisplayName),
 		Description:   utils.Ptr(testDescription),
 		RetentionDays: utils.Ptr(int32(testRetentionDays)),
-		ACL:           utils.Ptr([]string{testAcl}),
+		ACL:           []string{testAcl},
 	}
 	for _, mod := range mods {
 		mod(model)

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -193,7 +193,6 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
-				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		DisplayName:   utils.Ptr(testDisplayName),
 		Description:   utils.Ptr(testDescription),
-		RetentionDays: utils.Ptr(int64(testRetentionDays)),
+		RetentionDays: utils.Ptr(int32(testRetentionDays)),
 		ACL:           utils.Ptr([]string{testAcl}),
 	}
 	for _, mod := range mods {
@@ -188,31 +188,16 @@ func TestBuildRequest(t *testing.T) {
 			}),
 			isValid: true,
 		},
-		{
-			description: "retention days not valid",
-			model: fixtureInputModel(func(model *inputModel) {
-				model.RetentionDays = utils.Int64Ptr(1 << 31)
-			}),
-			expectedRequest: fixtureRequest(),
-			isValid:         false,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, err := buildRequest(testCtx, tt.model, testClient)
-
-			if err != nil {
-				if !tt.isValid {
-					return
-				}
-				t.Fatalf("error building request: %v", err)
-			}
-
+			request := buildRequest(testCtx, tt.model, testClient)
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
-				cmpopts.IgnoreFields(logs.ApiCreateLogsInstanceRequest{}, "ApiService"),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
+				cmpopts.EquateEmpty(),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/create/create_test.go
+++ b/internal/cmd/logs/instance/create/create_test.go
@@ -31,7 +31,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx       = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient    = &logs.APIClient{}
+	testClient    = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 	testProjectId = uuid.NewString()
 )
 
@@ -72,12 +72,12 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *logs.ApiCreateLogsInstanceRequest)) logs.ApiCreateLogsInstanceRequest {
-	request := testClient.CreateLogsInstance(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateLogsInstance(testCtx, testProjectId, testRegion)
 	request = request.CreateLogsInstancePayload(logs.CreateLogsInstancePayload{
-		DisplayName:   utils.Ptr(testDisplayName),
+		DisplayName:   testDisplayName,
 		Description:   utils.Ptr(testDescription),
-		RetentionDays: utils.Ptr(int64(testRetentionDays)),
-		Acl:           utils.Ptr([]string{testAcl}),
+		RetentionDays: testRetentionDays,
+		Acl:           []string{testAcl},
 	})
 
 	for _, mod := range mods {
@@ -166,11 +166,13 @@ func TestBuildRequest(t *testing.T) {
 		description     string
 		model           *inputModel
 		expectedRequest logs.ApiCreateLogsInstanceRequest
+		isValid         bool
 	}{
 		{
 			description:     "base case",
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
+			isValid:         true,
 		},
 		{
 			description: "no optional values",
@@ -179,20 +181,38 @@ func TestBuildRequest(t *testing.T) {
 				model.ACL = nil
 			}),
 			expectedRequest: fixtureRequest().CreateLogsInstancePayload(logs.CreateLogsInstancePayload{
-				DisplayName:   utils.Ptr(testDisplayName),
-				RetentionDays: utils.Ptr(int64(testRetentionDays)),
+				DisplayName:   testDisplayName,
+				RetentionDays: int32(testRetentionDays),
 				Description:   nil,
 				Acl:           nil,
 			}),
+			isValid: true,
+		},
+		{
+			description: "retention days not valid",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.RetentionDays = utils.Int64Ptr(1 << 31)
+			}),
+			expectedRequest: fixtureRequest(),
+			isValid:         false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request := buildRequest(testCtx, tt.model, testClient)
+			request, err := buildRequest(testCtx, tt.model, testClient)
+
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("error building request: %v", err)
+			}
+
 			diff := cmp.Diff(tt.expectedRequest, request,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(logs.ApiCreateLogsInstanceRequest{}, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/delete/delete.go
+++ b/internal/cmd/logs/instance/delete/delete.go
@@ -66,7 +66,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				projectLabel = model.ProjectId
 			}
 
-			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceID)
+			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceID)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceID
@@ -89,7 +89,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Deleting instance", func() error {
-					_, err = wait.DeleteLogsInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.Region, model.InstanceID).WaitWithContext(ctx)
+					_, err = wait.DeleteLogsInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceID).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -127,6 +127,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiDeleteLogsInstanceRequest {
-	req := apiClient.DeleteLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
+	req := apiClient.DefaultAPI.DeleteLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
 	return req
 }

--- a/internal/cmd/logs/instance/delete/delete.go
+++ b/internal/cmd/logs/instance/delete/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
@@ -19,7 +19,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs/wait"
+	"github.com/stackitcloud/stackit-sdk-go/services/logs/v1api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/client"
 	logsUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/utils"

--- a/internal/cmd/logs/instance/delete/delete_test.go
+++ b/internal/cmd/logs/instance/delete/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"

--- a/internal/cmd/logs/instance/delete/delete_test.go
+++ b/internal/cmd/logs/instance/delete/delete_test.go
@@ -165,7 +165,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/delete/delete_test.go
+++ b/internal/cmd/logs/instance/delete/delete_test.go
@@ -21,7 +21,7 @@ type testCtxKey struct{}
 
 var (
 	testCtx        = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient     = &logs.APIClient{}
+	testClient     = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
 )
@@ -67,7 +67,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 
 // Request
 func fixtureRequest(mods ...func(request *logs.ApiDeleteLogsInstanceRequest)) logs.ApiDeleteLogsInstanceRequest {
-	request := testClient.DeleteLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.DeleteLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -165,7 +165,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/describe/describe.go
+++ b/internal/cmd/logs/instance/describe/describe.go
@@ -84,7 +84,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiGetLogsInstanceRequest {
-	return apiClient.GetLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
+	return apiClient.DefaultAPI.GetLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
 }
 
 func outputResult(p *print.Printer, outputFormat string, instance *logs.LogsInstance) error {
@@ -93,13 +93,13 @@ func outputResult(p *print.Printer, outputFormat string, instance *logs.LogsInst
 	}
 	return p.OutputResult(outputFormat, instance, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(instance.Id))
+		table.AddRow("ID", instance.Id)
 		table.AddSeparator()
-		table.AddRow("DISPLAY NAME", utils.PtrString(instance.DisplayName))
+		table.AddRow("DISPLAY NAME", instance.DisplayName)
 		table.AddSeparator()
-		table.AddRow("RETENTION DAYS", utils.PtrString(instance.RetentionDays))
+		table.AddRow("RETENTION DAYS", instance.RetentionDays)
 		table.AddSeparator()
-		table.AddRow("ACL IP RANGES", utils.PtrString(instance.Acl))
+		table.AddRow("ACL IP RANGES", instance.Acl)
 		table.AddSeparator()
 		table.AddRow("DATA SOURCE", utils.PtrString(instance.DatasourceUrl))
 		table.AddSeparator()

--- a/internal/cmd/logs/instance/describe/describe.go
+++ b/internal/cmd/logs/instance/describe/describe.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 

--- a/internal/cmd/logs/instance/describe/describe_test.go
+++ b/internal/cmd/logs/instance/describe/describe_test.go
@@ -18,7 +18,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &logs.APIClient{}
+var testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -51,7 +51,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiGetLogsInstanceRequest)) logs.ApiGetLogsInstanceRequest {
-	request := testClient.GetLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.GetLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -140,7 +140,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/describe/describe_test.go
+++ b/internal/cmd/logs/instance/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"

--- a/internal/cmd/logs/instance/describe/describe_test.go
+++ b/internal/cmd/logs/instance/describe/describe_test.go
@@ -140,7 +140,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/list/list.go
+++ b/internal/cmd/logs/instance/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/logs/instance/list/list.go
+++ b/internal/cmd/logs/instance/list/list.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/logs/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 type inputModel struct {
@@ -117,7 +116,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiListLogsInstancesRequest {
-	request := apiClient.ListLogsInstances(ctx, model.ProjectId, model.Region)
+	request := apiClient.DefaultAPI.ListLogsInstances(ctx, model.ProjectId, model.Region)
 
 	return request
 }
@@ -133,9 +132,9 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, instances
 		table.SetHeader("NAME", "ID", "STATUS")
 		for _, instance := range instances {
 			table.AddRow(
-				utils.PtrString(instance.DisplayName),
-				utils.PtrString(instance.Id),
-				utils.PtrString(instance.Status),
+				instance.DisplayName,
+				instance.Id,
+				instance.Status,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/logs/instance/list/list_test.go
+++ b/internal/cmd/logs/instance/list/list_test.go
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &logs.APIClient{}
+var testClient = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -142,7 +142,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/list/list_test.go
+++ b/internal/cmd/logs/instance/list/list_test.go
@@ -142,7 +142,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/list/list_test.go
+++ b/internal/cmd/logs/instance/list/list_test.go
@@ -53,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiListLogsInstancesRequest)) logs.ApiListLogsInstancesRequest {
-	request := testClient.ListLogsInstances(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.ListLogsInstances(testCtx, testProjectId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/logs/instance/list/list_test.go
+++ b/internal/cmd/logs/instance/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/instance/update/update.go
+++ b/internal/cmd/logs/instance/update/update.go
@@ -34,7 +34,7 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 	InstanceID    string
 	DisplayName   *string
-	RetentionDays *int64
+	RetentionDays *int32
 	ACL           *[]string
 	Description   *string
 }
@@ -77,7 +77,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				projectLabel = model.ProjectId
 			}
 
-			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.Region, model.InstanceID)
+			instanceLabel, err := logsUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceID)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceID
@@ -108,7 +108,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(displayNameFlag, "", "Display name")
 	cmd.Flags().String(descriptionFlag, "", "Description")
 	cmd.Flags().StringSlice(aclFlag, []string{}, "Access control list")
-	cmd.Flags().Int64(retentionDaysFlag, 0, "The days for how long the logs should be stored before being cleaned up")
+	cmd.Flags().Int32(retentionDaysFlag, 0, "The days for how long the logs should be stored before being cleaned up")
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inputModel, error) {
@@ -120,7 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	}
 
 	displayName := flags.FlagToStringPointer(p, cmd, displayNameFlag)
-	retentionDays := flags.FlagToInt64Pointer(p, cmd, retentionDaysFlag)
+	retentionDays := flags.FlagToInt32Pointer(p, cmd, retentionDaysFlag)
 	acl := flags.FlagToStringSlicePointer(p, cmd, aclFlag)
 	description := flags.FlagToStringPointer(p, cmd, descriptionFlag)
 
@@ -142,10 +142,11 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APIClient) logs.ApiUpdateLogsInstanceRequest {
-	req := apiClient.UpdateLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
+	req := apiClient.DefaultAPI.UpdateLogsInstance(ctx, model.ProjectId, model.Region, model.InstanceID)
+
 	req = req.UpdateLogsInstancePayload(logs.UpdateLogsInstancePayload{
 		DisplayName:   model.DisplayName,
-		Acl:           model.ACL,
+		Acl:           utils.PtrValue(model.ACL),
 		RetentionDays: model.RetentionDays,
 		Description:   model.Description,
 	})
@@ -159,7 +160,7 @@ func outputResult(p *print.Printer, model *inputModel, projectLabel string, inst
 		return fmt.Errorf("input model is nil")
 	}
 	return p.OutputResult(model.OutputFormat, instance, func() error {
-		p.Outputf("Updated instance %q for project %q.\n", utils.PtrString(instance.DisplayName), projectLabel)
+		p.Outputf("Updated instance %q for project %q.\n", instance.DisplayName, projectLabel)
 		return nil
 	})
 }

--- a/internal/cmd/logs/instance/update/update.go
+++ b/internal/cmd/logs/instance/update/update.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 const (

--- a/internal/cmd/logs/instance/update/update.go
+++ b/internal/cmd/logs/instance/update/update.go
@@ -35,7 +35,7 @@ type inputModel struct {
 	InstanceID    string
 	DisplayName   *string
 	RetentionDays *int32
-	ACL           *[]string
+	ACL           []string
 	Description   *string
 }
 
@@ -121,7 +121,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 	displayName := flags.FlagToStringPointer(p, cmd, displayNameFlag)
 	retentionDays := flags.FlagToInt32Pointer(p, cmd, retentionDaysFlag)
-	acl := flags.FlagToStringSlicePointer(p, cmd, aclFlag)
+	acl := flags.FlagToStringSliceValue(p, cmd, aclFlag)
 	description := flags.FlagToStringPointer(p, cmd, descriptionFlag)
 
 	if displayName == nil && retentionDays == nil && acl == nil && description == nil {
@@ -146,7 +146,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *logs.APICli
 
 	req = req.UpdateLogsInstancePayload(logs.UpdateLogsInstancePayload{
 		DisplayName:   model.DisplayName,
-		Acl:           utils.PtrValue(model.ACL),
+		Acl:           model.ACL,
 		RetentionDays: model.RetentionDays,
 		Description:   model.Description,
 	})

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -240,8 +240,8 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest, logs.DefaultAPIService{}),
-				cmpopts.EquateComparable(testCtx),
+				cmp.AllowUnexported(tt.expectedRequest),
+				cmpopts.EquateComparable(testCtx, logs.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -240,7 +240,7 @@ func TestBuildRequest(t *testing.T) {
 			request := buildRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, logs.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
 			)
 			if diff != "" {

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	testCtx        = context.WithValue(context.Background(), testCtxKey{}, "foo")
-	testClient     = &logs.APIClient{}
+	testClient     = &logs.APIClient{DefaultAPI: &logs.DefaultAPIService{}}
 	testProjectId  = uuid.NewString()
 	testInstanceId = uuid.NewString()
 )
@@ -66,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceID:    testInstanceId,
 		DisplayName:   utils.Ptr("name"),
 		ACL:           utils.Ptr([]string{"0.0.0.0/0"}),
-		RetentionDays: utils.Ptr(int64(60)),
+		RetentionDays: utils.Ptr(int32(60)),
 		Description:   utils.Ptr("Example"),
 	}
 	for _, mod := range mods {
@@ -76,11 +76,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *logs.ApiUpdateLogsInstanceRequest)) logs.ApiUpdateLogsInstanceRequest {
-	request := testClient.UpdateLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
+	request := testClient.DefaultAPI.UpdateLogsInstance(testCtx, testProjectId, testRegion, testInstanceId)
 	request = request.UpdateLogsInstancePayload(logs.UpdateLogsInstancePayload{
 		DisplayName:   utils.Ptr("name"),
-		Acl:           utils.Ptr([]string{"0.0.0.0/0"}),
-		RetentionDays: utils.Ptr(int64(60)),
+		Acl:           []string{"0.0.0.0/0"},
+		RetentionDays: utils.Ptr(int32(60)),
 		Description:   utils.Ptr("Example"),
 	})
 	for _, mod := range mods {
@@ -160,7 +160,7 @@ func TestParseInput(t *testing.T) {
 				InstanceID:    testInstanceId,
 				DisplayName:   utils.Ptr("display-name"),
 				ACL:           utils.Ptr([]string{"0.0.0.0/24"}),
-				RetentionDays: utils.Ptr(int64(60)),
+				RetentionDays: utils.Ptr(int32(60)),
 				Description:   utils.Ptr("description"),
 			},
 		},
@@ -230,7 +230,7 @@ func TestBuildRequest(t *testing.T) {
 				},
 				InstanceID: testInstanceId,
 			},
-			expectedRequest: testClient.UpdateLogsInstance(testCtx, testProjectId, testRegion, testInstanceId).
+			expectedRequest: testClient.DefaultAPI.UpdateLogsInstance(testCtx, testProjectId, testRegion, testInstanceId).
 				UpdateLogsInstancePayload(logs.UpdateLogsInstancePayload{}),
 		},
 	}
@@ -242,6 +242,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -242,7 +242,6 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
-				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/logs/instance/update/update_test.go
+++ b/internal/cmd/logs/instance/update/update_test.go
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		InstanceID:    testInstanceId,
 		DisplayName:   utils.Ptr("name"),
-		ACL:           utils.Ptr([]string{"0.0.0.0/0"}),
+		ACL:           []string{"0.0.0.0/0"},
 		RetentionDays: utils.Ptr(int32(60)),
 		Description:   utils.Ptr("Example"),
 	}
@@ -159,7 +159,7 @@ func TestParseInput(t *testing.T) {
 				},
 				InstanceID:    testInstanceId,
 				DisplayName:   utils.Ptr("display-name"),
-				ACL:           utils.Ptr([]string{"0.0.0.0/24"}),
+				ACL:           []string{"0.0.0.0/24"},
 				RetentionDays: utils.Ptr(int32(60)),
 				Description:   utils.Ptr("description"),
 			},

--- a/internal/pkg/services/logs/client/client.go
+++ b/internal/pkg/services/logs/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"

--- a/internal/pkg/services/logs/client/client.go
+++ b/internal/pkg/services/logs/client/client.go
@@ -11,5 +11,5 @@ import (
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*logs.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.LogsCustomEndpointKey), false, genericclient.CreateApiClient[*logs.APIClient](logs.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.LogsCustomEndpointKey), false, logs.NewAPIClient)
 }

--- a/internal/pkg/services/logs/utils/utils.go
+++ b/internal/pkg/services/logs/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 )
 
 var (

--- a/internal/pkg/services/logs/utils/utils.go
+++ b/internal/pkg/services/logs/utils/utils.go
@@ -10,34 +10,24 @@ import (
 
 var (
 	ErrResponseNil = errors.New("response is nil")
-	ErrNameNil     = errors.New("display name is nil")
 )
 
-type LogsClient interface {
-	GetLogsInstanceExecute(ctx context.Context, projectId, regionId, instanceId string) (*logs.LogsInstance, error)
-	GetAccessTokenExecute(ctx context.Context, projectId string, regionId string, instanceId string, tId string) (*logs.AccessToken, error)
-}
-
-func GetInstanceName(ctx context.Context, apiClient LogsClient, projectId, regionId, instanceId string) (string, error) {
-	resp, err := apiClient.GetLogsInstanceExecute(ctx, projectId, regionId, instanceId)
+func GetInstanceName(ctx context.Context, apiClient logs.DefaultAPI, projectId, regionId, instanceId string) (string, error) {
+	resp, err := apiClient.GetLogsInstance(ctx, projectId, regionId, instanceId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get Logs instance: %w", err)
 	} else if resp == nil {
 		return "", ErrResponseNil
-	} else if resp.DisplayName == nil {
-		return "", ErrNameNil
 	}
-	return *resp.DisplayName, nil
+	return resp.DisplayName, nil
 }
 
-func GetAccessTokenName(ctx context.Context, apiClient LogsClient, projectId, regionId, instanceId, accessTokenId string) (string, error) {
-	resp, err := apiClient.GetAccessTokenExecute(ctx, projectId, regionId, instanceId, accessTokenId)
+func GetAccessTokenName(ctx context.Context, apiClient logs.DefaultAPI, projectId, regionId, instanceId, accessTokenId string) (string, error) {
+	resp, err := apiClient.GetAccessToken(ctx, projectId, regionId, instanceId, accessTokenId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get Logs access token: %w", err)
 	} else if resp == nil {
 		return "", ErrResponseNil
-	} else if resp.DisplayName == nil {
-		return "", ErrNameNil
 	}
-	return *resp.DisplayName, nil
+	return resp.DisplayName, nil
 }

--- a/internal/pkg/services/logs/utils/utils_test.go
+++ b/internal/pkg/services/logs/utils/utils_test.go
@@ -23,25 +23,28 @@ const (
 	testRegion       = "eu01"
 )
 
-type logsClientMocked struct {
+type mockSettings struct {
 	getInstanceFails    bool
 	getInstanceResp     *logs.LogsInstance
 	getAccessTokenFails bool
 	getAccessTokenResp  *logs.AccessToken
 }
 
-func (m *logsClientMocked) GetLogsInstanceExecute(_ context.Context, _, _, _ string) (*logs.LogsInstance, error) {
-	if m.getInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
+func newAPIMock(s mockSettings) logs.DefaultAPI {
+	return &logs.DefaultAPIServiceMock{
+		GetLogsInstanceExecuteMock: utils.Ptr(func(_ logs.ApiGetLogsInstanceRequest) (*logs.LogsInstance, error) {
+			if s.getInstanceFails {
+				return nil, fmt.Errorf("could not get instance")
+			}
+			return s.getInstanceResp, nil
+		}),
+		GetAccessTokenExecuteMock: utils.Ptr(func(_ logs.ApiGetAccessTokenRequest) (*logs.AccessToken, error) {
+			if s.getAccessTokenFails {
+				return nil, fmt.Errorf("could not get access token")
+			}
+			return s.getAccessTokenResp, nil
+		}),
 	}
-	return m.getInstanceResp, nil
-}
-
-func (m *logsClientMocked) GetAccessTokenExecute(_ context.Context, _, _, _, _ string) (*logs.AccessToken, error) {
-	if m.getAccessTokenFails {
-		return nil, fmt.Errorf("could not get access token")
-	}
-	return m.getAccessTokenResp, nil
 }
 
 func TestGetInstanceName(t *testing.T) {
@@ -55,7 +58,7 @@ func TestGetInstanceName(t *testing.T) {
 		{
 			description: "base",
 			getInstanceResp: &logs.LogsInstance{
-				DisplayName: utils.Ptr(testInstanceName),
+				DisplayName: testInstanceName,
 			},
 			isValid:        true,
 			expectedOutput: testInstanceName,
@@ -71,24 +74,16 @@ func TestGetInstanceName(t *testing.T) {
 			getInstanceResp:  nil,
 			isValid:          false,
 		},
-		{
-			description:      "name in response is nil",
-			getInstanceFails: false,
-			getInstanceResp: &logs.LogsInstance{
-				DisplayName: nil,
-			},
-			isValid: false,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &logsClientMocked{
+			client := mockSettings{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), client, testProjectId, testRegion, testInstanceId)
+			output, err := GetInstanceName(context.Background(), newAPIMock(client), testProjectId, testRegion, testInstanceId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -117,7 +112,7 @@ func TestGetAccessTokenName(t *testing.T) {
 		{
 			description: "base",
 			getAccessTokenResp: &logs.AccessToken{
-				DisplayName: utils.Ptr(testInstanceName),
+				DisplayName: testInstanceName,
 			},
 			isValid:        true,
 			expectedOutput: testInstanceName,
@@ -133,24 +128,16 @@ func TestGetAccessTokenName(t *testing.T) {
 			getAccessTokenResp:  nil,
 			isValid:             false,
 		},
-		{
-			description:         "name in response is nil",
-			getAccessTokenFails: false,
-			getAccessTokenResp: &logs.AccessToken{
-				DisplayName: nil,
-			},
-			isValid: false,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &logsClientMocked{
+			client := mockSettings{
 				getAccessTokenFails: tt.getAccessTokenFails,
 				getAccessTokenResp:  tt.getAccessTokenResp,
 			}
 
-			output, err := GetAccessTokenName(context.Background(), client, testProjectId, testRegion, testInstanceId, testAccessTokenId)
+			output, err := GetAccessTokenName(context.Background(), newAPIMock(client), testProjectId, testRegion, testInstanceId, testAccessTokenId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")

--- a/internal/pkg/services/logs/utils/utils_test.go
+++ b/internal/pkg/services/logs/utils/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/logs"
+	logs "github.com/stackitcloud/stackit-sdk-go/services/logs/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 

--- a/internal/pkg/services/logs/utils/utils_test.go
+++ b/internal/pkg/services/logs/utils/utils_test.go
@@ -78,12 +78,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := mockSettings{
+			settings := mockSettings{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), newAPIMock(client), testProjectId, testRegion, testInstanceId)
+			output, err := GetInstanceName(context.Background(), newAPIMock(settings), testProjectId, testRegion, testInstanceId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -132,12 +132,12 @@ func TestGetAccessTokenName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := mockSettings{
+			settings := mockSettings{
 				getAccessTokenFails: tt.getAccessTokenFails,
 				getAccessTokenResp:  tt.getAccessTokenResp,
 			}
 
-			output, err := GetAccessTokenName(context.Background(), newAPIMock(client), testProjectId, testRegion, testInstanceId, testAccessTokenId)
+			output, err := GetAccessTokenName(context.Background(), newAPIMock(settings), testProjectId, testRegion, testInstanceId, testAccessTokenId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -197,3 +197,12 @@ func FormatPossibleValues(values ...string) []string {
 	}
 	return formattedValues
 }
+
+// Map applies mapFn to each element in input and collects the results in a new slice
+func Map[T, U any](input []T, mapFn func(T) U) []U {
+	values := make([]U, len(input))
+	for i := range input {
+		values[i] = mapFn(input[i])
+	}
+	return values
+}

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -363,3 +363,44 @@ func TestGetSliceFromPointer(t *testing.T) {
 		})
 	}
 }
+
+func TestMap(t *testing.T) {
+	type args[T any, U any] struct {
+		input []T
+		mapFn func(T) U
+	}
+	type testCase[T any, U any] struct {
+		name string
+		args args[T, U]
+		want []U
+	}
+	tests := []testCase[string, *string]{
+		{
+			name: "default",
+			args: args[string, *string]{
+				input: []string{"foo", "bar"},
+				mapFn: func(s string) *string {
+					return Ptr(s)
+				},
+			},
+			want: []*string{Ptr("foo"), Ptr("bar")},
+		},
+		{
+			name: "input slice is nil",
+			args: args[string, *string]{
+				input: nil,
+				mapFn: func(s string) *string {
+					return Ptr(s)
+				},
+			},
+			want: []*string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Map(tt.args.input, tt.args.mapFn); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Map() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -379,9 +379,7 @@ func TestMap(t *testing.T) {
 			name: "default",
 			args: args[string, *string]{
 				input: []string{"foo", "bar"},
-				mapFn: func(s string) *string {
-					return Ptr(s)
-				},
+				mapFn: Ptr[string],
 			},
 			want: []*string{Ptr("foo"), Ptr("bar")},
 		},
@@ -389,9 +387,7 @@ func TestMap(t *testing.T) {
 			name: "input slice is nil",
 			args: args[string, *string]{
 				input: nil,
-				mapFn: func(s string) *string {
-					return Ptr(s)
-				},
+				mapFn: Ptr[string],
 			},
 			want: []*string{},
 		},


### PR DESCRIPTION
## Description

relates to STACKITCLI-367

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
