### PR TITLE
chore(mariadb): sdk migration

### DIFF
--- a/docs/stackit_mariadb_instance_create.md
+++ b/docs/stackit_mariadb_instance_create.md
@@ -30,7 +30,7 @@ stackit mariadb instance create [flags]
       --enable-monitoring               Enable monitoring
       --graphite string                 Graphite host
   -h, --help                            Help for "stackit mariadb instance create"
-      --metrics-frequency int           Metrics frequency
+      --metrics-frequency int32         Metrics frequency
       --metrics-prefix string           Metrics prefix
       --monitoring-instance-id string   Monitoring instance ID
   -n, --name string                     Instance name

--- a/docs/stackit_mariadb_instance_update.md
+++ b/docs/stackit_mariadb_instance_update.md
@@ -27,7 +27,7 @@ stackit mariadb instance update INSTANCE_ID [flags]
       --enable-monitoring               Enable monitoring
       --graphite string                 Graphite host
   -h, --help                            Help for "stackit mariadb instance update"
-      --metrics-frequency int           Metrics frequency
+      --metrics-frequency int32         Metrics frequency
       --metrics-prefix string           Metrics prefix
       --monitoring-instance-id string   Monitoring instance ID
       --plan-id string                  Plan ID

--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/kms v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/logme v0.30.0
-	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.25.6
+	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/observability v0.17.0
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/stackitcloud/stackit-sdk-go/services/logme v0.30.0 h1:csZlzmvAB+klgUQ
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.30.0/go.mod h1:JDOOYaGgcBts2x52nKPRMFgSZe7qqOFmfz1xIXCQgRY=
 github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2 h1:vr4atxFRT+EL+DqONMT5R44f7AzEMbePa9U7PEE0THU=
 github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2/go.mod h1:CAPsiTX7osAImfrG5RnIjaJ/Iz3QpoBKuH2fS346wuQ=
-github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.25.6 h1:Y/byRjX2u/OZl0gKS/Rau6ob2bDyv26xnw6A6JNkKJk=
-github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.25.6/go.mod h1:sY66ZgCgBc1mScPV95ek5WtUEGYizdP1RMsGaqbdbhw=
+github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0 h1:LFIH1wAp633ZAJw/7H3F4nq1DZe0Qu3rlDeXhobZEZA=
+github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0/go.mod h1:joa89Y1dyn0j22FstRcIKfW2ada3FDxNfttxSvq27uY=
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8 h1:S7t4wcT6SN8ZzdoY8d6VbF903zFpGjzqrU0FN27rJPg=
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8/go.mod h1:CdrhFUsBO7/iJleCc2yQjDChIbG6YaxKNBQRNCjgcF4=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.7.0 h1:UxnbsKm6PQV8Gudw/EhySaEh9q1xSaTG8mzJz1EvhnE=

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -14,9 +15,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/client"
 	mariadbUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
 	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
@@ -58,7 +56,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -109,7 +107,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiCreateCredentialsRequest {
-	req := apiClient.CreateCredentials(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.CreateCredentials(ctx, model.ProjectId, model.InstanceId)
 	return req
 }
 
@@ -118,26 +116,26 @@ func outputResult(p *print.Printer, outputFormat string, showPassword bool, inst
 		return fmt.Errorf("response is nil")
 	}
 
-	if !showPassword && resp.HasRaw() && resp.Raw.Credentials != nil {
-		resp.Raw.Credentials.Password = utils.Ptr("hidden")
+	if !showPassword && resp.HasRaw() {
+		resp.Raw.Credentials.Password = "hidden"
 	}
 
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, utils.PtrString(resp.Id))
+		p.Outputf("Created credentials for instance %q. Credentials ID: %s\n\n", instanceLabel, resp.Id)
 		// The username field cannot be set by the user, so we only display it if it's not returned empty
-		if resp.HasRaw() && resp.Raw.Credentials != nil {
-			if username := resp.Raw.Credentials.Username; username != nil && *username != "" {
-				p.Outputf("Username: %s\n", *username)
+		if resp.HasRaw() {
+			if resp.Raw.Credentials.Username != "" {
+				p.Outputf("Username: %s\n", resp.Raw.Credentials.Username)
 			}
 			if !showPassword {
 				p.Outputf("Password: <hidden>\n")
 			} else {
-				p.Outputf("Password: %s\n", utils.PtrString(resp.Raw.Credentials.Password))
+				p.Outputf("Password: %s\n", resp.Raw.Credentials.Password)
 			}
-			p.Outputf("Host: %s\n", utils.PtrString(resp.Raw.Credentials.Host))
-			p.Outputf("Port: %s\n", utils.PtrString(resp.Raw.Credentials.Port))
+			p.Outputf("Host: %s\n", resp.Raw.Credentials.Host)
+			p.Outputf("Port: %d\n", resp.Raw.Credentials.Port)
 		}
-		p.Outputf("URI: %s\n", utils.PtrString(resp.Uri))
+		p.Outputf("URI: %s\n", resp.Uri)
 		return nil
 	})
 }

--- a/internal/cmd/mariadb/credentials/create/create.go
+++ b/internal/cmd/mariadb/credentials/create/create.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/client"
 	mariadbUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/utils"
-	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/cmd/mariadb/credentials/create/create_test.go
+++ b/internal/cmd/mariadb/credentials/create/create_test.go
@@ -19,7 +19,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -49,7 +49,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiCreateCredentialsRequest)) mariadb.ApiCreateCredentialsRequest {
-	request := testClient.CreateCredentials(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.CreateCredentials(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -155,7 +155,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/credentials/create/create_test.go
+++ b/internal/cmd/mariadb/credentials/create/create_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/credentials/delete/delete.go
+++ b/internal/cmd/mariadb/credentials/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/cmd/mariadb/credentials/delete/delete.go
+++ b/internal/cmd/mariadb/credentials/delete/delete.go
@@ -56,13 +56,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			credentialsLabel, err := mariadbUtils.GetCredentialsUsername(ctx, apiClient, model.ProjectId, model.InstanceId, model.CredentialsId)
+			credentialsLabel, err := mariadbUtils.GetCredentialsUsername(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.CredentialsId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get credentials username: %v", err)
 				credentialsLabel = model.CredentialsId
@@ -115,6 +115,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiDeleteCredentialsRequest {
-	req := apiClient.DeleteCredentials(ctx, model.ProjectId, model.InstanceId, model.CredentialsId)
+	req := apiClient.DefaultAPI.DeleteCredentials(ctx, model.ProjectId, model.InstanceId, model.CredentialsId)
 	return req
 }

--- a/internal/cmd/mariadb/credentials/delete/delete_test.go
+++ b/internal/cmd/mariadb/credentials/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/credentials/delete/delete_test.go
+++ b/internal/cmd/mariadb/credentials/delete/delete_test.go
@@ -18,7 +18,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testCredentialsId = uuid.NewString()
@@ -60,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiDeleteCredentialsRequest)) mariadb.ApiDeleteCredentialsRequest {
-	request := testClient.DeleteCredentials(testCtx, testProjectId, testInstanceId, testCredentialsId)
+	request := testClient.DefaultAPI.DeleteCredentials(testCtx, testProjectId, testInstanceId, testCredentialsId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -188,7 +188,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/cmd/mariadb/credentials/describe/describe.go
+++ b/internal/cmd/mariadb/credentials/describe/describe.go
@@ -99,7 +99,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiGetCredentialsRequest {
-	req := apiClient.GetCredentials(ctx, model.ProjectId, model.InstanceId, model.CredentialsId)
+	req := apiClient.DefaultAPI.GetCredentials(ctx, model.ProjectId, model.InstanceId, model.CredentialsId)
 	return req
 }
 
@@ -110,15 +110,15 @@ func outputResult(p *print.Printer, outputFormat string, credentials *mariadb.Cr
 
 	return p.OutputResult(outputFormat, credentials, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(credentials.Id))
+		table.AddRow("ID", credentials.Id)
 		table.AddSeparator()
 		// The username field cannot be set by the user so we only display it if it's not returned empty
-		if credentials.HasRaw() && credentials.Raw.Credentials != nil {
-			if username := credentials.Raw.Credentials.Username; username != nil && *username != "" {
-				table.AddRow("USERNAME", *username)
+		if credentials.HasRaw() {
+			if credentials.Raw.Credentials.Username != "" {
+				table.AddRow("USERNAME", credentials.Raw.Credentials.Username)
 				table.AddSeparator()
 			}
-			table.AddRow("PASSWORD", utils.PtrString(credentials.Raw.Credentials.Password))
+			table.AddRow("PASSWORD", credentials.Raw.Credentials.Password)
 			table.AddSeparator()
 			table.AddRow("URI", utils.PtrString(credentials.Raw.Credentials.Uri))
 		}

--- a/internal/cmd/mariadb/credentials/describe/describe_test.go
+++ b/internal/cmd/mariadb/credentials/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/credentials/describe/describe_test.go
+++ b/internal/cmd/mariadb/credentials/describe/describe_test.go
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiGetCredentialsRequest)) mariadb.ApiGetCredentialsRequest {
-	request := testClient.GetCredentials(testCtx, testProjectId, testInstanceId, testCredentialsId)
+	request := testClient.DefaultAPI.GetCredentials(testCtx, testProjectId, testInstanceId, testCredentialsId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -189,7 +189,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/credentials/describe/describe_test.go
+++ b/internal/cmd/mariadb/credentials/describe/describe_test.go
@@ -19,7 +19,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testCredentialsId = uuid.NewString()

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/mariadb/credentials/list/list.go
+++ b/internal/cmd/mariadb/credentials/list/list.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/client"
 	mariadbUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -70,7 +69,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 			credentials := resp.GetCredentialsList()
 
-			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -120,7 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiListCredentialsRequest {
-	req := apiClient.ListCredentials(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.ListCredentials(ctx, model.ProjectId, model.InstanceId)
 	return req
 }
 
@@ -135,7 +134,7 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, credenti
 		table.SetHeader("ID")
 		for i := range credentials {
 			c := credentials[i]
-			table.AddRow(utils.PtrString(c.Id))
+			table.AddRow(c.Id)
 		}
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/mariadb/credentials/list/list_test.go
+++ b/internal/cmd/mariadb/credentials/list/list_test.go
@@ -18,7 +18,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -50,7 +50,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiListCredentialsRequest)) mariadb.ApiListCredentialsRequest {
-	request := testClient.ListCredentials(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.ListCredentials(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -160,7 +160,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/credentials/list/list_test.go
+++ b/internal/cmd/mariadb/credentials/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -47,7 +47,7 @@ type inputModel struct {
 	InstanceName         *string
 	EnableMonitoring     *bool
 	Graphite             *string
-	MetricsFrequency     *int64
+	MetricsFrequency     *int32
 	MetricsPrefix        *string
 	MonitoringInstanceId *string
 	SgwAcl               *[]string
@@ -98,7 +98,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				var dsaInvalidPlanError *cliErr.DSAInvalidPlanError
 				if !errors.As(err, &dsaInvalidPlanError) {
@@ -110,12 +110,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("create MariaDB instance: %w", err)
 			}
-			instanceId := *resp.InstanceId
 
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating instance", func() error {
-					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId).WaitWithContext(ctx)
+					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, resp.InstanceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -134,7 +133,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(instanceNameFlag, "n", "", "Instance name")
 	cmd.Flags().Bool(enableMonitoringFlag, false, "Enable monitoring")
 	cmd.Flags().String(graphiteFlag, "", "Graphite host")
-	cmd.Flags().Int64(metricsFrequencyFlag, 0, "Metrics frequency")
+	cmd.Flags().Int32(metricsFrequencyFlag, 0, "Metrics frequency")
 	cmd.Flags().String(metricsPrefixFlag, "", "Metrics prefix")
 	cmd.Flags().Var(flags.UUIDFlag(), monitoringInstanceIdFlag, "Monitoring instance ID")
 	cmd.Flags().Var(flags.CIDRSliceFlag(), sgwAclFlag, "List of IP networks in CIDR notation which are allowed to access this instance")
@@ -174,7 +173,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		EnableMonitoring:     flags.FlagToBoolPointer(p, cmd, enableMonitoringFlag),
 		MonitoringInstanceId: flags.FlagToStringPointer(p, cmd, monitoringInstanceIdFlag),
 		Graphite:             flags.FlagToStringPointer(p, cmd, graphiteFlag),
-		MetricsFrequency:     flags.FlagToInt64Pointer(p, cmd, metricsFrequencyFlag),
+		MetricsFrequency:     flags.FlagToInt32Pointer(p, cmd, metricsFrequencyFlag),
 		MetricsPrefix:        flags.FlagToStringPointer(p, cmd, metricsPrefixFlag),
 		SgwAcl:               flags.FlagToStringSlicePointer(p, cmd, sgwAclFlag),
 		Syslog:               flags.FlagToStringSlicePointer(p, cmd, syslogFlag),
@@ -187,18 +186,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	return &model, nil
 }
 
-type mariaDBClient interface {
-	CreateInstance(ctx context.Context, projectId string) mariadb.ApiCreateInstanceRequest
-	ListOfferingsExecute(ctx context.Context, projectId string) (*mariadb.ListOfferingsResponse, error)
-}
-
-func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClient) (mariadb.ApiCreateInstanceRequest, error) {
+func buildRequest(ctx context.Context, model *inputModel, apiClient mariadb.DefaultAPI) (mariadb.ApiCreateInstanceRequest, error) {
 	req := apiClient.CreateInstance(ctx, model.ProjectId)
 
 	var planId *string
 	var err error
 
-	offerings, err := apiClient.ListOfferingsExecute(ctx, model.ProjectId)
+	offerings, err := apiClient.ListOfferings(ctx, model.ProjectId).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MariaDB offerings: %w", err)
 	}
@@ -219,14 +213,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClien
 		}
 		planId = model.PlanId
 	}
-
 	var sgwAcl *string
 	if model.SgwAcl != nil {
 		sgwAcl = utils.Ptr(strings.Join(*model.SgwAcl, ","))
 	}
 
 	req = req.CreateInstancePayload(mariadb.CreateInstancePayload{
-		InstanceName: model.InstanceName,
+		InstanceName: utils.PtrString(model.InstanceName),
 		Parameters: &mariadb.InstanceParameters{
 			EnableMonitoring:     model.EnableMonitoring,
 			Graphite:             model.Graphite,
@@ -234,9 +227,9 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClien
 			MetricsFrequency:     model.MetricsFrequency,
 			MetricsPrefix:        model.MetricsPrefix,
 			SgwAcl:               sgwAcl,
-			Syslog:               model.Syslog,
+			Syslog:               utils.GetSliceFromPointer(model.Syslog),
 		},
-		PlanId: planId,
+		PlanId: utils.PtrString(planId),
 	})
 	return req, nil
 }
@@ -251,7 +244,7 @@ func outputResult(p *print.Printer, outputFormat string, async bool, projectLabe
 		if async {
 			operationState = "Triggered creation of"
 		}
-		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, utils.PtrString(resp.InstanceId))
+		p.Outputf("%s instance for project %q. Instance ID: %s\n", operationState, projectLabel, resp.InstanceId)
 		return nil
 	})
 }

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/wait"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api/wait"
 )
 
 const (

--- a/internal/cmd/mariadb/instance/create/create.go
+++ b/internal/cmd/mariadb/instance/create/create.go
@@ -51,7 +51,7 @@ type inputModel struct {
 	MetricsPrefix        *string
 	MonitoringInstanceId *string
 	SgwAcl               *[]string
-	Syslog               *[]string
+	Syslog               []string
 	PlanId               *string
 }
 
@@ -176,7 +176,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		MetricsFrequency:     flags.FlagToInt32Pointer(p, cmd, metricsFrequencyFlag),
 		MetricsPrefix:        flags.FlagToStringPointer(p, cmd, metricsPrefixFlag),
 		SgwAcl:               flags.FlagToStringSlicePointer(p, cmd, sgwAclFlag),
-		Syslog:               flags.FlagToStringSlicePointer(p, cmd, syslogFlag),
+		Syslog:               flags.FlagToStringSliceValue(p, cmd, syslogFlag),
 		PlanId:               planId,
 		PlanName:             planName,
 		Version:              version,
@@ -227,7 +227,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariadb.Defa
 			MetricsFrequency:     model.MetricsFrequency,
 			MetricsPrefix:        model.MetricsPrefix,
 			SgwAcl:               sgwAcl,
-			Syslog:               utils.GetSliceFromPointer(model.Syslog),
+			Syslog:               model.Syslog,
 		},
 		PlanId: utils.PtrString(planId),
 	})

--- a/internal/cmd/mariadb/instance/create/create_test.go
+++ b/internal/cmd/mariadb/instance/create/create_test.go
@@ -21,22 +21,22 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 
-type mariaDBClientMocked struct {
+type mockSettings struct {
 	returnError       bool
 	listOfferingsResp *mariadb.ListOfferingsResponse
 }
 
-func (c *mariaDBClientMocked) CreateInstance(ctx context.Context, projectId string) mariadb.ApiCreateInstanceRequest {
-	return testClient.CreateInstance(ctx, projectId)
-}
-
-func (c *mariaDBClientMocked) ListOfferingsExecute(_ context.Context, _ string) (*mariadb.ListOfferingsResponse, error) {
-	if c.returnError {
-		return nil, fmt.Errorf("list flavors failed")
+func newAPIMock(s mockSettings) mariadb.DefaultAPI {
+	return &mariadb.DefaultAPIServiceMock{
+		ListOfferingsExecuteMock: utils.Ptr(func(_ mariadb.ApiListOfferingsRequest) (*mariadb.ListOfferingsResponse, error) {
+			if s.returnError {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return s.listOfferingsResp, nil
+		}),
 	}
-	return c.listOfferingsResp, nil
 }
 
 var testProjectId = uuid.NewString()
@@ -71,7 +71,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceName:         utils.Ptr("example-name"),
 		EnableMonitoring:     utils.Ptr(true),
 		Graphite:             utils.Ptr("example-graphite"),
-		MetricsFrequency:     utils.Ptr(int64(100)),
+		MetricsFrequency:     utils.Ptr(int32(100)),
 		MetricsPrefix:        utils.Ptr("example-prefix"),
 		MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 		SgwAcl:               utils.Ptr([]string{"198.51.100.14/24"}),
@@ -85,19 +85,19 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiCreateInstanceRequest)) mariadb.ApiCreateInstanceRequest {
-	request := testClient.CreateInstance(testCtx, testProjectId)
+	request := testClient.DefaultAPI.CreateInstance(testCtx, testProjectId)
 	request = request.CreateInstancePayload(mariadb.CreateInstancePayload{
-		InstanceName: utils.Ptr("example-name"),
+		InstanceName: "example-name",
 		Parameters: &mariadb.InstanceParameters{
 			EnableMonitoring:     utils.Ptr(true),
 			Graphite:             utils.Ptr("example-graphite"),
-			MetricsFrequency:     utils.Ptr(int64(100)),
+			MetricsFrequency:     utils.Ptr(int32(100)),
 			MetricsPrefix:        utils.Ptr("example-prefix"),
 			MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 			SgwAcl:               utils.Ptr("198.51.100.14/24"),
-			Syslog:               utils.Ptr([]string{"example-syslog"}),
+			Syslog:               []string{"example-syslog"},
 		},
-		PlanId: utils.Ptr(testPlanId),
+		PlanId: testPlanId,
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -178,7 +178,7 @@ func TestParseInput(t *testing.T) {
 				InstanceName:     utils.Ptr(""),
 				EnableMonitoring: utils.Ptr(false),
 				Graphite:         utils.Ptr(""),
-				MetricsFrequency: utils.Ptr(int64(0)),
+				MetricsFrequency: utils.Ptr(int32(0)),
 				MetricsPrefix:    utils.Ptr(""),
 			},
 		},
@@ -285,13 +285,13 @@ func TestBuildRequest(t *testing.T) {
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
 			getOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("example-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "example-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -309,13 +309,13 @@ func TestBuildRequest(t *testing.T) {
 			),
 			expectedRequest: fixtureRequest(),
 			getOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("example-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "example-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -344,13 +344,13 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			getOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("other-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "other-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -368,30 +368,30 @@ func TestBuildRequest(t *testing.T) {
 				PlanId: utils.Ptr(testPlanId),
 			},
 			getOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("example-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "example-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
 				},
 			},
-			expectedRequest: testClient.CreateInstance(testCtx, testProjectId).
-				CreateInstancePayload(mariadb.CreateInstancePayload{PlanId: utils.Ptr(testPlanId), Parameters: &mariadb.InstanceParameters{}}),
+			expectedRequest: testClient.DefaultAPI.CreateInstance(testCtx, testProjectId).
+				CreateInstancePayload(mariadb.CreateInstancePayload{PlanId: testPlanId, Parameters: &mariadb.InstanceParameters{}}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mariaDBClientMocked{
+			settings := mockSettings{
 				returnError:       tt.getOfferingsFails,
 				listOfferingsResp: tt.getOfferingsResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPIMock(settings))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -402,6 +402,8 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/instance/create/create_test.go
+++ b/internal/cmd/mariadb/instance/create/create_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/instance/create/create_test.go
+++ b/internal/cmd/mariadb/instance/create/create_test.go
@@ -75,7 +75,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		MetricsPrefix:        utils.Ptr("example-prefix"),
 		MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 		SgwAcl:               utils.Ptr([]string{"198.51.100.14/24"}),
-		Syslog:               utils.Ptr([]string{"example-syslog"}),
+		Syslog:               []string{"example-syslog"},
 		PlanId:               utils.Ptr(testPlanId),
 	}
 	for _, mod := range mods {
@@ -254,9 +254,7 @@ func TestParseInput(t *testing.T) {
 			syslogValues: []string{"example-syslog-1", "example-syslog-2"},
 			isValid:      true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Syslog = utils.Ptr(
-					append(*model.Syslog, "example-syslog-1", "example-syslog-2"),
-				)
+				model.Syslog = append(model.Syslog, "example-syslog-1", "example-syslog-2")
 			}),
 		},
 	}

--- a/internal/cmd/mariadb/instance/delete/delete.go
+++ b/internal/cmd/mariadb/instance/delete/delete.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/wait"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api/wait"
 )
 
 const (

--- a/internal/cmd/mariadb/instance/delete/delete.go
+++ b/internal/cmd/mariadb/instance/delete/delete.go
@@ -54,7 +54,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -76,7 +76,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Deleting instance", func() error {
-					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId).WaitWithContext(ctx)
+					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -113,6 +113,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiDeleteInstanceRequest {
-	req := apiClient.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
 	return req
 }

--- a/internal/cmd/mariadb/instance/delete/delete_test.go
+++ b/internal/cmd/mariadb/instance/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/instance/delete/delete_test.go
+++ b/internal/cmd/mariadb/instance/delete/delete_test.go
@@ -18,7 +18,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 

--- a/internal/cmd/mariadb/instance/delete/delete_test.go
+++ b/internal/cmd/mariadb/instance/delete/delete_test.go
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiDeleteInstanceRequest)) mariadb.ApiDeleteInstanceRequest {
-	request := testClient.DeleteInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.DeleteInstance(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -161,7 +161,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -100,18 +100,17 @@ func outputResult(p *print.Printer, outputFormat string, instance *mariadb.Insta
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(instance.InstanceId))
 		table.AddSeparator()
-		table.AddRow("NAME", utils.PtrString(instance.Name))
+		table.AddRow("NAME", instance.Name)
 		table.AddSeparator()
-		if instance.LastOperation != nil {
-			table.AddRow("LAST OPERATION TYPE", utils.PtrString(instance.LastOperation.Type))
-			table.AddSeparator()
-			table.AddRow("LAST OPERATION STATE", utils.PtrString(instance.LastOperation.State))
-			table.AddSeparator()
-		}
-		table.AddRow("PLAN ID", utils.PtrString(instance.PlanId))
+		table.AddRow("LAST OPERATION TYPE", instance.LastOperation.GetType())
+		table.AddSeparator()
+		table.AddRow("LAST OPERATION STATE", instance.LastOperation.GetState())
+		table.AddSeparator()
+
+		table.AddRow("PLAN ID", instance.PlanId)
 		// Only show ACL if it's present and not empty
 		if instance.Parameters != nil {
-			acl := (*instance.Parameters)[aclParameterKey]
+			acl := instance.Parameters[aclParameterKey]
 			aclStr, ok := acl.(string)
 			if ok {
 				if aclStr != "" {

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -87,7 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId)
 	return req
 }
 

--- a/internal/cmd/mariadb/instance/describe/describe.go
+++ b/internal/cmd/mariadb/instance/describe/describe.go
@@ -102,11 +102,12 @@ func outputResult(p *print.Printer, outputFormat string, instance *mariadb.Insta
 		table.AddSeparator()
 		table.AddRow("NAME", instance.Name)
 		table.AddSeparator()
-		table.AddRow("LAST OPERATION TYPE", instance.LastOperation.GetType())
-		table.AddSeparator()
-		table.AddRow("LAST OPERATION STATE", instance.LastOperation.GetState())
-		table.AddSeparator()
-
+		if _, ok := instance.LastOperation.GetStateOk(); ok {
+			table.AddRow("LAST OPERATION TYPE", instance.LastOperation.GetType())
+			table.AddSeparator()
+			table.AddRow("LAST OPERATION STATE", instance.LastOperation.GetState())
+			table.AddSeparator()
+		}
 		table.AddRow("PLAN ID", instance.PlanId)
 		// Only show ACL if it's present and not empty
 		if instance.Parameters != nil {

--- a/internal/cmd/mariadb/instance/describe/describe_test.go
+++ b/internal/cmd/mariadb/instance/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/instance/describe/describe_test.go
+++ b/internal/cmd/mariadb/instance/describe/describe_test.go
@@ -58,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiGetInstanceRequest)) mariadb.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -162,7 +162,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/instance/describe/describe_test.go
+++ b/internal/cmd/mariadb/instance/describe/describe_test.go
@@ -19,7 +19,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -131,15 +131,12 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, instances
 		for i := range instances {
 			instance := instances[i]
 
-			lastOperationType, lastOperationState := "", ""
-			if instance.LastOperation != nil {
-				lastOperationType = utils.PtrString(instance.LastOperation.Type)
-				lastOperationState = utils.PtrString(instance.LastOperation.State)
-			}
+			lastOperationType := string(instance.LastOperation.GetType())
+			lastOperationState := string(instance.LastOperation.GetState())
 
 			table.AddRow(
 				utils.PtrString(instance.InstanceId),
-				utils.PtrString(instance.Name),
+				instance.Name,
 				lastOperationType,
 				lastOperationState,
 			)

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -115,7 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiListInstancesRequest {
-	req := apiClient.ListInstances(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.ListInstances(ctx, model.ProjectId)
 	return req
 }
 

--- a/internal/cmd/mariadb/instance/list/list.go
+++ b/internal/cmd/mariadb/instance/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/mariadb/instance/list/list_test.go
+++ b/internal/cmd/mariadb/instance/list/list_test.go
@@ -18,7 +18,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -47,7 +47,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiListInstancesRequest)) mariadb.ApiListInstancesRequest {
-	request := testClient.ListInstances(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListInstances(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/mariadb/instance/list/list_test.go
+++ b/internal/cmd/mariadb/instance/list/list_test.go
@@ -136,7 +136,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/instance/list/list_test.go
+++ b/internal/cmd/mariadb/instance/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 type testCtxKey struct{}

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -20,8 +20,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/wait"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
+	"github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api/wait"
 )
 
 const (

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -47,7 +47,7 @@ type inputModel struct {
 
 	EnableMonitoring     *bool
 	Graphite             *string
-	MetricsFrequency     *int64
+	MetricsFrequency     *int32
 	MetricsPrefix        *string
 	MonitoringInstanceId *string
 	SgwAcl               *[]string
@@ -95,7 +95,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				var dsaInvalidPlanError *cliErr.DSAInvalidPlanError
 				if !errors.As(err, &dsaInvalidPlanError) {
@@ -112,7 +112,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Updating instance", func() error {
-					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId).WaitWithContext(ctx)
+					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, instanceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -135,7 +135,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(enableMonitoringFlag, false, "Enable monitoring")
 	cmd.Flags().String(graphiteFlag, "", "Graphite host")
-	cmd.Flags().Int64(metricsFrequencyFlag, 0, "Metrics frequency")
+	cmd.Flags().Int32(metricsFrequencyFlag, 0, "Metrics frequency")
 	cmd.Flags().String(metricsPrefixFlag, "", "Metrics prefix")
 	cmd.Flags().Var(flags.UUIDFlag(), monitoringInstanceIdFlag, "Monitoring instance ID")
 	cmd.Flags().Var(flags.CIDRSliceFlag(), sgwAclFlag, "List of IP networks in CIDR notation which are allowed to access this instance")
@@ -156,7 +156,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	enableMonitoring := flags.FlagToBoolPointer(p, cmd, enableMonitoringFlag)
 	monitoringInstanceId := flags.FlagToStringPointer(p, cmd, monitoringInstanceIdFlag)
 	graphite := flags.FlagToStringPointer(p, cmd, graphiteFlag)
-	metricsFrequency := flags.FlagToInt64Pointer(p, cmd, metricsFrequencyFlag)
+	metricsFrequency := flags.FlagToInt32Pointer(p, cmd, metricsFrequencyFlag)
 	metricsPrefix := flags.FlagToStringPointer(p, cmd, metricsPrefixFlag)
 	sgwAcl := flags.FlagToStringSlicePointer(p, cmd, sgwAclFlag)
 	syslog := flags.FlagToStringSlicePointer(p, cmd, syslogFlag)
@@ -197,18 +197,13 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	return &model, nil
 }
 
-type mariaDBClient interface {
-	PartialUpdateInstance(ctx context.Context, projectId, instanceId string) mariadb.ApiPartialUpdateInstanceRequest
-	ListOfferingsExecute(ctx context.Context, projectId string) (*mariadb.ListOfferingsResponse, error)
-}
-
-func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClient) (mariadb.ApiPartialUpdateInstanceRequest, error) {
+func buildRequest(ctx context.Context, model *inputModel, apiClient mariadb.DefaultAPI) (mariadb.ApiPartialUpdateInstanceRequest, error) {
 	req := apiClient.PartialUpdateInstance(ctx, model.ProjectId, model.InstanceId)
 
 	var planId *string
 	var err error
 
-	offerings, err := apiClient.DefaultAPI.ListOfferingsExecute(ctx, model.ProjectId)
+	offerings, err := apiClient.ListOfferings(ctx, model.ProjectId).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MariaDB offerings: %w", err)
 	}
@@ -246,7 +241,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClien
 			MetricsFrequency:     model.MetricsFrequency,
 			MetricsPrefix:        model.MetricsPrefix,
 			SgwAcl:               sgwAcl,
-			Syslog:               model.Syslog,
+			Syslog:               utils.GetSliceFromPointer(model.Syslog),
 		},
 		PlanId: planId,
 	})

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -51,7 +51,7 @@ type inputModel struct {
 	MetricsPrefix        *string
 	MonitoringInstanceId *string
 	SgwAcl               *[]string
-	Syslog               *[]string
+	Syslog               []string
 	PlanId               *string
 }
 
@@ -159,7 +159,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	metricsFrequency := flags.FlagToInt32Pointer(p, cmd, metricsFrequencyFlag)
 	metricsPrefix := flags.FlagToStringPointer(p, cmd, metricsPrefixFlag)
 	sgwAcl := flags.FlagToStringSlicePointer(p, cmd, sgwAclFlag)
-	syslog := flags.FlagToStringSlicePointer(p, cmd, syslogFlag)
+	syslog := flags.FlagToStringSliceValue(p, cmd, syslogFlag)
 	planId := flags.FlagToStringPointer(p, cmd, planIdFlag)
 	planName := flags.FlagToStringValue(p, cmd, planNameFlag)
 	version := flags.FlagToStringValue(p, cmd, versionFlag)
@@ -241,7 +241,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariadb.Defa
 			MetricsFrequency:     model.MetricsFrequency,
 			MetricsPrefix:        model.MetricsPrefix,
 			SgwAcl:               sgwAcl,
-			Syslog:               utils.GetSliceFromPointer(model.Syslog),
+			Syslog:               model.Syslog,
 		},
 		PlanId: planId,
 	})

--- a/internal/cmd/mariadb/instance/update/update.go
+++ b/internal/cmd/mariadb/instance/update/update.go
@@ -82,7 +82,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := mariadbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -208,7 +208,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient mariaDBClien
 	var planId *string
 	var err error
 
-	offerings, err := apiClient.ListOfferingsExecute(ctx, model.ProjectId)
+	offerings, err := apiClient.DefaultAPI.ListOfferingsExecute(ctx, model.ProjectId)
 	if err != nil {
 		return req, fmt.Errorf("get MariaDB offerings: %w", err)
 	}

--- a/internal/cmd/mariadb/instance/update/update_test.go
+++ b/internal/cmd/mariadb/instance/update/update_test.go
@@ -86,7 +86,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		MetricsPrefix:        utils.Ptr("example-prefix"),
 		MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 		SgwAcl:               utils.Ptr([]string{"198.51.100.14/24"}),
-		Syslog:               utils.Ptr([]string{"example-syslog"}),
+		Syslog:               []string{"example-syslog"},
 		PlanId:               utils.Ptr(testPlanId),
 	}
 	for _, mod := range mods {
@@ -268,9 +268,7 @@ func TestParseInput(t *testing.T) {
 			syslogValues: []string{"example-syslog-1", "example-syslog-2"},
 			isValid:      true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Syslog = utils.Ptr(
-					append(*model.Syslog, "example-syslog-1", "example-syslog-2"),
-				)
+				model.Syslog = append(model.Syslog, "example-syslog-1", "example-syslog-2")
 			}),
 		},
 	}

--- a/internal/cmd/mariadb/instance/update/update_test.go
+++ b/internal/cmd/mariadb/instance/update/update_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag

--- a/internal/cmd/mariadb/instance/update/update_test.go
+++ b/internal/cmd/mariadb/instance/update/update_test.go
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 
 type mariaDBClientMocked struct {
 	returnError       bool

--- a/internal/cmd/mariadb/instance/update/update_test.go
+++ b/internal/cmd/mariadb/instance/update/update_test.go
@@ -22,20 +22,20 @@ type testCtxKey struct{}
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 
-type mariaDBClientMocked struct {
+type mockSettings struct {
 	returnError       bool
 	listOfferingsResp *mariadb.ListOfferingsResponse
 }
 
-func (c *mariaDBClientMocked) PartialUpdateInstance(ctx context.Context, projectId, instanceId string) mariadb.ApiPartialUpdateInstanceRequest {
-	return testClient.PartialUpdateInstance(ctx, projectId, instanceId)
-}
-
-func (c *mariaDBClientMocked) ListOfferingsExecute(_ context.Context, _ string) (*mariadb.ListOfferingsResponse, error) {
-	if c.returnError {
-		return nil, fmt.Errorf("list flavors failed")
+func newAPIMock(s mockSettings) mariadb.DefaultAPI {
+	return &mariadb.DefaultAPIServiceMock{
+		ListOfferingsExecuteMock: utils.Ptr(func(_ mariadb.ApiListOfferingsRequest) (*mariadb.ListOfferingsResponse, error) {
+			if s.returnError {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return s.listOfferingsResp, nil
+		}),
 	}
-	return c.listOfferingsResp, nil
 }
 
 var (
@@ -82,7 +82,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceId:           testInstanceId,
 		EnableMonitoring:     utils.Ptr(true),
 		Graphite:             utils.Ptr("example-graphite"),
-		MetricsFrequency:     utils.Ptr(int64(100)),
+		MetricsFrequency:     utils.Ptr(int32(100)),
 		MetricsPrefix:        utils.Ptr("example-prefix"),
 		MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 		SgwAcl:               utils.Ptr([]string{"198.51.100.14/24"}),
@@ -96,16 +96,16 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiPartialUpdateInstanceRequest)) mariadb.ApiPartialUpdateInstanceRequest {
-	request := testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId)
 	request = request.PartialUpdateInstancePayload(mariadb.PartialUpdateInstancePayload{
 		Parameters: &mariadb.InstanceParameters{
 			EnableMonitoring:     utils.Ptr(true),
 			Graphite:             utils.Ptr("example-graphite"),
-			MetricsFrequency:     utils.Ptr(int64(100)),
+			MetricsFrequency:     utils.Ptr(int32(100)),
 			MetricsPrefix:        utils.Ptr("example-prefix"),
 			MonitoringInstanceId: utils.Ptr(testMonitoringInstanceId),
 			SgwAcl:               utils.Ptr("198.51.100.14/24"),
-			Syslog:               utils.Ptr([]string{"example-syslog"}),
+			Syslog:               []string{"example-syslog"},
 		},
 		PlanId: utils.Ptr(testPlanId),
 	})
@@ -186,7 +186,7 @@ func TestParseInput(t *testing.T) {
 				PlanId:           utils.Ptr(testPlanId),
 				EnableMonitoring: utils.Ptr(false),
 				Graphite:         utils.Ptr(""),
-				MetricsFrequency: utils.Ptr(int64(0)),
+				MetricsFrequency: utils.Ptr(int32(0)),
 				MetricsPrefix:    utils.Ptr(""),
 			},
 		},
@@ -363,13 +363,13 @@ func TestBuildRequest(t *testing.T) {
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
 			listOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("example-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "example-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -387,13 +387,13 @@ func TestBuildRequest(t *testing.T) {
 			),
 			expectedRequest: fixtureRequest(),
 			listOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("example-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "example-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -422,13 +422,13 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			listOfferingsResp: &mariadb.ListOfferingsResponse{
-				Offerings: &[]mariadb.Offering{
+				Offerings: []mariadb.Offering{
 					{
-						Version: utils.Ptr("example-version"),
-						Plans: &[]mariadb.Plan{
+						Version: "example-version",
+						Plans: []mariadb.Plan{
 							{
-								Name: utils.Ptr("other-plan-name"),
-								Id:   utils.Ptr(testPlanId),
+								Name: "other-plan-name",
+								Id:   testPlanId,
 							},
 						},
 					},
@@ -445,18 +445,18 @@ func TestBuildRequest(t *testing.T) {
 				},
 				InstanceId: testInstanceId,
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId).
 				PartialUpdateInstancePayload(mariadb.PartialUpdateInstancePayload{Parameters: &mariadb.InstanceParameters{}}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mariaDBClientMocked{
+			settings := mockSettings{
 				returnError:       tt.getOfferingsFails,
 				listOfferingsResp: tt.listOfferingsResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPIMock(settings))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -467,6 +467,8 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -115,7 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mariadb.APIClient) mariadb.ApiListOfferingsRequest {
-	req := apiClient.ListOfferings(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.ListOfferings(ctx, model.ProjectId)
 	return req
 }
 

--- a/internal/cmd/mariadb/plans/plans.go
+++ b/internal/cmd/mariadb/plans/plans.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/mariadb/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -131,14 +130,14 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, plans []m
 		for i := range plans {
 			o := plans[i]
 			if o.Plans != nil {
-				for j := range *o.Plans {
-					plan := (*o.Plans)[j]
+				for j := range o.Plans {
+					plan := o.Plans[j]
 					table.AddRow(
-						utils.PtrString(o.Name),
-						utils.PtrString(o.Version),
-						utils.PtrString(plan.Id),
-						utils.PtrString(plan.Name),
-						utils.PtrString(plan.Description),
+						o.Name,
+						o.Version,
+						plan.Id,
+						plan.Name,
+						plan.Description,
 					)
 				}
 				table.AddSeparator()

--- a/internal/cmd/mariadb/plans/plans_test.go
+++ b/internal/cmd/mariadb/plans/plans_test.go
@@ -18,7 +18,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mariadb.APIClient{}
+var testClient = &mariadb.APIClient{DefaultAPI: &mariadb.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -47,7 +47,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mariadb.ApiListOfferingsRequest)) mariadb.ApiListOfferingsRequest {
-	request := testClient.ListOfferings(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListOfferings(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/mariadb/plans/plans_test.go
+++ b/internal/cmd/mariadb/plans/plans_test.go
@@ -136,7 +136,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mariadb.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mariadb/plans/plans_test.go
+++ b/internal/cmd/mariadb/plans/plans_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 type testCtxKey struct{}

--- a/internal/pkg/services/mariadb/client/client.go
+++ b/internal/pkg/services/mariadb/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*mariadb.APIClient, error) {

--- a/internal/pkg/services/mariadb/client/client.go
+++ b/internal/pkg/services/mariadb/client/client.go
@@ -10,5 +10,5 @@ import (
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*mariadb.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.MariaDBCustomEndpointKey), true, genericclient.CreateApiClient[*mariadb.APIClient](mariadb.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.MariaDBCustomEndpointKey), true, mariadb.NewAPIClient)
 }

--- a/internal/pkg/services/mariadb/utils/utils.go
+++ b/internal/pkg/services/mariadb/utils/utils.go
@@ -15,9 +15,9 @@ const (
 )
 
 func ValidatePlanId(planId string, offerings *mariadb.ListOfferingsResponse) error {
-	for _, offer := range *offerings.Offerings {
-		for _, plan := range *offer.Plans {
-			if plan.Id != nil && strings.EqualFold(*plan.Id, planId) {
+	for _, offer := range offerings.Offerings {
+		for _, plan := range offer.Plans {
+			if strings.EqualFold(plan.Id, planId) {
 				return nil
 			}
 		}
@@ -33,21 +33,18 @@ func LoadPlanId(planName, version string, offerings *mariadb.ListOfferingsRespon
 	availableVersions := ""
 	availablePlanNames := ""
 	isValidVersion := false
-	for _, offer := range *offerings.Offerings {
-		if !strings.EqualFold(*offer.Version, version) {
-			availableVersions = fmt.Sprintf("%s\n- %s", availableVersions, *offer.Version)
+	for _, offer := range offerings.Offerings {
+		if !strings.EqualFold(offer.Version, version) {
+			availableVersions = fmt.Sprintf("%s\n- %s", availableVersions, offer.Version)
 			continue
 		}
 		isValidVersion = true
 
-		for _, plan := range *offer.Plans {
-			if plan.Name == nil {
-				continue
+		for _, plan := range offer.Plans {
+			if strings.EqualFold(plan.Name, planName) {
+				return &plan.Id, nil
 			}
-			if strings.EqualFold(*plan.Name, planName) && plan.Id != nil {
-				return plan.Id, nil
-			}
-			availablePlanNames = fmt.Sprintf("%s\n- %s", availablePlanNames, *plan.Name)
+			availablePlanNames = fmt.Sprintf("%s\n- %s", availablePlanNames, plan.Name)
 		}
 	}
 
@@ -65,23 +62,18 @@ func LoadPlanId(planName, version string, offerings *mariadb.ListOfferingsRespon
 	}
 }
 
-type MariaDBClient interface {
-	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*mariadb.Instance, error)
-	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*mariadb.CredentialsResponse, error)
-}
-
-func GetInstanceName(ctx context.Context, apiClient MariaDBClient, projectId, instanceId string) (string, error) {
-	resp, err := apiClient.GetInstanceExecute(ctx, projectId, instanceId)
+func GetInstanceName(ctx context.Context, apiClient mariadb.DefaultAPI, projectId, instanceId string) (string, error) {
+	resp, err := apiClient.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get MariaDB instance: %w", err)
 	}
-	return *resp.Name, nil
+	return resp.Name, nil
 }
 
-func GetCredentialsUsername(ctx context.Context, apiClient MariaDBClient, projectId, instanceId, credentialsId string) (string, error) {
-	resp, err := apiClient.GetCredentialsExecute(ctx, projectId, instanceId, credentialsId)
+func GetCredentialsUsername(ctx context.Context, apiClient mariadb.DefaultAPI, projectId, instanceId, credentialsId string) (string, error) {
+	resp, err := apiClient.GetCredentials(ctx, projectId, instanceId, credentialsId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get MariaDB credentials: %w", err)
 	}
-	return *resp.Raw.Credentials.Username, nil
+	return resp.Raw.Credentials.Username, nil
 }

--- a/internal/pkg/services/mariadb/utils/utils.go
+++ b/internal/pkg/services/mariadb/utils/utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 const (

--- a/internal/pkg/services/mariadb/utils/utils_test.go
+++ b/internal/pkg/services/mariadb/utils/utils_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v1api"
 )
 
 var (

--- a/internal/pkg/services/mariadb/utils/utils_test.go
+++ b/internal/pkg/services/mariadb/utils/utils_test.go
@@ -22,25 +22,28 @@ const (
 	testCredentialsUsername = "username"
 )
 
-type mariaDBClientMocked struct {
+type mockSettings struct {
 	getInstanceFails    bool
 	getInstanceResp     *mariadb.Instance
 	getCredentialsFails bool
 	getCredentialsResp  *mariadb.CredentialsResponse
 }
 
-func (m *mariaDBClientMocked) GetInstanceExecute(_ context.Context, _, _ string) (*mariadb.Instance, error) {
-	if m.getInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
+func newAPIMock(m mockSettings) mariadb.DefaultAPI {
+	return &mariadb.DefaultAPIServiceMock{
+		GetInstanceExecuteMock: utils.Ptr(func(_ mariadb.ApiGetInstanceRequest) (*mariadb.Instance, error) {
+			if m.getInstanceFails {
+				return nil, fmt.Errorf("could not get instance")
+			}
+			return m.getInstanceResp, nil
+		}),
+		GetCredentialsExecuteMock: utils.Ptr(func(_ mariadb.ApiGetCredentialsRequest) (*mariadb.CredentialsResponse, error) {
+			if m.getCredentialsFails {
+				return nil, fmt.Errorf("could not get user")
+			}
+			return m.getCredentialsResp, nil
+		}),
 	}
-	return m.getInstanceResp, nil
-}
-
-func (m *mariaDBClientMocked) GetCredentialsExecute(_ context.Context, _, _, _ string) (*mariadb.CredentialsResponse, error) {
-	if m.getCredentialsFails {
-		return nil, fmt.Errorf("could not get user")
-	}
-	return m.getCredentialsResp, nil
 }
 
 func TestGetInstanceName(t *testing.T) {
@@ -54,7 +57,7 @@ func TestGetInstanceName(t *testing.T) {
 		{
 			description: "base",
 			getInstanceResp: &mariadb.Instance{
-				Name: utils.Ptr(testInstanceName),
+				Name: testInstanceName,
 			},
 			isValid:        true,
 			expectedOutput: testInstanceName,
@@ -68,12 +71,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mariaDBClientMocked{
+			settings := mockSettings{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), client, testProjectId, testInstanceId)
+			output, err := GetInstanceName(context.Background(), newAPIMock(settings), testProjectId, testInstanceId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -103,8 +106,8 @@ func TestGetCredentialsUsername(t *testing.T) {
 			description: "base",
 			getCredentialsResp: &mariadb.CredentialsResponse{
 				Raw: &mariadb.RawCredentials{
-					Credentials: &mariadb.Credentials{
-						Username: utils.Ptr(testCredentialsUsername),
+					Credentials: mariadb.Credentials{
+						Username: testCredentialsUsername,
 					},
 				},
 			},
@@ -120,12 +123,12 @@ func TestGetCredentialsUsername(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mariaDBClientMocked{
+			settings := mockSettings{
 				getCredentialsFails: tt.getCredentialsFails,
 				getCredentialsResp:  tt.getCredentialsResp,
 			}
 
-			output, err := GetCredentialsUsername(context.Background(), client, testProjectId, testInstanceId, testCredentialsId)
+			output, err := GetCredentialsUsername(context.Background(), newAPIMock(settings), testProjectId, testInstanceId, testCredentialsId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")


### PR DESCRIPTION
## Description

relates to STACKITCLI-368

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
