### PR TITLE
fix(intake): set region to false in ConfigureClient

### DIFF
--- a/internal/pkg/services/intake/client/client.go
+++ b/internal/pkg/services/intake/client/client.go
@@ -11,5 +11,5 @@ import (
 
 // ConfigureClient creates and configures a new Intake API client
 func ConfigureClient(p *print.Printer, cliVersion string) (*intake.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.IntakeCustomEndpointKey), true, genericclient.CreateApiClient[*intake.APIClient](intake.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.IntakeCustomEndpointKey), false, genericclient.CreateApiClient[*intake.APIClient](intake.NewAPIClient))
 }


### PR DESCRIPTION
## Description

In order to test this just run a _intake list_ without the fix and with the fix

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->



## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
