### PR TITLE
SDK migration Secrets-Manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.5
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0
 	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3
-	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.3
+	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0 h1:JPP6a
 github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0/go.mod h1:NEz3f+GV5G++BE9/MmZCsXJyCih7jtg0pZuSyG2sLEs=
 github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3 h1:AiGNJmpQ/f9cglaIQQ4SyePbtCI3K1DQLNvqVN9jKSo=
 github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3/go.mod h1:U/q0V89fvCF2O1ZJfi68/Chie9YY/5s7xBHI1Klq7wA=
-github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.3 h1:3hZSg3z+4AXa5LbR2Vl38VmSA83ABItE63E53LuyWv8=
-github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.14.3/go.mod h1:5unx5r0IgeFCtJDEgsWddtgKvYSw442FDNdhtfyJnQI=
+github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1 h1:U5rstX5e6Am2t+Ukv5K1Sbftzxt5aFALMa9YS4jCJoo=
+github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1/go.mod h1:2XA8PE05Qg6BL2YXO4XgfGI9qskJ3cicLE5Qq0aqDdY=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8 h1:LLyANBzE8sQa0/49tQBqq4sVLhNgwdqCeQm76srJHWw=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8/go.mod h1:/bmg57XZu+bGczzcoumrukiGMPGzI2mOyTT4BVIQUBs=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6 h1:sQ3fdtUjgIL2Ul8nRYVVacHOwi5aSMTGGbYVL30oQBU=

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -154,7 +154,7 @@ func buildCreateInstanceRequest(ctx context.Context, model *inputModel, apiClien
 		Name: model.InstanceName,
 	}
 
-	if model.KmsKeyId != nil {
+	if model.KmsKeyId != nil && model.KmsKeyringId != nil && model.KmsKeyVersion != nil && model.KmsServiceAccountEmail != nil {
 		payload.KmsKey = &secretsmanager.KmsKeyPayload{
 			KeyId:               *model.KmsKeyId,
 			KeyRingId:           *model.KmsKeyringId,

--- a/internal/cmd/secrets-manager/instance/create/create.go
+++ b/internal/cmd/secrets-manager/instance/create/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -16,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -34,7 +33,7 @@ const (
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 
-	InstanceName *string
+	InstanceName string
 	Acls         *[]string
 
 	KmsKeyId               *string
@@ -92,7 +91,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("create Secrets Manager instance: %w", err)
 			}
-			instanceId := *resp.Id
+			instanceId := resp.Id
 
 			// Call API to create ACLs for instance, if ACLs are provided
 			if model.Acls != nil {
@@ -136,7 +135,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 	model := inputModel{
 		GlobalFlagModel:        globalFlags,
-		InstanceName:           flags.FlagToStringPointer(p, cmd, instanceNameFlag),
+		InstanceName:           flags.FlagToStringValue(p, cmd, instanceNameFlag),
 		Acls:                   flags.FlagToStringSlicePointer(p, cmd, aclFlag),
 		KmsKeyId:               flags.FlagToStringPointer(p, cmd, kmsKeyIdFlag),
 		KmsKeyringId:           flags.FlagToStringPointer(p, cmd, kmsKeyringIdFlag),
@@ -149,7 +148,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildCreateInstanceRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiCreateInstanceRequest {
-	req := apiClient.CreateInstance(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.CreateInstance(ctx, model.ProjectId)
 
 	payload := secretsmanager.CreateInstancePayload{
 		Name: model.InstanceName,
@@ -157,10 +156,10 @@ func buildCreateInstanceRequest(ctx context.Context, model *inputModel, apiClien
 
 	if model.KmsKeyId != nil {
 		payload.KmsKey = &secretsmanager.KmsKeyPayload{
-			KeyId:               model.KmsKeyId,
-			KeyRingId:           model.KmsKeyringId,
-			KeyVersion:          model.KmsKeyVersion,
-			ServiceAccountEmail: model.KmsServiceAccountEmail,
+			KeyId:               *model.KmsKeyId,
+			KeyRingId:           *model.KmsKeyringId,
+			KeyVersion:          *model.KmsKeyVersion,
+			ServiceAccountEmail: *model.KmsServiceAccountEmail,
 		}
 	}
 
@@ -170,15 +169,15 @@ func buildCreateInstanceRequest(ctx context.Context, model *inputModel, apiClien
 }
 
 func buildUpdateACLsRequest(ctx context.Context, model *inputModel, instanceId string, apiClient *secretsmanager.APIClient) secretsmanager.ApiUpdateACLsRequest {
-	req := apiClient.UpdateACLs(ctx, model.ProjectId, instanceId)
+	req := apiClient.DefaultAPI.UpdateACLs(ctx, model.ProjectId, instanceId)
 
 	cidrs := make([]secretsmanager.UpdateACLPayload, len(*model.Acls))
 
 	for i, acl := range *model.Acls {
-		cidrs[i] = secretsmanager.UpdateACLPayload{Cidr: utils.Ptr(acl)}
+		cidrs[i] = secretsmanager.UpdateACLPayload{Cidr: acl}
 	}
 
-	req = req.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{Cidrs: &cidrs})
+	req = req.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{Cidrs: cidrs})
 
 	return req
 }

--- a/internal/cmd/secrets-manager/instance/create/create_test.go
+++ b/internal/cmd/secrets-manager/instance/create/create_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -20,7 +20,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -49,7 +51,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		InstanceName: utils.Ptr("example"),
+		InstanceName: "example",
 		Acls:         utils.Ptr([]string{"198.51.100.14/24"}),
 	}
 	for _, mod := range mods {
@@ -59,9 +61,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiCreateInstanceRequest)) secretsmanager.ApiCreateInstanceRequest {
-	request := testClient.CreateInstance(testCtx, testProjectId)
+	request := testClient.DefaultAPI.CreateInstance(testCtx, testProjectId)
 	request = request.CreateInstancePayload(secretsmanager.CreateInstancePayload{
-		Name: utils.Ptr("example"),
+		Name: "example",
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -70,11 +72,11 @@ func fixtureRequest(mods ...func(request *secretsmanager.ApiCreateInstanceReques
 }
 
 func fixtureUpdateACLsRequest(mods ...func(request *secretsmanager.ApiUpdateACLsRequest)) secretsmanager.ApiUpdateACLsRequest {
-	request := testClient.UpdateACLs(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.UpdateACLs(testCtx, testProjectId, testInstanceId)
 	request = request.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{
-		Cidrs: utils.Ptr([]secretsmanager.UpdateACLPayload{
-			{Cidr: utils.Ptr("198.51.100.14/24")},
-		})})
+		Cidrs: []secretsmanager.UpdateACLPayload{
+			{Cidr: "198.51.100.14/24"},
+		}})
 
 	for _, mod := range mods {
 		mod(&request)
@@ -115,7 +117,7 @@ func TestParseInput(t *testing.T) {
 					ProjectId: testProjectId,
 					Verbosity: globalflags.VerbosityDefault,
 				},
-				InstanceName: utils.Ptr(""),
+				InstanceName: "",
 				Acls:         &[]string{},
 			},
 		},
@@ -240,15 +242,15 @@ func TestBuildCreateInstanceRequest(t *testing.T) {
 			}),
 			expectedRequest: fixtureRequest(func(request *secretsmanager.ApiCreateInstanceRequest) {
 				payload := secretsmanager.CreateInstancePayload{
-					Name: utils.Ptr("example"),
+					Name: "example",
 					KmsKey: &secretsmanager.KmsKeyPayload{
-						KeyId:               utils.Ptr(testKmsKeyId),
-						KeyRingId:           utils.Ptr(testKmsKeyringId),
-						KeyVersion:          utils.Ptr(testKmsKeyVersion),
-						ServiceAccountEmail: utils.Ptr(testKmsServiceAccountEmail),
+						KeyId:               testKmsKeyId,
+						KeyRingId:           testKmsKeyringId,
+						KeyVersion:          testKmsKeyVersion,
+						ServiceAccountEmail: testKmsServiceAccountEmail,
 					},
 				}
-				*request = (*request).CreateInstancePayload(payload)
+				*request = request.CreateInstancePayload(payload)
 			}),
 		},
 	}
@@ -284,10 +286,10 @@ func TestBuildCreateACLRequests(t *testing.T) {
 				*model.Acls = append(*model.Acls, "1.2.3.4/32")
 			}),
 			expectedRequest: fixtureUpdateACLsRequest().UpdateACLsPayload(secretsmanager.UpdateACLsPayload{
-				Cidrs: utils.Ptr([]secretsmanager.UpdateACLPayload{
-					{Cidr: utils.Ptr("198.51.100.14/24")},
-					{Cidr: utils.Ptr("1.2.3.4/32")},
-				})}),
+				Cidrs: []secretsmanager.UpdateACLPayload{
+					{Cidr: "198.51.100.14/24"},
+					{Cidr: "1.2.3.4/32"},
+				}}),
 		},
 	}
 

--- a/internal/cmd/secrets-manager/instance/delete/delete.go
+++ b/internal/cmd/secrets-manager/instance/delete/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -52,7 +52,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := secretsmanagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := secretsmanagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -96,6 +96,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiDeleteInstanceRequest {
-	req := apiClient.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.DeleteInstance(ctx, model.ProjectId, model.InstanceId)
 	return req
 }

--- a/internal/cmd/secrets-manager/instance/delete/delete_test.go
+++ b/internal/cmd/secrets-manager/instance/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -18,7 +18,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -57,7 +59,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiDeleteInstanceRequest)) secretsmanager.ApiDeleteInstanceRequest {
-	request := testClient.DeleteInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.DeleteInstance(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/secrets-manager/instance/describe/describe.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -93,12 +93,12 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildGetInstanceRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId)
 	return req
 }
 
 func buildListACLsRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiListACLsRequest {
-	req := apiClient.ListACLs(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.ListACLs(ctx, model.ProjectId, model.InstanceId)
 	return req
 }
 
@@ -116,38 +116,37 @@ func outputResult(p *print.Printer, outputFormat string, instance *secretsmanage
 
 	return p.OutputResult(outputFormat, output, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(instance.Id))
+		table.AddRow("ID", instance.Id)
 		table.AddSeparator()
-		table.AddRow("NAME", utils.PtrString(instance.Name))
+		table.AddRow("NAME", instance.Name)
 		table.AddSeparator()
-		table.AddRow("STATE", utils.PtrString(instance.State))
+		table.AddRow("STATE", instance.State)
 		table.AddSeparator()
-		table.AddRow("SECRETS", utils.PtrString(instance.SecretCount))
+		table.AddRow("SECRETS", instance.SecretCount)
 		table.AddSeparator()
-		table.AddRow("ENGINE", utils.PtrString(instance.SecretsEngine))
+		table.AddRow("ENGINE", instance.SecretsEngine)
 		table.AddSeparator()
-		table.AddRow("CREATION DATE", utils.PtrString(instance.CreationStartDate))
+		table.AddRow("CREATION DATE", instance.CreationStartDate)
 		table.AddSeparator()
 		kmsKey := instance.KmsKey
-		showKms := kmsKey != nil && (kmsKey.KeyId != nil || kmsKey.KeyRingId != nil || kmsKey.KeyVersion != nil || kmsKey.ServiceAccountEmail != nil)
-		if showKms {
-			table.AddRow("KMS KEY ID", utils.PtrString(kmsKey.KeyId))
+		if kmsKey != nil {
+			table.AddRow("KMS KEY ID", kmsKey.KeyId)
 			table.AddSeparator()
-			table.AddRow("KMS KEYRING ID", utils.PtrString(kmsKey.KeyRingId))
+			table.AddRow("KMS KEYRING ID", kmsKey.KeyRingId)
 			table.AddSeparator()
-			table.AddRow("KMS KEY VERSION", utils.PtrString(kmsKey.KeyVersion))
+			table.AddRow("KMS KEY VERSION", kmsKey.KeyVersion)
 			table.AddSeparator()
-			table.AddRow("KMS SERVICE ACCOUNT EMAIL", utils.PtrString(kmsKey.ServiceAccountEmail))
+			table.AddRow("KMS SERVICE ACCOUNT EMAIL", kmsKey.ServiceAccountEmail)
 		}
 		// Only show ACL if it's present and not empty
-		if aclList.Acls != nil && len(*aclList.Acls) > 0 {
+		if len(aclList.Acls) > 0 {
 			var cidrs []string
 
-			for _, acl := range *aclList.Acls {
-				cidrs = append(cidrs, *acl.Cidr)
+			for _, acl := range aclList.Acls {
+				cidrs = append(cidrs, acl.Cidr)
 			}
 
-			if showKms {
+			if kmsKey != nil {
 				table.AddSeparator()
 			}
 			table.AddRow("ACL", strings.Join(cidrs, ","))

--- a/internal/cmd/secrets-manager/instance/describe/describe_test.go
+++ b/internal/cmd/secrets-manager/instance/describe/describe_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +19,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -59,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureGetInstanceRequest(mods ...func(request *secretsmanager.ApiGetInstanceRequest)) secretsmanager.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -67,7 +68,7 @@ func fixtureGetInstanceRequest(mods ...func(request *secretsmanager.ApiGetInstan
 }
 
 func fixtureListACLsRequest(mods ...func(request *secretsmanager.ApiListACLsRequest)) secretsmanager.ApiListACLsRequest {
-	request := testClient.ListACLs(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.ListACLs(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -251,10 +252,10 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				instance: &secretsmanager.Instance{
 					KmsKey: &secretsmanager.KmsKeyPayload{
-						KeyId:               utils.Ptr("key-id"),
-						KeyRingId:           utils.Ptr("keyring-id"),
-						KeyVersion:          utils.Ptr(int64(1)),
-						ServiceAccountEmail: utils.Ptr("my-service-account-1234567@sa.stackit.cloud"),
+						KeyId:               "key-id",
+						KeyRingId:           "keyring-id",
+						KeyVersion:          1,
+						ServiceAccountEmail: "my-service-account-1234567@sa.stackit.cloud",
 					},
 				},
 				aclList: &secretsmanager.ListACLsResponse{},

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -67,7 +66,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("get Secrets Manager instances: %w", err)
 			}
 
-			if resp.Instances == nil || len(*resp.Instances) == 0 {
+			if len(resp.Instances) == 0 {
 				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
@@ -76,14 +75,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				params.Printer.Info("No instances found for project %q\n", projectLabel)
 				return nil
 			}
-			instances := *resp.Instances
 
 			// Truncate output
-			if model.Limit != nil && len(instances) > int(*model.Limit) {
-				instances = instances[:*model.Limit]
+			if model.Limit != nil && len((resp.Instances)) > int(*model.Limit) {
+				(resp.Instances) = resp.Instances[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, instances)
+			return outputResult(params.Printer, model.OutputFormat, (resp.Instances))
 		},
 	}
 
@@ -119,7 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiListInstancesRequest {
-	req := apiClient.ListInstances(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.ListInstances(ctx, model.ProjectId)
 	return req
 }
 
@@ -130,10 +128,10 @@ func outputResult(p *print.Printer, outputFormat string, instances []secretsmana
 		for i := range instances {
 			instance := instances[i]
 			table.AddRow(
-				utils.PtrString(instance.Id),
-				utils.PtrString(instance.Name),
-				utils.PtrString(instance.State),
-				utils.PtrString(instance.SecretCount),
+				instance.Id,
+				instance.Name,
+				instance.State,
+				instance.SecretCount,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/secrets-manager/instance/list/list.go
+++ b/internal/cmd/secrets-manager/instance/list/list.go
@@ -77,11 +77,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Truncate output
-			if model.Limit != nil && len((resp.Instances)) > int(*model.Limit) {
-				(resp.Instances) = resp.Instances[:*model.Limit]
+			if model.Limit != nil && len(resp.Instances) > int(*model.Limit) {
+				resp.Instances = resp.Instances[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, (resp.Instances))
+			return outputResult(params.Printer, model.OutputFormat, resp.Instances)
 		},
 	}
 

--- a/internal/cmd/secrets-manager/instance/list/list_test.go
+++ b/internal/cmd/secrets-manager/instance/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -49,7 +51,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiListInstancesRequest)) secretsmanager.ApiListInstancesRequest {
-	request := testClient.ListInstances(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListInstances(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/secrets-manager/instance/update/update.go
+++ b/internal/cmd/secrets-manager/instance/update/update.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -79,7 +79,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			existingInstanceName, err := secretsManagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			existingInstanceName, err := secretsManagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				existingInstanceName = model.InstanceId
@@ -93,7 +93,10 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Call API - execute UpdateInstance and/or UpdateACLs based on flags
 			if model.InstanceName != nil {
-				req := buildUpdateInstanceRequest(ctx, model, apiClient)
+				req, err := buildUpdateInstanceRequest(ctx, model, apiClient)
+				if err != nil {
+					return fmt.Errorf("unable to build update instance request: %w", err)
+				}
 				err = req.Execute()
 				if err != nil {
 					return fmt.Errorf("update Secrets Manager instance: %w", err)
@@ -162,37 +165,39 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	return &model, nil
 }
 
-func buildUpdateInstanceRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiUpdateInstanceRequest {
-	req := apiClient.UpdateInstance(ctx, model.ProjectId, model.InstanceId)
+func buildUpdateInstanceRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) (secretsmanager.ApiUpdateInstanceRequest, error) {
+	if model.InstanceName != nil {
+		req := apiClient.DefaultAPI.UpdateInstance(ctx, model.ProjectId, model.InstanceId)
 
-	payload := secretsmanager.UpdateInstancePayload{
-		Name: model.InstanceName,
-	}
-
-	if model.KmsKeyId != nil {
-		payload.KmsKey = &secretsmanager.KmsKeyPayload{
-			KeyId:               model.KmsKeyId,
-			KeyRingId:           model.KmsKeyringId,
-			KeyVersion:          model.KmsKeyVersion,
-			ServiceAccountEmail: model.KmsServiceAccountEmail,
+		payload := secretsmanager.UpdateInstancePayload{
+			Name: *model.InstanceName,
 		}
+
+		if model.KmsKeyId != nil && model.KmsKeyringId != nil && model.KmsKeyVersion != nil && model.KmsServiceAccountEmail != nil {
+			payload.KmsKey = &secretsmanager.KmsKeyPayload{
+				KeyId:               *model.KmsKeyId,
+				KeyRingId:           *model.KmsKeyringId,
+				KeyVersion:          *model.KmsKeyVersion,
+				ServiceAccountEmail: *model.KmsServiceAccountEmail,
+			}
+		}
+		req = req.UpdateInstancePayload(payload)
+
+		return req, nil
 	}
-
-	req = req.UpdateInstancePayload(payload)
-
-	return req
+	return secretsmanager.ApiUpdateInstanceRequest{}, fmt.Errorf("instanceName must not be null")
 }
 
 func buildUpdateACLsRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiUpdateACLsRequest {
-	req := apiClient.UpdateACLs(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.UpdateACLs(ctx, model.ProjectId, model.InstanceId)
 
 	cidrs := []secretsmanager.UpdateACLPayload{}
 
 	for _, acl := range *model.Acls {
-		cidrs = append(cidrs, secretsmanager.UpdateACLPayload{Cidr: utils.Ptr(acl)})
+		cidrs = append(cidrs, secretsmanager.UpdateACLPayload{Cidr: acl})
 	}
 
-	req = req.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{Cidrs: &cidrs})
+	req = req.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{Cidrs: cidrs})
 
 	return req
 }

--- a/internal/cmd/secrets-manager/instance/update/update.go
+++ b/internal/cmd/secrets-manager/instance/update/update.go
@@ -166,26 +166,26 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildUpdateInstanceRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) (secretsmanager.ApiUpdateInstanceRequest, error) {
-	if model.InstanceName != nil {
-		req := apiClient.DefaultAPI.UpdateInstance(ctx, model.ProjectId, model.InstanceId)
-
-		payload := secretsmanager.UpdateInstancePayload{
-			Name: *model.InstanceName,
-		}
-
-		if model.KmsKeyId != nil && model.KmsKeyringId != nil && model.KmsKeyVersion != nil && model.KmsServiceAccountEmail != nil {
-			payload.KmsKey = &secretsmanager.KmsKeyPayload{
-				KeyId:               *model.KmsKeyId,
-				KeyRingId:           *model.KmsKeyringId,
-				KeyVersion:          *model.KmsKeyVersion,
-				ServiceAccountEmail: *model.KmsServiceAccountEmail,
-			}
-		}
-		req = req.UpdateInstancePayload(payload)
-
-		return req, nil
+	if model.InstanceName == nil {
+		return secretsmanager.ApiUpdateInstanceRequest{}, fmt.Errorf("instanceName must not be null")
 	}
-	return secretsmanager.ApiUpdateInstanceRequest{}, fmt.Errorf("instanceName must not be null")
+	req := apiClient.DefaultAPI.UpdateInstance(ctx, model.ProjectId, model.InstanceId)
+
+	payload := secretsmanager.UpdateInstancePayload{
+		Name: *model.InstanceName,
+	}
+
+	if model.KmsKeyId != nil && model.KmsKeyringId != nil && model.KmsKeyVersion != nil && model.KmsServiceAccountEmail != nil {
+		payload.KmsKey = &secretsmanager.KmsKeyPayload{
+			KeyId:               *model.KmsKeyId,
+			KeyRingId:           *model.KmsKeyringId,
+			KeyVersion:          *model.KmsKeyVersion,
+			ServiceAccountEmail: *model.KmsServiceAccountEmail,
+		}
+	}
+	req = req.UpdateInstancePayload(payload)
+
+	return req, nil
 }
 
 func buildUpdateACLsRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiUpdateACLsRequest {

--- a/internal/cmd/secrets-manager/instance/update/update_test.go
+++ b/internal/cmd/secrets-manager/instance/update/update_test.go
@@ -358,6 +358,7 @@ func TestBuildUpdateInstanceRequest(t *testing.T) {
 		description     string
 		model           *inputModel
 		expectedRequest secretsmanager.ApiUpdateInstanceRequest
+		wantErr         bool
 	}{
 		{
 			description: "with name only",
@@ -382,11 +383,21 @@ func TestBuildUpdateInstanceRequest(t *testing.T) {
 			}),
 			expectedRequest: fixtureUpdateInstanceRequest(),
 		},
+		{
+			description: "nil instance name",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.InstanceName = nil
+			}),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request, _ := buildUpdateInstanceRequest(testCtx, tt.model, testClient)
+			request, err := buildUpdateInstanceRequest(testCtx, tt.model, testClient)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildUpdateInstanceRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/secrets-manager/instance/update/update_test.go
+++ b/internal/cmd/secrets-manager/instance/update/update_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -24,7 +24,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 
 var (
 	testProjectId  = uuid.NewString()
@@ -76,11 +78,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiUpdateACLsRequest)) secretsmanager.ApiUpdateACLsRequest {
-	request := testClient.UpdateACLs(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.UpdateACLs(testCtx, testProjectId, testInstanceId)
 	request = request.UpdateACLsPayload(secretsmanager.UpdateACLsPayload{
-		Cidrs: utils.Ptr([]secretsmanager.UpdateACLPayload{
-			{Cidr: utils.Ptr(testACL1)},
-		})})
+		Cidrs: []secretsmanager.UpdateACLPayload{
+			{Cidr: testACL1},
+		}})
 
 	for _, mod := range mods {
 		mod(&request)
@@ -89,14 +91,14 @@ func fixtureRequest(mods ...func(request *secretsmanager.ApiUpdateACLsRequest)) 
 }
 
 func fixtureUpdateInstanceRequest(mods ...func(request *secretsmanager.ApiUpdateInstanceRequest)) secretsmanager.ApiUpdateInstanceRequest {
-	request := testClient.UpdateInstance(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.UpdateInstance(testCtx, testProjectId, testInstanceId)
 	request = request.UpdateInstancePayload(secretsmanager.UpdateInstancePayload{
-		Name: utils.Ptr(testInstanceName),
+		Name: testInstanceName,
 		KmsKey: &secretsmanager.KmsKeyPayload{
-			KeyId:               utils.Ptr(testKmsKeyId),
-			KeyRingId:           utils.Ptr(testKmsKeyringId),
-			KeyVersion:          utils.Ptr(testKmsKeyVersion),
-			ServiceAccountEmail: utils.Ptr(testKmsServiceAccountEmail),
+			KeyId:               testKmsKeyId,
+			KeyRingId:           testKmsKeyringId,
+			KeyVersion:          testKmsKeyVersion,
+			ServiceAccountEmail: testKmsServiceAccountEmail,
 		},
 	})
 
@@ -329,10 +331,10 @@ func TestBuildUpdateACLsRequest(t *testing.T) {
 				*model.Acls = append(*model.Acls, testACL2)
 			}),
 			expectedRequest: fixtureRequest().UpdateACLsPayload(secretsmanager.UpdateACLsPayload{
-				Cidrs: utils.Ptr([]secretsmanager.UpdateACLPayload{
-					{Cidr: utils.Ptr(testACL1)},
-					{Cidr: utils.Ptr(testACL2)},
-				})}),
+				Cidrs: []secretsmanager.UpdateACLPayload{
+					{Cidr: testACL1},
+					{Cidr: testACL2},
+				}}),
 		},
 	}
 
@@ -363,9 +365,9 @@ func TestBuildUpdateInstanceRequest(t *testing.T) {
 				model.Acls = nil
 				model.InstanceName = utils.Ptr(testInstanceName)
 			}),
-			expectedRequest: testClient.UpdateInstance(testCtx, testProjectId, testInstanceId).
+			expectedRequest: testClient.DefaultAPI.UpdateInstance(testCtx, testProjectId, testInstanceId).
 				UpdateInstancePayload(secretsmanager.UpdateInstancePayload{
-					Name: utils.Ptr(testInstanceName),
+					Name: testInstanceName,
 				}),
 		},
 		{
@@ -384,7 +386,7 @@ func TestBuildUpdateInstanceRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			request := buildUpdateInstanceRequest(testCtx, tt.model, testClient)
+			request, _ := buildUpdateInstanceRequest(testCtx, tt.model, testClient)
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/client"
 	secretsManagerUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
 	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
@@ -30,8 +29,8 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 
 	InstanceId  string
-	Description *string
-	Write       *bool
+	Description string
+	Write       bool
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -110,8 +109,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
 		InstanceId:      flags.FlagToStringValue(p, cmd, instanceIdFlag),
-		Description:     utils.Ptr(flags.FlagToStringValue(p, cmd, descriptionFlag)),
-		Write:           utils.Ptr(flags.FlagToBoolValue(p, cmd, writeFlag)),
+		Description:     flags.FlagToStringValue(p, cmd, descriptionFlag),
+		Write:           flags.FlagToBoolValue(p, cmd, writeFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -120,17 +119,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiCreateUserRequest {
 	req := apiClient.DefaultAPI.CreateUser(ctx, model.ProjectId, model.InstanceId)
-	var description string
-	var write bool
-	if model.Description != nil {
-		description = *model.Description
-	}
-	if model.Write != nil {
-		write = *model.Write
-	}
 	req = req.CreateUserPayload(secretsmanager.CreateUserPayload{
-		Description: description,
-		Write:       write,
+		Description: model.Description,
+		Write:       model.Write,
 	})
 	return req
 }

--- a/internal/cmd/secrets-manager/user/create/create.go
+++ b/internal/cmd/secrets-manager/user/create/create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -65,7 +65,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -119,10 +119,18 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiCreateUserRequest {
-	req := apiClient.CreateUser(ctx, model.ProjectId, model.InstanceId)
+	req := apiClient.DefaultAPI.CreateUser(ctx, model.ProjectId, model.InstanceId)
+	var description string
+	var write bool
+	if model.Description != nil {
+		description = *model.Description
+	}
+	if model.Write != nil {
+		write = *model.Write
+	}
 	req = req.CreateUserPayload(secretsmanager.CreateUserPayload{
-		Description: model.Description,
-		Write:       model.Write,
+		Description: description,
+		Write:       write,
 	})
 	return req
 }
@@ -133,11 +141,11 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *se
 	}
 
 	return p.OutputResult(outputFormat, user, func() error {
-		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
-		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
-		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
-		p.Outputf("Description: %s\n", utils.PtrString(user.Description))
-		p.Outputf("Write Access: %s\n", utils.PtrString(user.Write))
+		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, user.Id)
+		p.Outputf("Username: %s\n", user.Username)
+		p.Outputf("Password: %s\n", user.Password)
+		p.Outputf("Description: %s\n", user.Description)
+		p.Outputf("Write Access: %t\n", user.Write)
 
 		return nil
 	})

--- a/internal/cmd/secrets-manager/user/create/create_test.go
+++ b/internal/cmd/secrets-manager/user/create/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -54,10 +56,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiCreateUserRequest)) secretsmanager.ApiCreateUserRequest {
-	request := testClient.CreateUser(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.CreateUser(testCtx, testProjectId, testInstanceId)
 	request = request.CreateUserPayload(secretsmanager.CreateUserPayload{
-		Description: utils.Ptr("sample description"),
-		Write:       utils.Ptr(false),
+		Description: "sample description",
+		Write:       false,
 	})
 
 	for _, mod := range mods {

--- a/internal/cmd/secrets-manager/user/create/create_test.go
+++ b/internal/cmd/secrets-manager/user/create/create_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -46,8 +45,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		InstanceId:  testInstanceId,
-		Description: utils.Ptr("sample description"),
-		Write:       utils.Ptr(false),
+		Description: "sample description",
+		Write:       false,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -90,7 +89,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Description = utils.Ptr("")
+				model.Description = ""
 			}),
 		},
 		{
@@ -148,7 +147,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Write = utils.Ptr(true)
+				model.Write = true
 			}),
 		},
 	}

--- a/internal/cmd/secrets-manager/user/delete/delete.go
+++ b/internal/cmd/secrets-manager/user/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -60,13 +60,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := secretsManagerUtils.GetUserLabel(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId)
+			userLabel, err := secretsManagerUtils.GetUserLabel(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user label: %v", err)
 				userLabel = fmt.Sprintf("%q", model.UserId)
@@ -119,6 +119,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiDeleteUserRequest {
-	req := apiClient.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
+	req := apiClient.DefaultAPI.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
 	return req
 }

--- a/internal/cmd/secrets-manager/user/delete/delete_test.go
+++ b/internal/cmd/secrets-manager/user/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -18,7 +18,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -60,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiDeleteUserRequest)) secretsmanager.ApiDeleteUserRequest {
-	request := testClient.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId)
+	request := testClient.DefaultAPI.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/secrets-manager/user/describe/describe.go
+++ b/internal/cmd/secrets-manager/user/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -67,7 +67,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("get Secrets Manager user: %w", err)
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, *resp)
+			return outputResult(params.Printer, model.OutputFormat, resp)
 		},
 	}
 
@@ -101,26 +101,26 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiGetUserRequest {
-	req := apiClient.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
+	req := apiClient.DefaultAPI.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, user secretsmanager.User) error {
+func outputResult(p *print.Printer, outputFormat string, user *secretsmanager.User) error {
 	return p.OutputResult(outputFormat, user, func() error {
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(user.Id))
+		table.AddRow("ID", user.Id)
 		table.AddSeparator()
-		table.AddRow("USERNAME", utils.PtrString(user.Username))
+		table.AddRow("USERNAME", user.Username)
 		table.AddSeparator()
-		if user.Description != nil && *user.Description != "" {
-			table.AddRow("DESCRIPTION", *user.Description)
+		if user.Description != "" {
+			table.AddRow("DESCRIPTION", user.Description)
 			table.AddSeparator()
 		}
-		if user.Password != nil && *user.Password != "" {
-			table.AddRow("PASSWORD", *user.Password)
+		if user.Password != "" {
+			table.AddRow("PASSWORD", user.Password)
 			table.AddSeparator()
 		}
-		table.AddRow("WRITE ACCESS", utils.PtrString(user.Write))
+		table.AddRow("WRITE ACCESS", user.Write)
 
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/secrets-manager/user/describe/describe_test.go
+++ b/internal/cmd/secrets-manager/user/describe/describe_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -19,7 +20,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -61,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiGetUserRequest)) secretsmanager.ApiGetUserRequest {
-	request := testClient.GetUser(testCtx, testProjectId, testInstanceId, testUserId)
+	request := testClient.DefaultAPI.GetUser(testCtx, testProjectId, testInstanceId, testUserId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -224,7 +227,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.user); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, utils.Ptr(tt.args.user)); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -79,8 +79,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Truncate output
-			if model.Limit != nil && len((resp.Users)) > int(*model.Limit) {
-				(resp.Users) = resp.Users[:*model.Limit]
+			if model.Limit != nil && len(resp.Users) > int(*model.Limit) {
+				resp.Users = resp.Users[:*model.Limit]
 			}
 
 			return outputResult(params.Printer, model.OutputFormat, (resp.Users))

--- a/internal/cmd/secrets-manager/user/list/list.go
+++ b/internal/cmd/secrets-manager/user/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/client"
 	secretsManagerUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/secrets-manager/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -69,8 +68,8 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get Secrets Manager users: %w", err)
 			}
-			if resp.Users == nil || len(*resp.Users) == 0 {
-				instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId)
+			if len(resp.Users) == 0 {
+				instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId)
 				if err != nil {
 					params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 					instanceLabel = *model.InstanceId
@@ -78,14 +77,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				params.Printer.Info("No users found for instance %q\n", instanceLabel)
 				return nil
 			}
-			users := *resp.Users
 
 			// Truncate output
-			if model.Limit != nil && len(users) > int(*model.Limit) {
-				users = users[:*model.Limit]
+			if model.Limit != nil && len((resp.Users)) > int(*model.Limit) {
+				(resp.Users) = resp.Users[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, users)
+			return outputResult(params.Printer, model.OutputFormat, (resp.Users))
 		},
 	}
 
@@ -126,7 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) secretsmanager.ApiListUsersRequest {
-	req := apiClient.ListUsers(ctx, model.ProjectId, *model.InstanceId)
+	req := apiClient.DefaultAPI.ListUsers(ctx, model.ProjectId, *model.InstanceId)
 	return req
 }
 
@@ -137,10 +135,10 @@ func outputResult(p *print.Printer, outputFormat string, users []secretsmanager.
 		for i := range users {
 			user := users[i]
 			table.AddRow(
-				utils.PtrString(user.Id),
-				utils.PtrString(user.Username),
-				utils.PtrString(user.Description),
-				utils.PtrString(user.Write),
+				user.Id,
+				user.Username,
+				user.Description,
+				user.Write,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/secrets-manager/user/list/list_test.go
+++ b/internal/cmd/secrets-manager/user/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -52,7 +54,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiListUsersRequest)) secretsmanager.ApiListUsersRequest {
-	request := testClient.ListUsers(testCtx, testProjectId, testInstanceId)
+	request := testClient.DefaultAPI.ListUsers(testCtx, testProjectId, testInstanceId)
 	for _, mod := range mods {
 		mod(&request)
 	}

--- a/internal/cmd/secrets-manager/user/update/update.go
+++ b/internal/cmd/secrets-manager/user/update/update.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 const (
@@ -64,13 +64,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId)
+			instanceLabel, err := secretsManagerUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := secretsManagerUtils.GetUserLabel(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId)
+			userLabel, err := secretsManagerUtils.GetUserLabel(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user label: %v", err)
 				userLabel = fmt.Sprintf("%q", model.UserId)
@@ -141,7 +141,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *secretsmanager.APIClient) (secretsmanager.ApiUpdateUserRequest, error) {
-	req := apiClient.UpdateUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
+	req := apiClient.DefaultAPI.UpdateUser(ctx, model.ProjectId, model.InstanceId, model.UserId)
 
 	var write bool
 

--- a/internal/cmd/secrets-manager/user/update/update_test.go
+++ b/internal/cmd/secrets-manager/user/update/update_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -19,7 +19,9 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &secretsmanager.APIClient{}
+var testClient = &secretsmanager.APIClient{
+	DefaultAPI: secretsmanager.DefaultAPIServiceMock{},
+}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -64,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *secretsmanager.ApiUpdateUserRequest)) secretsmanager.ApiUpdateUserRequest {
-	request := testClient.UpdateUser(testCtx, testProjectId, testInstanceId, testUserId)
+	request := testClient.DefaultAPI.UpdateUser(testCtx, testProjectId, testInstanceId, testUserId)
 	request = request.UpdateUserPayload(secretsmanager.UpdateUserPayload{
 		Write: utils.Ptr(true),
 	})

--- a/internal/pkg/services/secrets-manager/client/client.go
+++ b/internal/pkg/services/secrets-manager/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*secretsmanager.APIClient, error) {

--- a/internal/pkg/services/secrets-manager/utils/utils.go
+++ b/internal/pkg/services/secrets-manager/utils/utils.go
@@ -4,38 +4,38 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 )
 
 type SecretsManagerClient interface {
-	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*secretsmanager.Instance, error)
-	GetUserExecute(ctx context.Context, projectId string, instanceId string, userId string) (*secretsmanager.User, error)
+	GetInstance(ctx context.Context, projectId, instanceId string) secretsmanager.ApiGetInstanceRequest
+	GetUser(ctx context.Context, projectId string, instanceId string, userId string) secretsmanager.ApiGetUserRequest
 }
 
 func GetInstanceName(ctx context.Context, apiClient SecretsManagerClient, projectId, instanceId string) (string, error) {
-	resp, err := apiClient.GetInstanceExecute(ctx, projectId, instanceId)
+	resp, err := apiClient.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get Secrets Manager instance: %w", err)
 	}
-	return *resp.Name, nil
+	return resp.Name, nil
 }
 
 func GetUserLabel(ctx context.Context, apiClient SecretsManagerClient, projectId, instanceId, userId string) (string, error) {
-	resp, err := apiClient.GetUserExecute(ctx, projectId, instanceId, userId)
+	resp, err := apiClient.GetUser(ctx, projectId, instanceId, userId).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get Secrets Manager user: %w", err)
 	}
 
-	if resp.Username == nil || *resp.Username == "" {
+	if resp.Username == "" {
 		// Should never happen, username is auto-generated
 		return "", fmt.Errorf("username is empty")
 	}
 
 	var userLabel string
-	if resp.Description == nil || *resp.Description == "" {
-		userLabel = fmt.Sprintf("%q", *resp.Username)
+	if resp.Description == "" {
+		userLabel = fmt.Sprintf("%q", resp.Username)
 	} else {
-		userLabel = fmt.Sprintf("%q (%s)", *resp.Username, *resp.Description)
+		userLabel = fmt.Sprintf("%q (%s)", resp.Username, resp.Description)
 	}
 	return userLabel, nil
 }

--- a/internal/pkg/services/secrets-manager/utils/utils_test.go
+++ b/internal/pkg/services/secrets-manager/utils/utils_test.go
@@ -74,12 +74,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			mockOptions := &apiClientMockOptions{
+			mockOptions := apiClientMockOptions{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), newAPIClient(*mockOptions).DefaultAPI, testProjectId, testInstanceId)
+			output, err := GetInstanceName(context.Background(), newAPIClient(mockOptions).DefaultAPI, testProjectId, testInstanceId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")

--- a/internal/pkg/services/secrets-manager/utils/utils_test.go
+++ b/internal/pkg/services/secrets-manager/utils/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
@@ -23,25 +23,30 @@ const (
 	testDescription  = "sample description"
 )
 
-type secretsManagerClientMocked struct {
+type apiClientMockOptions struct {
 	getInstanceFails bool
 	getInstanceResp  *secretsmanager.Instance
 	getUserFails     bool
 	getUserResp      *secretsmanager.User
 }
 
-func (s *secretsManagerClientMocked) GetInstanceExecute(_ context.Context, _, _ string) (*secretsmanager.Instance, error) {
-	if s.getInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
+func newAPIClient(options apiClientMockOptions) secretsmanager.APIClient {
+	return secretsmanager.APIClient{
+		DefaultAPI: secretsmanager.DefaultAPIServiceMock{
+			GetUserExecuteMock: utils.Ptr(func(_ secretsmanager.ApiGetUserRequest) (*secretsmanager.User, error) {
+				if options.getUserFails {
+					return nil, fmt.Errorf("could not get user")
+				}
+				return options.getUserResp, nil
+			}),
+			GetInstanceExecuteMock: utils.Ptr(func(_ secretsmanager.ApiGetInstanceRequest) (*secretsmanager.Instance, error) {
+				if options.getInstanceFails {
+					return nil, fmt.Errorf("could not get instance")
+				}
+				return options.getInstanceResp, nil
+			}),
+		},
 	}
-	return s.getInstanceResp, nil
-}
-
-func (s *secretsManagerClientMocked) GetUserExecute(_ context.Context, _, _, _ string) (*secretsmanager.User, error) {
-	if s.getUserFails {
-		return nil, fmt.Errorf("could not get user")
-	}
-	return s.getUserResp, nil
 }
 
 func TestGetInstanceName(t *testing.T) {
@@ -55,7 +60,7 @@ func TestGetInstanceName(t *testing.T) {
 		{
 			description: "base",
 			getInstanceResp: &secretsmanager.Instance{
-				Name: utils.Ptr(testInstanceName),
+				Name: testInstanceName,
 			},
 			isValid:        true,
 			expectedOutput: testInstanceName,
@@ -69,12 +74,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &secretsManagerClientMocked{
+			mockOptions := &apiClientMockOptions{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), client, testProjectId, testInstanceId)
+			output, err := GetInstanceName(context.Background(), newAPIClient(*mockOptions).DefaultAPI, testProjectId, testInstanceId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -103,8 +108,8 @@ func TestGetUserDetails(t *testing.T) {
 		{
 			description: "base",
 			GetUserResp: &secretsmanager.User{
-				Username:    utils.Ptr(testUserName),
-				Description: utils.Ptr(testDescription),
+				Username:    testUserName,
+				Description: testDescription,
 			},
 			isValid:        true,
 			expectedOutput: fmt.Sprintf("%q (%s)", testUserName, testDescription),
@@ -112,7 +117,7 @@ func TestGetUserDetails(t *testing.T) {
 		{
 			description: "user has no description",
 			GetUserResp: &secretsmanager.User{
-				Username: utils.Ptr(testUserName),
+				Username: testUserName,
 			},
 			isValid:        true,
 			expectedOutput: fmt.Sprintf("%q", testUserName),
@@ -120,8 +125,8 @@ func TestGetUserDetails(t *testing.T) {
 		{
 			description: "user has empty description",
 			GetUserResp: &secretsmanager.User{
-				Username:    utils.Ptr(testUserName),
-				Description: utils.Ptr(""),
+				Username:    testUserName,
+				Description: "",
 			},
 			isValid:        true,
 			expectedOutput: fmt.Sprintf("%q", testUserName),
@@ -129,14 +134,14 @@ func TestGetUserDetails(t *testing.T) {
 		{
 			description: "user has empty username",
 			GetUserResp: &secretsmanager.User{
-				Username: utils.Ptr(""),
+				Username: "",
 			},
 			isValid: false,
 		},
 		{
 			description: "user has no username",
 			GetUserResp: &secretsmanager.User{
-				Username: nil,
+				Username: "",
 			},
 			isValid: false,
 		},
@@ -149,12 +154,12 @@ func TestGetUserDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &secretsManagerClientMocked{
+			options := &apiClientMockOptions{
 				getUserFails: tt.getUserFails,
 				getUserResp:  tt.GetUserResp,
 			}
 
-			userLabel, err := GetUserLabel(context.Background(), client, testProjectId, testInstanceId, testUserId)
+			userLabel, err := GetUserLabel(context.Background(), newAPIClient(*options).DefaultAPI, testProjectId, testInstanceId, testUserId)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")


### PR DESCRIPTION
## Description
Updates the Secrets-Manager SDK
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-377

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
