### PR TITLE
fix(project): validate billingReference for standalone public projects

### DIFF
--- a/internal/cmd/affinity-groups/create/create_test.go
+++ b/internal/cmd/affinity-groups/create/create_test.go
@@ -121,6 +121,26 @@ func TestParseInput(t *testing.T) {
 				},
 			),
 		},
+		{
+			description: "fails public project without network area and without billing reference",
+			flagValues: fixtureFlagValues(
+				func(flagValues map[string]string) {
+					flagValues["label"] = "scope=PUBLIC"
+					delete(flagValues, "network-area-id")
+				},
+			),
+			isValid: false,
+		},
+		{
+			description: "fails public project with empty billing reference",
+			flagValues: fixtureFlagValues(
+				func(flagValues map[string]string) {
+					flagValues["label"] = "scope=PUBLIC,billingReference="
+					delete(flagValues, "network-area-id")
+				},
+			),
+			isValid: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -112,6 +112,8 @@ func configureFlags(cmd *cobra.Command) {
 func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 
+	networkAreaId := flags.FlagToStringPointer(p, cmd, networkAreaIdFlag)
+
 	labels := flags.FlagToStringToStringPointer(p, cmd, labelFlag)
 	if labels != nil {
 		labelKeyRegex := regexp.MustCompile(labelKeyRegex)
@@ -131,6 +133,18 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 				}
 			}
 		}
+
+		if scope, hasScope := (*labels)["scope"]; hasScope && scope == "PUBLIC" {
+			_, hasBilling := (*labels)["billingReference"]
+
+			if networkAreaId == nil && !hasBilling {
+				return nil, &errors.FlagValidationError{
+					Flag:    labelFlag,
+					Details: "creating a standalone public project (without a network area) requires a 'billingReference' label (e.g., --label billingReference=<value>)",
+				}
+			}
+		}
+
 	}
 
 	model := inputModel{

--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -135,9 +135,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		}
 
 		if scope, hasScope := (*labels)["scope"]; hasScope && scope == "PUBLIC" {
-			_, hasBilling := (*labels)["billingReference"]
+			billingReference, hasBilling := (*labels)["billingReference"]
 
-			if networkAreaId == nil && !hasBilling {
+			if networkAreaId == nil && (!hasBilling || billingReference == "") {
 				return nil, &errors.FlagValidationError{
 					Flag:    labelFlag,
 					Details: "creating a standalone public project (without a network area) requires a 'billingReference' label (e.g., --label billingReference=<value>)",


### PR DESCRIPTION
## Description

relates to [#1452](https://github.com/stackitcloud/stackit-cli/issues/1452)

Before the fix:
```
 ~/Documents/dev/stackit-cli  main ?1                                                                                                                                          3s

> ./stackit-test project create --parent-id 12345 --name "Test public project" --label scope=PUBLIC

Are you sure you want to create a project under the parent with ID "12345"? [y/N] y
Error: create project: 404 Not Found, status code 404, Body: {"timeStamp":"2026-07-05T19:52:13.783789128Z","path":"/resource-management/v2/projects","status":404,"error":"Not Found","message":"Container [12345] was not found."}
```

After the fix:
```
 ~/Documents/dev/stackit-cli  fix-project-public-validation ?1                                                                                                                

> ./stackit-test project create --parent-id 12345 --name "Test public project" --label scope=PUBLIC

Error: the provided flag --label is invalid: creating a standalone public project (without a network area) requires a 'billingReference' label (e.g., --label billingReference=<value>)

> 
```

### Note on Testing
Unfortunately because I only have a French phone number, I was unable to complete the project creation process to access the STACKIT Portal to check the payload validation conditions.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
