### PR TITLE
feat(ske): Check service enablement only in error case

### DIFF
--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -95,21 +95,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Check if the project is enabled before trying to create
-			enabled, err := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
-			if err != nil {
-				return err
-			}
-			if !enabled {
-				return &errors.ServiceDisabledError{
-					Service: "ske",
-				}
-			}
-
 			// Check if cluster exists
 			exists, err := skeUtils.ClusterExists(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.ClusterName)
 			if err != nil {
-				return err
+				// Check if the project is enabled
+				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
+				if enabledErr != nil {
+					return fmt.Errorf("check if project is enabled failed: %w", enabledErr)
+				}
+				if !enabled {
+					return &errors.ServiceDisabledError{
+						Service: "ske",
+					}
+				}
+				return fmt.Errorf("cluster exists check failed: %w", err)
 			}
 			if exists {
 				return fmt.Errorf("cluster with name %s already exists", model.ClusterName)

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -68,19 +68,20 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			// Check if SKE is enabled for this project
-			enabled, err := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
-			if err != nil {
-				return err
-			}
-			if !enabled {
-				return fmt.Errorf("SKE isn't enabled for this project, please run 'stackit ske enable'")
-			}
-
 			// Call API
 			req := buildRequest(ctx, model, apiClient)
 			resp, err := req.Execute()
 			if err != nil {
+				// Check if SKE is enabled for this project
+				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
+				if enabledErr != nil {
+					return fmt.Errorf("check if project is enabled failed: %w", enabledErr)
+				}
+				if !enabled {
+					return &errors.ServiceDisabledError{
+						Service: "ske",
+					}
+				}
 				return fmt.Errorf("get SKE clusters: %w", err)
 			}
 			clusters := resp.Items


### PR DESCRIPTION
STACKITCLI-287

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->



## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
