### PR TITLE
feat(mongodbflex): migrate to v2 API

### DIFF
--- a/docs/stackit_mongodbflex_instance_create.md
+++ b/docs/stackit_mongodbflex_instance_create.md
@@ -28,11 +28,11 @@ stackit mongodbflex instance create [flags]
 ```
       --acl strings              The access control list (ACL). Must contain at least one valid subnet, for instance '0.0.0.0/0' for open access (discouraged), '1.2.3.0/24 for a public IP range of an organization, '1.2.3.4/32' for a single IP range, etc. (default [])
       --backup-schedule string   Backup schedule (default "0 0/6 * * *")
-      --cpu int                  Number of CPUs
+      --cpu int32                Number of CPUs
       --flavor-id string         ID of the flavor
   -h, --help                     Help for "stackit mongodbflex instance create"
   -n, --name string              Instance name
-      --ram int                  Amount of RAM (in GB)
+      --ram int32                Amount of RAM (in GB)
       --storage-class string     Storage class (default "premium-perf2-mongodb")
       --storage-size int         Storage size (in GB) (default 10)
       --type string              Instance type, (one of: [Replica, Sharded, Single]) (default "Replica")

--- a/docs/stackit_mongodbflex_instance_update.md
+++ b/docs/stackit_mongodbflex_instance_update.md
@@ -25,11 +25,11 @@ stackit mongodbflex instance update INSTANCE_ID [flags]
 ```
       --acl strings              Lists of IP networks in CIDR notation which are allowed to access this instance (default [])
       --backup-schedule string   Backup schedule
-      --cpu int                  Number of CPUs
+      --cpu int32                Number of CPUs
       --flavor-id string         ID of the flavor
   -h, --help                     Help for "stackit mongodbflex instance update"
   -n, --name string              Instance name
-      --ram int                  Amount of RAM (in GB)
+      --ram int32                Amount of RAM (in GB)
       --storage-class string     Storage class
       --storage-size int         Storage size (in GB)
       --type string              Instance type, (one of: [Replica, Sharded, Single])

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/intake v0.7.1
 	github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2
-	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8
+	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.5
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -618,12 +618,12 @@ github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2 h1:vr4atxFRT+EL+DqON
 github.com/stackitcloud/stackit-sdk-go/services/logs v0.5.2/go.mod h1:CAPsiTX7osAImfrG5RnIjaJ/Iz3QpoBKuH2fS346wuQ=
 github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0 h1:LFIH1wAp633ZAJw/7H3F4nq1DZe0Qu3rlDeXhobZEZA=
 github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.30.0/go.mod h1:joa89Y1dyn0j22FstRcIKfW2ada3FDxNfttxSvq27uY=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8 h1:S7t4wcT6SN8ZzdoY8d6VbF903zFpGjzqrU0FN27rJPg=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.5.8/go.mod h1:CdrhFUsBO7/iJleCc2yQjDChIbG6YaxKNBQRNCjgcF4=
+github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0 h1:SVd3WMmLAE0Jxk2SaRuM85DTOOXHycyMpZGx9vzqNkI=
+github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0Kn18d8hTOrVAMKcQrXiab+Cuj0cTnAYHmj0=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0 h1:KhuWPXr1hl8BFLGLSi6wjxh5o6OQXH9amfquMhYQROU=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.17.0 h1:LGwCvvST0fwUgZ6bOxYIfu45qqTgv421ZS07UhKjZL8=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.17.0/go.mod h1:9KdrXC5JS30Ay3mR0adb3vNdhca+qxiy/cPF5P4wehQ=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6 h1:oTVx1+O177Ojn8OvXIOUbRSwtx7L59jhxDPrZEQFOfQ=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6/go.mod h1:6ZBeCCY6qG8w1oK7osf61Egyv3mp7Ahv6GDGxiarDGo=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.5 h1:H67e3KnHQx954yI8fuQmxXwRf/myqAdLg2KvxImp00g=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0 h1:SVd3WMmLA
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0Kn18d8hTOrVAMKcQrXiab+Cuj0cTnAYHmj0=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.17.0 h1:LGwCvvST0fwUgZ6bOxYIfu45qqTgv421ZS07UhKjZL8=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.17.0/go.mod h1:9KdrXC5JS30Ay3mR0adb3vNdhca+qxiy/cPF5P4wehQ=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0 h1:KhuWPXr1hl8BFLGLSi6wjxh5o6OQXH9amfquMhYQROU=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6 h1:oTVx1+O177Ojn8OvXIOUbRSwtx7L59jhxDPrZEQFOfQ=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.24.6/go.mod h1:6ZBeCCY6qG8w1oK7osf61Egyv3mp7Ahv6GDGxiarDGo=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.3.5 h1:H67e3KnHQx954yI8fuQmxXwRf/myqAdLg2KvxImp00g=

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -119,10 +119,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup *mongodbflex.Backup) error {
-	if backup == nil {
-		return fmt.Errorf("API response is nil")
-	}
 	return p.OutputResult(outputFormat, backup, func() error {
+		if backup == nil {
+			return fmt.Errorf("API response is nil")
+		}
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))
 		table.AddSeparator()

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -119,9 +119,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup *mongodbflex.Backup) error {
-	// allows passing empty backups but avoids having to pass large backup by value
 	if backup == nil {
-		backup = &mongodbflex.Backup{}
+		return fmt.Errorf("API response is nil")
 	}
 	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()

--- a/internal/cmd/mongodbflex/backup/describe/describe.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -61,7 +61,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongoUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongoUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -75,13 +75,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("describe backup for MongoDB Flex instance: %w", err)
 			}
 
-			restoreJobs, err := apiClient.ListRestoreJobs(ctx, model.ProjectId, model.InstanceId, model.Region).Execute()
+			restoreJobs, err := apiClient.DefaultAPI.ListRestoreJobs(ctx, model.ProjectId, model.InstanceId, model.Region).Execute()
 			if err != nil {
 				return fmt.Errorf("get restore jobs for MongoDB Flex instance %q: %w", instanceLabel, err)
 			}
 
 			restoreJobState := mongoUtils.GetRestoreStatus(model.BackupId, restoreJobs)
-			return outputResult(params.Printer, model.OutputFormat, restoreJobState, *resp.Item)
+			return outputResult(params.Printer, model.OutputFormat, restoreJobState, resp.Item)
 		},
 	}
 	configureFlags(cmd)
@@ -114,11 +114,15 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiGetBackupRequest {
-	req := apiClient.GetBackup(ctx, model.ProjectId, model.InstanceId, model.BackupId, model.Region)
+	req := apiClient.DefaultAPI.GetBackup(ctx, model.ProjectId, model.InstanceId, model.BackupId, model.Region)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup mongodbflex.Backup) error {
+func outputResult(p *print.Printer, outputFormat, restoreStatus string, backup *mongodbflex.Backup) error {
+	// allows passing empty backups but avoids having to pass large backup by value
+	if backup == nil {
+		backup = &mongodbflex.Backup{}
+	}
 	return p.OutputResult(outputFormat, backup, func() error {
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(backup.Id))

--- a/internal/cmd/mongodbflex/backup/describe/describe_test.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe_test.go
@@ -210,7 +210,7 @@ func TestOutputResult(t *testing.T) {
 		{
 			name:    "empty",
 			args:    args{},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "set backup",

--- a/internal/cmd/mongodbflex/backup/describe/describe_test.go
+++ b/internal/cmd/mongodbflex/backup/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiGetBackupRequest)) mongodbflex.ApiGetBackupRequest {
-	request := testClient.GetBackup(testCtx, testProjectId, testInstanceId, testBackupId, testRegion)
+	request := testClient.DefaultAPI.GetBackup(testCtx, testProjectId, testInstanceId, testBackupId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -187,7 +187,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -199,7 +199,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat  string
-		backup        mongodbflex.Backup
+		backup        *mongodbflex.Backup
 		restoreStatus string
 	}
 	tests := []struct {
@@ -215,7 +215,7 @@ func TestOutputResult(t *testing.T) {
 		{
 			name: "set backup",
 			args: args{
-				backup: mongodbflex.Backup{},
+				backup: &mongodbflex.Backup{},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/mongodbflex/backup/list/list.go
+++ b/internal/cmd/mongodbflex/backup/list/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -63,7 +63,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = *model.InstanceId
@@ -75,9 +75,9 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get backups for MongoDB Flex instance %q: %w", instanceLabel, err)
 			}
-			backups := utils.GetSliceFromPointer(resp.Items)
+			backups := resp.Items
 
-			restoreJobs, err := apiClient.ListRestoreJobs(ctx, model.ProjectId, *model.InstanceId, model.Region).Execute()
+			restoreJobs, err := apiClient.DefaultAPI.ListRestoreJobs(ctx, model.ProjectId, *model.InstanceId, model.Region).Execute()
 			if err != nil {
 				return fmt.Errorf("get restore jobs for MongoDB Flex instance %q: %w", instanceLabel, err)
 			}
@@ -128,7 +128,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiListBackupsRequest {
-	req := apiClient.ListBackups(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.ListBackups(ctx, model.ProjectId, *model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/mongodbflex/backup/list/list_test.go
+++ b/internal/cmd/mongodbflex/backup/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiListBackupsRequest)) mongodbflex.ApiListBackupsRequest {
-	request := testClient.ListBackups(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.ListBackups(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -166,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -63,7 +63,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = *model.InstanceId
@@ -75,11 +75,11 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get restore jobs for MongoDB Flex instance %q: %w", instanceLabel, err)
 			}
-			if resp.Items == nil || len(*resp.Items) == 0 {
+			if len(resp.Items) == 0 {
 				cmd.Printf("No restore jobs found for instance %q\n", instanceLabel)
 				return nil
 			}
-			restoreJobs := *resp.Items
+			restoreJobs := resp.Items
 
 			// Truncate output
 			if model.Limit != nil && len(restoreJobs) > int(*model.Limit) {
@@ -127,7 +127,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiListRestoreJobsRequest {
-	req := apiClient.ListRestoreJobs(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.ListRestoreJobs(ctx, model.ProjectId, *model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs.go
@@ -75,18 +75,15 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get restore jobs for MongoDB Flex instance %q: %w", instanceLabel, err)
 			}
-			if len(resp.Items) == 0 {
-				cmd.Printf("No restore jobs found for instance %q\n", instanceLabel)
-				return nil
-			}
-			restoreJobs := resp.Items
+
+			restoreJobs := resp.GetItems()
 
 			// Truncate output
 			if model.Limit != nil && len(restoreJobs) > int(*model.Limit) {
 				restoreJobs = restoreJobs[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, restoreJobs)
+			return outputResult(params.Printer, model.OutputFormat, instanceLabel, restoreJobs)
 		},
 	}
 
@@ -131,8 +128,12 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, restoreJobs []mongodbflex.RestoreInstanceStatus) error {
+func outputResult(p *print.Printer, outputFormat, instanceLabel string, restoreJobs []mongodbflex.RestoreInstanceStatus) error {
 	return p.OutputResult(outputFormat, restoreJobs, func() error {
+		if len(restoreJobs) == 0 {
+			p.Outputf("No restore jobs found for instance %q\n", instanceLabel)
+			return nil
+		}
 		table := tables.NewTable()
 		table.SetHeader("ID", "BACKUP ID", "BACKUP INSTANCE ID", "DATE", "STATUS")
 		for i := range restoreJobs {

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs_test.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs_test.go
@@ -177,8 +177,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		restoreJobs  []mongodbflex.RestoreInstanceStatus
+		outputFormat  string
+		instanceLabel string
+		restoreJobs   []mongodbflex.RestoreInstanceStatus
 	}
 	tests := []struct {
 		name    string
@@ -208,7 +209,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.restoreJobs); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.instanceLabel, tt.args.restoreJobs); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs_test.go
+++ b/internal/cmd/mongodbflex/backup/restore-jobs/restore_jobs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiListRestoreJobsRequest)) mongodbflex.ApiListRestoreJobsRequest {
-	request := testClient.ListRestoreJobs(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.ListRestoreJobs(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -166,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/backup/restore/restore.go
+++ b/internal/cmd/mongodbflex/backup/restore/restore.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	wait "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api/wait"
 )
 
 const (
@@ -71,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.ProjectId
@@ -100,7 +100,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 				if !model.Async {
 					err := spinner.Run(params.Printer, "Restoring instance", func() error {
-						_, err = wait.RestoreInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId, model.BackupId, model.Region).WaitWithContext(ctx)
+						_, err = wait.RestoreInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.BackupId, model.Region).WaitWithContext(ctx)
 						return err
 					})
 					if err != nil {
@@ -125,7 +125,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Cloning instance", func() error {
-					_, err = wait.CloneInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.CloneInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -183,19 +183,19 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRestoreRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiRestoreInstanceRequest {
-	req := apiClient.RestoreInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.RestoreInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	req = req.RestoreInstancePayload(mongodbflex.RestoreInstancePayload{
-		BackupId:   &model.BackupId,
-		InstanceId: &model.BackupInstanceId,
+		BackupId:   model.BackupId,
+		InstanceId: model.BackupInstanceId,
 	})
 	return req
 }
 
 func buildCloneRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiCloneInstanceRequest {
-	req := apiClient.CloneInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.CloneInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	req = req.CloneInstancePayload(mongodbflex.CloneInstancePayload{
 		Timestamp:  &model.Timestamp,
-		InstanceId: &model.BackupInstanceId,
+		InstanceId: model.BackupInstanceId,
 	})
 	return req
 }

--- a/internal/cmd/mongodbflex/backup/restore/restore_test.go
+++ b/internal/cmd/mongodbflex/backup/restore/restore_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 type testCtxKey struct{}
@@ -23,7 +23,7 @@ const (
 )
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
@@ -61,10 +61,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRestoreRequest(mods ...func(request mongodbflex.ApiRestoreInstanceRequest)) mongodbflex.ApiRestoreInstanceRequest {
-	request := testClient.RestoreInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.RestoreInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.RestoreInstancePayload(mongodbflex.RestoreInstancePayload{
-		BackupId:   utils.Ptr(testBackupId),
-		InstanceId: utils.Ptr(testBackupInstanceId),
+		BackupId:   testBackupId,
+		InstanceId: testBackupInstanceId,
 	})
 	for _, mod := range mods {
 		mod(request)
@@ -73,10 +73,10 @@ func fixtureRestoreRequest(mods ...func(request mongodbflex.ApiRestoreInstanceRe
 }
 
 func fixtureCloneRequest(mods ...func(request mongodbflex.ApiCloneInstanceRequest)) mongodbflex.ApiCloneInstanceRequest {
-	request := testClient.CloneInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.CloneInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.CloneInstancePayload(mongodbflex.CloneInstancePayload{
 		Timestamp:  utils.Ptr(testTimestamp),
-		InstanceId: utils.Ptr(testBackupInstanceId),
+		InstanceId: testBackupInstanceId,
 	})
 	for _, mod := range mods {
 		mod(request)
@@ -195,7 +195,7 @@ func TestBuildRestoreRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx))
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}))
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
 			}
@@ -225,7 +225,7 @@ func TestBuildCloneRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx))
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}))
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
 			}

--- a/internal/cmd/mongodbflex/backup/schedule/schedule.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -92,7 +92,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/mongodbflex/backup/schedule/schedule_test.go
+++ b/internal/cmd/mongodbflex/backup/schedule/schedule_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -53,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiGetInstanceRequest)) mongodbflex.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -149,7 +149,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
+++ b/internal/cmd/mongodbflex/backup/update-schedule/update_schedule.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -31,11 +31,11 @@ const (
 
 	// Default values for the backup schedule options
 	defaultBackupSchedule                       = "0 0/6 * * *"
-	defaultSnapshotRetentionDays          int64 = 3
-	defaultDailySnapshotRetentionDays     int64 = 0
-	defaultWeeklySnapshotRetentionWeeks   int64 = 3
-	defaultMonthlySnapshotRetentionMonths int64 = 1
-	defaultPointInTimeWindowHours         int64 = 30
+	defaultSnapshotRetentionDays          int32 = 3
+	defaultDailySnapshotRetentionDays     int32 = 0
+	defaultWeeklySnapshotRetentionWeeks   int32 = 3
+	defaultMonthlySnapshotRetentionMonths int32 = 1
+	defaultPointInTimeWindowHours         int32 = 30
 )
 
 type inputModel struct {
@@ -43,10 +43,10 @@ type inputModel struct {
 
 	InstanceId                     *string
 	BackupSchedule                 *string
-	SnapshotRetentionDays          *int64
-	DailySnaphotRetentionDays      *int64
-	WeeklySnapshotRetentionWeeks   *int64
-	MonthlySnapshotRetentionMonths *int64
+	SnapshotRetentionDays          *int32
+	DailySnaphotRetentionDays      *int32
+	WeeklySnapshotRetentionWeeks   *int32
+	MonthlySnapshotRetentionMonths *int32
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -83,7 +83,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongoDBflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId, model.Region)
+			instanceLabel, err := mongoDBflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = *model.InstanceId
@@ -138,10 +138,10 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	}
 
 	schedule := flags.FlagToStringPointer(p, cmd, scheduleFlag)
-	snapshotRetentionDays := flags.FlagToInt64Pointer(p, cmd, snapshotRetentionDaysFlag)
-	dailySnapshotRetentionDays := flags.FlagToInt64Pointer(p, cmd, dailySnapshotRetentionDaysFlag)
-	weeklySnapshotRetentionWeeks := flags.FlagToInt64Pointer(p, cmd, weeklySnapshotRetentionWeeksFlag)
-	monthlySnapshotRetentionMonths := flags.FlagToInt64Pointer(p, cmd, monthlySnapshotRetentionMonthsFlag)
+	snapshotRetentionDays := flags.FlagToInt32Pointer(p, cmd, snapshotRetentionDaysFlag)
+	dailySnapshotRetentionDays := flags.FlagToInt32Pointer(p, cmd, dailySnapshotRetentionDaysFlag)
+	weeklySnapshotRetentionWeeks := flags.FlagToInt32Pointer(p, cmd, weeklySnapshotRetentionWeeksFlag)
+	monthlySnapshotRetentionMonths := flags.FlagToInt32Pointer(p, cmd, monthlySnapshotRetentionMonthsFlag)
 
 	if schedule == nil && snapshotRetentionDays == nil && dailySnapshotRetentionDays == nil && weeklySnapshotRetentionWeeks == nil && monthlySnapshotRetentionMonths == nil {
 		return nil, &cliErr.EmptyUpdateError{}
@@ -159,7 +159,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildUpdateBackupScheduleRequest(ctx context.Context, model *inputModel, instance *mongodbflex.Instance, apiClient *mongodbflex.APIClient) mongodbflex.ApiUpdateBackupScheduleRequest {
-	req := apiClient.UpdateBackupSchedule(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.UpdateBackupSchedule(ctx, model.ProjectId, *model.InstanceId, model.Region)
 
 	payload := getUpdateBackupSchedulePayload(instance)
 
@@ -196,25 +196,40 @@ func getUpdateBackupSchedulePayload(instance *mongodbflex.Instance) mongodbflex.
 	if backupSchedule == nil {
 		backupSchedule = utils.Ptr(defaultBackupSchedule)
 	}
-	dailySnapshotRetentionDays, err := strconv.ParseInt(options["dailySnapshotRetentionDays"], 10, 64)
+	parsedDailySnapshotRetentionDays, err := strconv.ParseInt(options["dailySnapshotRetentionDays"], 10, 32)
+	var dailySnapshotRetentionDays int32
 	if err != nil {
 		dailySnapshotRetentionDays = defaultDailySnapshotRetentionDays
+	} else {
+		dailySnapshotRetentionDays = int32(parsedDailySnapshotRetentionDays)
 	}
-	weeklySnapshotRetentionWeeks, err := strconv.ParseInt(options["weeklySnapshotRetentionWeeks"], 10, 64)
+	parsedWeeklySnapshotRetentionWeeks, err := strconv.ParseInt(options["weeklySnapshotRetentionWeeks"], 10, 32)
+	var weeklySnapshotRetentionWeeks int32
 	if err != nil {
 		weeklySnapshotRetentionWeeks = defaultWeeklySnapshotRetentionWeeks
+	} else {
+		weeklySnapshotRetentionWeeks = int32(parsedWeeklySnapshotRetentionWeeks)
 	}
-	monthlySnapshotRetentionMonths, err := strconv.ParseInt(options["monthlySnapshotRetentionMonths"], 10, 64)
+	parsedMonthlySnapshotRetentionMonths, err := strconv.ParseInt(options["monthlySnapshotRetentionMonths"], 10, 32)
+	var monthlySnapshotRetentionMonths int32
 	if err != nil {
 		monthlySnapshotRetentionMonths = defaultMonthlySnapshotRetentionMonths
+	} else {
+		monthlySnapshotRetentionMonths = int32(parsedMonthlySnapshotRetentionMonths)
 	}
-	pointInTimeWindowHours, err := strconv.ParseInt(options["pointInTimeWindowHours"], 10, 64)
+	parsedPointInTimeWindowHours, err := strconv.ParseInt(options["pointInTimeWindowHours"], 10, 32)
+	var pointInTimeWindowHours int32
 	if err != nil {
 		pointInTimeWindowHours = defaultPointInTimeWindowHours
+	} else {
+		pointInTimeWindowHours = int32(parsedPointInTimeWindowHours)
 	}
-	snapshotRetentionDays, err := strconv.ParseInt(options["snapshotRetentionDays"], 10, 64)
+	parsedSnapshotRetentionDays, err := strconv.ParseInt(options["snapshotRetentionDays"], 10, 32)
+	var snapshotRetentionDays int32
 	if err != nil {
 		snapshotRetentionDays = defaultSnapshotRetentionDays
+	} else {
+		snapshotRetentionDays = int32(parsedSnapshotRetentionDays)
 	}
 
 	defaultPayload := mongodbflex.UpdateBackupSchedulePayload{
@@ -229,6 +244,6 @@ func getUpdateBackupSchedulePayload(instance *mongodbflex.Instance) mongodbflex.
 }
 
 func buildGetInstanceRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, *model.InstanceId, model.Region)
 	return req
 }

--- a/internal/cmd/mongodbflex/backup/update-schedule/update_schedule_test.go
+++ b/internal/cmd/mongodbflex/backup/update-schedule/update_schedule_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -58,11 +58,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 func fixturePayload(mods ...func(payload *mongodbflex.UpdateBackupSchedulePayload)) mongodbflex.UpdateBackupSchedulePayload {
 	payload := mongodbflex.UpdateBackupSchedulePayload{
 		BackupSchedule:                 utils.Ptr(testSchedule),
-		SnapshotRetentionDays:          utils.Ptr(int64(3)),
-		DailySnapshotRetentionDays:     utils.Ptr(int64(0)),
-		WeeklySnapshotRetentionWeeks:   utils.Ptr(int64(3)),
-		MonthlySnapshotRetentionMonths: utils.Ptr(int64(1)),
-		PointInTimeWindowHours:         utils.Ptr(int64(30)),
+		SnapshotRetentionDays:          utils.Ptr(int32(3)),
+		DailySnapshotRetentionDays:     utils.Ptr(int32(0)),
+		WeeklySnapshotRetentionWeeks:   utils.Ptr(int32(3)),
+		MonthlySnapshotRetentionMonths: utils.Ptr(int32(1)),
+		PointInTimeWindowHours:         utils.Ptr(int32(30)),
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -71,7 +71,7 @@ func fixturePayload(mods ...func(payload *mongodbflex.UpdateBackupSchedulePayloa
 }
 
 func fixtureUpdateBackupScheduleRequest(mods ...func(request *mongodbflex.ApiUpdateBackupScheduleRequest)) mongodbflex.ApiUpdateBackupScheduleRequest {
-	request := testClient.UpdateBackupSchedule(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.UpdateBackupSchedule(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.UpdateBackupSchedulePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -80,7 +80,7 @@ func fixtureUpdateBackupScheduleRequest(mods ...func(request *mongodbflex.ApiUpd
 }
 
 func fixtureGetInstanceRequest(mods ...func(request *mongodbflex.ApiGetInstanceRequest)) mongodbflex.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -201,7 +201,7 @@ func TestBuildGetInstanceRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -231,12 +231,12 @@ func TestBuildUpdateBackupScheduleRequest(t *testing.T) {
 					Region:    testRegion,
 				},
 				InstanceId:                utils.Ptr(testInstanceId),
-				DailySnaphotRetentionDays: utils.Ptr(int64(2)),
+				DailySnaphotRetentionDays: utils.Ptr(int32(2)),
 			},
 			instance: fixtureInstance(),
 			expectedRequest: fixtureUpdateBackupScheduleRequest().UpdateBackupSchedulePayload(
 				fixturePayload(func(payload *mongodbflex.UpdateBackupSchedulePayload) {
-					payload.DailySnapshotRetentionDays = utils.Ptr(int64(2))
+					payload.DailySnapshotRetentionDays = utils.Ptr(int32(2))
 				}),
 			),
 		},
@@ -249,19 +249,19 @@ func TestBuildUpdateBackupScheduleRequest(t *testing.T) {
 				},
 				InstanceId:                     utils.Ptr(testInstanceId),
 				BackupSchedule:                 utils.Ptr("0 0/6 5 2 1"),
-				DailySnaphotRetentionDays:      utils.Ptr(int64(2)),
-				WeeklySnapshotRetentionWeeks:   utils.Ptr(int64(2)),
-				MonthlySnapshotRetentionMonths: utils.Ptr(int64(2)),
-				SnapshotRetentionDays:          utils.Ptr(int64(2)),
+				DailySnaphotRetentionDays:      utils.Ptr(int32(2)),
+				WeeklySnapshotRetentionWeeks:   utils.Ptr(int32(2)),
+				MonthlySnapshotRetentionMonths: utils.Ptr(int32(2)),
+				SnapshotRetentionDays:          utils.Ptr(int32(2)),
 			},
 			instance: fixtureInstance(),
 			expectedRequest: fixtureUpdateBackupScheduleRequest().UpdateBackupSchedulePayload(
 				fixturePayload(func(payload *mongodbflex.UpdateBackupSchedulePayload) {
 					payload.BackupSchedule = utils.Ptr("0 0/6 5 2 1")
-					payload.DailySnapshotRetentionDays = utils.Ptr(int64(2))
-					payload.WeeklySnapshotRetentionWeeks = utils.Ptr(int64(2))
-					payload.MonthlySnapshotRetentionMonths = utils.Ptr(int64(2))
-					payload.SnapshotRetentionDays = utils.Ptr(int64(2))
+					payload.DailySnapshotRetentionDays = utils.Ptr(int32(2))
+					payload.WeeklySnapshotRetentionWeeks = utils.Ptr(int32(2))
+					payload.MonthlySnapshotRetentionMonths = utils.Ptr(int32(2))
+					payload.SnapshotRetentionDays = utils.Ptr(int32(2))
 				}),
 			),
 		},
@@ -285,7 +285,7 @@ func TestBuildUpdateBackupScheduleRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -51,9 +51,9 @@ var typeFlag = flags.StringEnumFlag(
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 
-	InstanceName   *string
-	ACL            *[]string
-	BackupSchedule *string
+	InstanceName   string
+	ACL            []string
+	BackupSchedule string
 	FlavorId       *string
 	CPU            *int32
 	RAM            *int32
@@ -185,9 +185,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
-		InstanceName:    flags.FlagToStringPointer(p, cmd, instanceNameFlag),
-		ACL:             flags.FlagToStringSlicePointer(p, cmd, aclFlag),
-		BackupSchedule:  utils.Ptr(flags.FlagWithDefaultToStringValue(p, cmd, backupScheduleFlag)),
+		InstanceName:    flags.FlagToStringValue(p, cmd, instanceNameFlag),
+		ACL:             flags.FlagToStringSliceValue(p, cmd, aclFlag),
+		BackupSchedule:  flags.FlagWithDefaultToStringValue(p, cmd, backupScheduleFlag),
 		FlavorId:        flavorId,
 		CPU:             cpu,
 		RAM:             ram,
@@ -228,7 +228,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 			return req, err
 		}
 	} else {
-		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, &flavors.Flavors)
+		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, flavors.Flavors)
 		if err != nil {
 			return req, err
 		}
@@ -250,9 +250,9 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 	}
 
 	req = req.CreateInstancePayload(mongodbflex.CreateInstancePayload{
-		Name:           *model.InstanceName,
-		Acl:            mongodbflex.ACL{Items: *model.ACL},
-		BackupSchedule: *model.BackupSchedule,
+		Name:           model.InstanceName,
+		Acl:            mongodbflex.ACL{Items: model.ACL},
+		BackupSchedule: model.BackupSchedule,
 		FlavorId:       *flavorId,
 		Replicas:       replicas,
 		Storage: mongodbflex.Storage{

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	wait "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -55,8 +55,8 @@ type inputModel struct {
 	ACL            *[]string
 	BackupSchedule *string
 	FlavorId       *string
-	CPU            *int64
-	RAM            *int64
+	CPU            *int32
+	RAM            *int32
 	StorageClass   *string
 	StorageSize    *int64
 	Version        *string
@@ -108,7 +108,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 			// Fill in version, if needed
 			if model.Version == nil {
-				version, err := mongodbflexUtils.GetLatestMongoDBVersion(ctx, apiClient, model.ProjectId, model.Region)
+				version, err := mongodbflexUtils.GetLatestMongoDBVersion(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region)
 				if err != nil {
 					return fmt.Errorf("get latest MongoDB version: %w", err)
 				}
@@ -116,7 +116,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				return err
 			}
@@ -129,7 +129,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating instance", func() error {
-					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.CreateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -149,8 +149,8 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "The access control list (ACL). Must contain at least one valid subnet, for instance '0.0.0.0/0' for open access (discouraged), '1.2.3.0/24 for a public IP range of an organization, '1.2.3.4/32' for a single IP range, etc.")
 	cmd.Flags().String(backupScheduleFlag, defaultBackupSchedule, "Backup schedule")
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
-	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")
-	cmd.Flags().Int64(ramFlag, 0, "Amount of RAM (in GB)")
+	cmd.Flags().Int32(cpuFlag, 0, "Number of CPUs")
+	cmd.Flags().Int32(ramFlag, 0, "Amount of RAM (in GB)")
 	cmd.Flags().String(storageClassFlag, defaultStorageClass, "Storage class")
 	cmd.Flags().Int64(storageSizeFlag, defaultStorageSize, "Storage size (in GB)")
 	cmd.Flags().String(versionFlag, "", "MongoDB version. Defaults to the latest version available")
@@ -169,8 +169,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	storageSize := flags.FlagWithDefaultToInt64Value(p, cmd, storageSizeFlag)
 
 	flavorId := flags.FlagToStringPointer(p, cmd, flavorIdFlag)
-	cpu := flags.FlagToInt64Pointer(p, cmd, cpuFlag)
-	ram := flags.FlagToInt64Pointer(p, cmd, ramFlag)
+	cpu := flags.FlagToInt32Pointer(p, cmd, cpuFlag)
+	ram := flags.FlagToInt32Pointer(p, cmd, ramFlag)
 
 	if flavorId == nil && (cpu == nil || ram == nil) {
 		return nil, &cliErr.DatabaseInputFlavorError{
@@ -203,8 +203,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 type MongoDBFlexClient interface {
 	CreateInstance(ctx context.Context, projectId, region string) mongodbflex.ApiCreateInstanceRequest
-	ListFlavorsExecute(ctx context.Context, projectId, region string) (*mongodbflex.ListFlavorsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId, region string) (*mongodbflex.ListStoragesResponse, error)
+	ListFlavors(ctx context.Context, projectId, region string) mongodbflex.ApiListFlavorsRequest
+	ListStorages(ctx context.Context, projectId, flavorId, region string) mongodbflex.ApiListStoragesRequest
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexClient) (mongodbflex.ApiCreateInstanceRequest, error) {
@@ -213,13 +213,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 	var flavorId *string
 	var err error
 
-	flavors, err := apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+	flavors, err := apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MongoDB Flex flavors: %w", err)
 	}
 
 	if model.FlavorId == nil {
-		flavorId, err = mongodbflexUtils.LoadFlavorId(*model.CPU, *model.RAM, flavors.Flavors)
+		flavorId, err = mongodbflexUtils.LoadFlavorId(*model.CPU, *model.RAM, &flavors.Flavors)
 		if err != nil {
 			var dsaInvalidPlanError *cliErr.DSAInvalidPlanError
 			if !errors.As(err, &dsaInvalidPlanError) {
@@ -228,14 +228,14 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 			return req, err
 		}
 	} else {
-		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, flavors.Flavors)
+		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, &flavors.Flavors)
 		if err != nil {
 			return req, err
 		}
 		flavorId = model.FlavorId
 	}
 
-	storages, err := apiClient.ListStoragesExecute(ctx, model.ProjectId, *flavorId, model.Region)
+	storages, err := apiClient.ListStorages(ctx, model.ProjectId, *flavorId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MongoDB Flex storages: %w", err)
 	}
@@ -250,19 +250,19 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 	}
 
 	req = req.CreateInstancePayload(mongodbflex.CreateInstancePayload{
-		Name:           model.InstanceName,
-		Acl:            &mongodbflex.CreateInstancePayloadAcl{Items: model.ACL},
-		BackupSchedule: model.BackupSchedule,
-		FlavorId:       flavorId,
-		Replicas:       &replicas,
-		Storage: &mongodbflex.Storage{
+		Name:           *model.InstanceName,
+		Acl:            mongodbflex.ACL{Items: *model.ACL},
+		BackupSchedule: *model.BackupSchedule,
+		FlavorId:       *flavorId,
+		Replicas:       replicas,
+		Storage: mongodbflex.Storage{
 			Class: model.StorageClass,
 			Size:  model.StorageSize,
 		},
-		Version: model.Version,
-		Options: utils.Ptr(map[string]string{
+		Version: *model.Version,
+		Options: map[string]string{
 			"type": *model.Type,
-		}),
+		},
 	})
 	return req, nil
 }

--- a/internal/cmd/mongodbflex/instance/create/create.go
+++ b/internal/cmd/mongodbflex/instance/create/create.go
@@ -54,12 +54,12 @@ type inputModel struct {
 	InstanceName   string
 	ACL            []string
 	BackupSchedule string
-	FlavorId       *string
+	FlavorId       string
 	CPU            *int32
 	RAM            *int32
 	StorageClass   *string
 	StorageSize    *int64
-	Version        *string
+	Version        string
 	Type           *string
 }
 
@@ -107,12 +107,12 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Fill in version, if needed
-			if model.Version == nil {
+			if model.Version == "" {
 				version, err := mongodbflexUtils.GetLatestMongoDBVersion(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region)
 				if err != nil {
 					return fmt.Errorf("get latest MongoDB version: %w", err)
 				}
-				model.Version = &version
+				model.Version = version
 			}
 
 			// Call API
@@ -168,16 +168,16 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 	storageSize := flags.FlagWithDefaultToInt64Value(p, cmd, storageSizeFlag)
 
-	flavorId := flags.FlagToStringPointer(p, cmd, flavorIdFlag)
+	flavorId := flags.FlagToStringValue(p, cmd, flavorIdFlag)
 	cpu := flags.FlagToInt32Pointer(p, cmd, cpuFlag)
 	ram := flags.FlagToInt32Pointer(p, cmd, ramFlag)
 
-	if flavorId == nil && (cpu == nil || ram == nil) {
+	if flavorId == "" && (cpu == nil || ram == nil) {
 		return nil, &cliErr.DatabaseInputFlavorError{
 			Cmd: cmd,
 		}
 	}
-	if flavorId != nil && (cpu != nil || ram != nil) {
+	if flavorId != "" && (cpu != nil || ram != nil) {
 		return nil, &cliErr.DatabaseInputFlavorError{
 			Cmd: cmd,
 		}
@@ -193,7 +193,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		RAM:             ram,
 		StorageClass:    utils.Ptr(flags.FlagWithDefaultToStringValue(p, cmd, storageClassFlag)),
 		StorageSize:     &storageSize,
-		Version:         flags.FlagToStringPointer(p, cmd, versionFlag),
+		Version:         flags.FlagToStringValue(p, cmd, versionFlag),
 		Type:            typeFlag.Ptr(),
 	}
 
@@ -210,7 +210,7 @@ type MongoDBFlexClient interface {
 func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexClient) (mongodbflex.ApiCreateInstanceRequest, error) {
 	req := apiClient.CreateInstance(ctx, model.ProjectId, model.Region)
 
-	var flavorId *string
+	var flavorId string
 	var err error
 
 	flavors, err := apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
@@ -218,8 +218,8 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 		return req, fmt.Errorf("get MongoDB Flex flavors: %w", err)
 	}
 
-	if model.FlavorId == nil {
-		flavorId, err = mongodbflexUtils.LoadFlavorId(*model.CPU, *model.RAM, &flavors.Flavors)
+	if model.FlavorId == "" {
+		foundFlavorId, err := mongodbflexUtils.LoadFlavorId(*model.CPU, *model.RAM, &flavors.Flavors)
 		if err != nil {
 			var dsaInvalidPlanError *cliErr.DSAInvalidPlanError
 			if !errors.As(err, &dsaInvalidPlanError) {
@@ -227,19 +227,20 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 			}
 			return req, err
 		}
+		flavorId = *foundFlavorId
 	} else {
-		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, flavors.Flavors)
+		err := mongodbflexUtils.ValidateFlavorId(model.FlavorId, flavors.Flavors)
 		if err != nil {
 			return req, err
 		}
 		flavorId = model.FlavorId
 	}
 
-	storages, err := apiClient.ListStorages(ctx, model.ProjectId, *flavorId, model.Region).Execute()
+	storages, err := apiClient.ListStorages(ctx, model.ProjectId, flavorId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MongoDB Flex storages: %w", err)
 	}
-	err = mongodbflexUtils.ValidateStorage(model.StorageClass, model.StorageSize, storages, *flavorId)
+	err = mongodbflexUtils.ValidateStorage(model.StorageClass, model.StorageSize, storages, flavorId)
 	if err != nil {
 		return req, err
 	}
@@ -253,13 +254,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 		Name:           model.InstanceName,
 		Acl:            mongodbflex.ACL{Items: model.ACL},
 		BackupSchedule: model.BackupSchedule,
-		FlavorId:       *flavorId,
+		FlavorId:       flavorId,
 		Replicas:       replicas,
 		Storage: mongodbflex.Storage{
 			Class: model.StorageClass,
 			Size:  model.StorageSize,
 		},
-		Version: *model.Version,
+		Version: model.Version,
 		Options: map[string]string{
 			"type": *model.Type,
 		},

--- a/internal/cmd/mongodbflex/instance/create/create_test.go
+++ b/internal/cmd/mongodbflex/instance/create/create_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -23,35 +23,34 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 
-type mongoDBFlexClientMocked struct {
+type mockSettings struct {
 	listFlavorsFails  bool
 	listFlavorsResp   *mongodbflex.ListFlavorsResponse
 	listStoragesFails bool
 	listStoragesResp  *mongodbflex.ListStoragesResponse
 }
 
-func (c *mongoDBFlexClientMocked) CreateInstance(ctx context.Context, projectId, region string) mongodbflex.ApiCreateInstanceRequest {
-	return testClient.CreateInstance(ctx, projectId, region)
-}
-
-func (c *mongoDBFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*mongodbflex.ListStoragesResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list storages failed")
-	}
-	return c.listStoragesResp, nil
-}
-
-func (c *mongoDBFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*mongodbflex.ListFlavorsResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
-	}
-	return c.listFlavorsResp, nil
-}
-
 var testProjectId = uuid.NewString()
 var testFlavorId = uuid.NewString()
+
+func newAPICLientMock(settings mockSettings) mongodbflex.DefaultAPI {
+	return mongodbflex.DefaultAPIServiceMock{
+		ListStoragesExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListStoragesRequest) (*mongodbflex.ListStoragesResponse, error) {
+			if settings.listFlavorsFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return settings.listStoragesResp, nil
+		}),
+		ListFlavorsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListFlavorsRequest) (*mongodbflex.ListFlavorsResponse, error) {
+			if settings.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return settings.listFlavorsResp, nil
+		}),
+	}
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -95,7 +94,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiCreateInstanceRequest)) mongodbflex.ApiCreateInstanceRequest {
-	request := testClient.CreateInstance(testCtx, testProjectId, testRegion)
+	request := testClient.DefaultAPI.CreateInstance(testCtx, testProjectId, testRegion)
 	request = request.CreateInstancePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -105,19 +104,19 @@ func fixtureRequest(mods ...func(request *mongodbflex.ApiCreateInstanceRequest))
 
 func fixturePayload(mods ...func(payload *mongodbflex.CreateInstancePayload)) mongodbflex.CreateInstancePayload {
 	payload := mongodbflex.CreateInstancePayload{
-		Name:           utils.Ptr("example-name"),
-		Acl:            &mongodbflex.CreateInstancePayloadAcl{Items: utils.Ptr([]string{"0.0.0.0/0"})},
-		BackupSchedule: utils.Ptr("0 0/6 * * *"),
-		FlavorId:       utils.Ptr(testFlavorId),
-		Replicas:       utils.Ptr(int64(3)),
-		Storage: &mongodbflex.Storage{
+		Name:           "example-name",
+		Acl:            mongodbflex.ACL{Items: []string{"0.0.0.0/0"}},
+		BackupSchedule: "0 0/6 * * *",
+		FlavorId:       testFlavorId,
+		Replicas:       int32(3),
+		Storage: mongodbflex.Storage{
 			Class: utils.Ptr("premium-perf4-mongodb"),
 			Size:  utils.Ptr(int64(10)),
 		},
-		Version: utils.Ptr("6.0"),
-		Options: utils.Ptr(map[string]string{
+		Version: "6.0",
+		Options: map[string]string{
 			"type": "Replica",
-		}),
+		},
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -159,8 +158,8 @@ func TestParseInput(t *testing.T) {
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
 				model.FlavorId = nil
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 		},
 		{
@@ -279,16 +278,16 @@ func TestBuildRequest(t *testing.T) {
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -300,28 +299,28 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -333,20 +332,20 @@ func TestBuildRequest(t *testing.T) {
 			model:       fixtureInputModel(func(model *inputModel) { model.Type = utils.Ptr("Single") }),
 			isValid:     true,
 			expectedRequest: fixtureRequest().CreateInstancePayload(fixturePayload(func(payload *mongodbflex.CreateInstancePayload) {
-				payload.Options = utils.Ptr(map[string]string{"type": "Single"})
-				payload.Replicas = utils.Ptr(int64(1))
+				payload.Options = map[string]string{"type": "Single"}
+				payload.Replicas = int32(1)
 			})),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -358,20 +357,20 @@ func TestBuildRequest(t *testing.T) {
 			model:       fixtureInputModel(func(model *inputModel) { model.Type = utils.Ptr("Sharded") }),
 			isValid:     true,
 			expectedRequest: fixtureRequest().CreateInstancePayload(fixturePayload(func(payload *mongodbflex.CreateInstancePayload) {
-				payload.Options = utils.Ptr(map[string]string{"type": "Sharded"})
-				payload.Replicas = utils.Ptr(int64(9))
+				payload.Options = map[string]string{"type": "Sharded"}
+				payload.Replicas = int32(9)
 			})),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -383,8 +382,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -395,21 +394,21 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(5))
-					model.RAM = utils.Ptr(int64(9))
+					model.CPU = utils.Ptr(int32(5))
+					model.RAM = utils.Ptr(int32(9))
 				},
 			),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
@@ -420,8 +419,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -435,16 +434,16 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -460,16 +459,16 @@ func TestBuildRequest(t *testing.T) {
 				},
 			),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"premium-perf4-mongodb"},
+				StorageClasses: []string{"premium-perf4-mongodb"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -481,13 +480,13 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mongoDBFlexClientMocked{
+			settings := mockSettings{
 				listFlavorsFails:  tt.listFlavorsFails,
 				listFlavorsResp:   tt.listFlavorsResp,
 				listStoragesFails: tt.listStoragesFails,
 				listStoragesResp:  tt.listStoragesResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPICLientMock(settings))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -496,8 +495,9 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
+				cmp.AllowUnexported(tt.expectedRequest, mongodbflex.DefaultAPIService{}),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/instance/create/create_test.go
+++ b/internal/cmd/mongodbflex/instance/create/create_test.go
@@ -26,10 +26,9 @@ var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 
 type mockSettings struct {
-	listFlavorsFails  bool
-	listFlavorsResp   *mongodbflex.ListFlavorsResponse
-	listStoragesFails bool
-	listStoragesResp  *mongodbflex.ListStoragesResponse
+	listFlavorsFails bool
+	listFlavorsResp  *mongodbflex.ListFlavorsResponse
+	listStoragesResp *mongodbflex.ListStoragesResponse
 }
 
 var testProjectId = uuid.NewString()
@@ -263,34 +262,33 @@ func TestParseInput(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	tests := []struct {
-		description       string
-		model             *inputModel
-		expectedRequest   mongodbflex.ApiCreateInstanceRequest
-		listFlavorsFails  bool
-		listFlavorsResp   *mongodbflex.ListFlavorsResponse
-		listStoragesFails bool
-		listStoragesResp  *mongodbflex.ListStoragesResponse
-		isValid           bool
+		description        string
+		model              *inputModel
+		expectedRequest    mongodbflex.ApiCreateInstanceRequest
+		mockClientSettings mockSettings
+		isValid            bool
 	}{
 		{
 			description:     "base with flavor ID",
 			model:           fixtureInputModel(),
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 		},
@@ -305,25 +303,27 @@ func TestBuildRequest(t *testing.T) {
 			),
 			isValid:         true,
 			expectedRequest: fixtureRequest(),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
-					},
-					{
-						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int32(1)),
-						Memory: utils.Ptr(int32(8)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
+						{
+							Id:     utils.Ptr("other-flavor"),
+							Cpu:    utils.Ptr(int32(1)),
+							Memory: utils.Ptr(int32(8)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 		},
@@ -335,20 +335,22 @@ func TestBuildRequest(t *testing.T) {
 				payload.Options = map[string]string{"type": "Single"}
 				payload.Replicas = int32(1)
 			})),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 		},
@@ -360,20 +362,22 @@ func TestBuildRequest(t *testing.T) {
 				payload.Options = map[string]string{"type": "Sharded"}
 				payload.Replicas = int32(9)
 			})),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 		},
@@ -386,8 +390,10 @@ func TestBuildRequest(t *testing.T) {
 					model.RAM = utils.Ptr(int32(4))
 				},
 			),
-			listFlavorsFails: true,
-			isValid:          false,
+			mockClientSettings: mockSettings{
+				listFlavorsFails: true,
+			},
+			isValid: false,
 		},
 		{
 			description: "flavor id not found",
@@ -398,17 +404,19 @@ func TestBuildRequest(t *testing.T) {
 					model.RAM = utils.Ptr(int32(9))
 				},
 			),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
-					},
-					{
-						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int32(1)),
-						Memory: utils.Ptr(int32(8)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
+						{
+							Id:     utils.Ptr("other-flavor"),
+							Cpu:    utils.Ptr(int32(1)),
+							Memory: utils.Ptr(int32(8)),
+						},
 					},
 				},
 			},
@@ -423,8 +431,10 @@ func TestBuildRequest(t *testing.T) {
 					model.RAM = utils.Ptr(int32(4))
 				},
 			),
-			listFlavorsFails: true,
-			isValid:          false,
+			mockClientSettings: mockSettings{
+				listFlavorsFails: true,
+			},
+			isValid: false,
 		},
 		{
 			description: "invalid storage class",
@@ -433,20 +443,22 @@ func TestBuildRequest(t *testing.T) {
 					model.StorageClass = utils.Ptr("non-existing-class")
 				},
 			),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 			isValid: false,
@@ -458,20 +470,22 @@ func TestBuildRequest(t *testing.T) {
 					model.StorageSize = utils.Ptr(int64(9))
 				},
 			),
-			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: []mongodbflex.InstanceFlavor{
-					{
-						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int32(2)),
-						Memory: utils.Ptr(int32(4)),
+			mockClientSettings: mockSettings{
+				listFlavorsResp: &mongodbflex.ListFlavorsResponse{
+					Flavors: []mongodbflex.InstanceFlavor{
+						{
+							Id:     utils.Ptr(testFlavorId),
+							Cpu:    utils.Ptr(int32(2)),
+							Memory: utils.Ptr(int32(4)),
+						},
 					},
 				},
-			},
-			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: []string{"premium-perf4-mongodb"},
-				StorageRange: &mongodbflex.StorageRange{
-					Min: utils.Ptr(int64(10)),
-					Max: utils.Ptr(int64(100)),
+				listStoragesResp: &mongodbflex.ListStoragesResponse{
+					StorageClasses: []string{"premium-perf4-mongodb"},
+					StorageRange: &mongodbflex.StorageRange{
+						Min: utils.Ptr(int64(10)),
+						Max: utils.Ptr(int64(100)),
+					},
 				},
 			},
 			isValid: false,
@@ -480,13 +494,7 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			settings := mockSettings{
-				listFlavorsFails:  tt.listFlavorsFails,
-				listFlavorsResp:   tt.listFlavorsResp,
-				listStoragesFails: tt.listStoragesFails,
-				listStoragesResp:  tt.listStoragesResp,
-			}
-			request, err := buildRequest(testCtx, tt.model, newAPICLientMock(settings))
+			request, err := buildRequest(testCtx, tt.model, newAPICLientMock(tt.mockClientSettings))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -495,7 +503,7 @@ func TestBuildRequest(t *testing.T) {
 			}
 
 			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest, mongodbflex.DefaultAPIService{}),
+				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
 				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)

--- a/internal/cmd/mongodbflex/instance/create/create_test.go
+++ b/internal/cmd/mongodbflex/instance/create/create_test.go
@@ -80,10 +80,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		InstanceName:   "example-name",
 		ACL:            []string{"0.0.0.0/0"},
 		BackupSchedule: "0 0/6 * * *",
-		FlavorId:       utils.Ptr(testFlavorId),
+		FlavorId:       testFlavorId,
 		StorageClass:   utils.Ptr("premium-perf4-mongodb"),
 		StorageSize:    utils.Ptr(int64(10)),
-		Version:        utils.Ptr("6.0"),
+		Version:        "6.0",
 		Type:           utils.Ptr("Replica"),
 	}
 	for _, mod := range mods {
@@ -156,7 +156,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.FlavorId = nil
+				model.FlavorId = ""
 				model.CPU = utils.Ptr(int32(2))
 				model.RAM = utils.Ptr(int32(4))
 			}),
@@ -216,7 +216,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Version = nil
+				model.Version = ""
 			}),
 		},
 		{
@@ -294,7 +294,7 @@ func TestBuildRequest(t *testing.T) {
 			description: "with CPU and RAM",
 			model: fixtureInputModel(
 				func(model *inputModel) {
-					model.FlavorId = nil
+					model.FlavorId = ""
 					model.CPU = utils.Ptr(int32(2))
 					model.RAM = utils.Ptr(int32(4))
 				},
@@ -383,7 +383,7 @@ func TestBuildRequest(t *testing.T) {
 			description: "get flavors fails",
 			model: fixtureInputModel(
 				func(model *inputModel) {
-					model.FlavorId = nil
+					model.FlavorId = ""
 					model.CPU = utils.Ptr(int32(2))
 					model.RAM = utils.Ptr(int32(4))
 				},
@@ -397,7 +397,7 @@ func TestBuildRequest(t *testing.T) {
 			description: "flavor id not found",
 			model: fixtureInputModel(
 				func(model *inputModel) {
-					model.FlavorId = nil
+					model.FlavorId = ""
 					model.CPU = utils.Ptr(int32(5))
 					model.RAM = utils.Ptr(int32(9))
 				},
@@ -424,7 +424,7 @@ func TestBuildRequest(t *testing.T) {
 			description: "get storages fails",
 			model: fixtureInputModel(
 				func(model *inputModel) {
-					model.FlavorId = nil
+					model.FlavorId = ""
 					model.CPU = utils.Ptr(int32(2))
 					model.RAM = utils.Ptr(int32(4))
 				},

--- a/internal/cmd/mongodbflex/instance/create/create_test.go
+++ b/internal/cmd/mongodbflex/instance/create/create_test.go
@@ -77,9 +77,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		InstanceName:   utils.Ptr("example-name"),
-		ACL:            utils.Ptr([]string{"0.0.0.0/0"}),
-		BackupSchedule: utils.Ptr("0 0/6 * * *"),
+		InstanceName:   "example-name",
+		ACL:            []string{"0.0.0.0/0"},
+		BackupSchedule: "0 0/6 * * *",
 		FlavorId:       utils.Ptr(testFlavorId),
 		StorageClass:   utils.Ptr("premium-perf4-mongodb"),
 		StorageSize:    utils.Ptr(int64(10)),
@@ -225,9 +225,8 @@ func TestParseInput(t *testing.T) {
 			aclValues:   []string{"198.51.100.14/24", "198.51.100.14/32"},
 			isValid:     true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ACL = utils.Ptr(
-					append(*model.ACL, "198.51.100.14/24", "198.51.100.14/32"),
-				)
+				model.ACL =
+					append(model.ACL, "198.51.100.14/24", "198.51.100.14/32")
 			}),
 		},
 		{
@@ -236,9 +235,8 @@ func TestParseInput(t *testing.T) {
 			aclValues:   []string{"198.51.100.14/24,198.51.100.14/32"},
 			isValid:     true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.ACL = utils.Ptr(
-					append(*model.ACL, "198.51.100.14/24", "198.51.100.14/32"),
-				)
+				model.ACL =
+					append(model.ACL, "198.51.100.14/24", "198.51.100.14/32")
 			}),
 		},
 		{

--- a/internal/cmd/mongodbflex/instance/delete/delete.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	wait "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api/wait"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -76,7 +76,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Deleting instance", func() error {
-					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.DeleteInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -113,6 +113,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiDeleteInstanceRequest {
-	req := apiClient.DeleteInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.DeleteInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }

--- a/internal/cmd/mongodbflex/instance/delete/delete_test.go
+++ b/internal/cmd/mongodbflex/instance/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiDeleteInstanceRequest)) mongodbflex.ApiDeleteInstanceRequest {
-	request := testClient.DeleteInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.DeleteInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -165,7 +165,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -92,11 +92,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex
 }
 
 func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.Instance) error {
-	if instance == nil {
-		return fmt.Errorf("instance is nil")
-	}
-
 	return p.OutputResult(outputFormat, instance, func() error {
+		if instance == nil {
+			return fmt.Errorf("instance is nil")
+		}
 		var instanceType string
 		if instance.HasReplicas() {
 			var err error

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -121,8 +121,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		table.AddRow("VERSION", utils.PtrString(instance.Version))
 		table.AddSeparator()
 		if instance.HasAcl() {
-			aclsArray := instance.Acl.Items
-			acls := strings.Join(aclsArray, ",")
+			acls := strings.Join(instance.Acl.Items, ",")
 			table.AddRow("ACL", acls)
 			table.AddSeparator()
 		}

--- a/internal/cmd/mongodbflex/instance/describe/describe.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -87,7 +87,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiGetInstanceRequest {
-	req := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region)
 	return req
 }
 
@@ -121,7 +121,7 @@ func outputResult(p *print.Printer, outputFormat string, instance *mongodbflex.I
 		table.AddRow("VERSION", utils.PtrString(instance.Version))
 		table.AddSeparator()
 		if instance.HasAcl() {
-			aclsArray := *instance.Acl.Items
+			aclsArray := instance.Acl.Items
 			acls := strings.Join(aclsArray, ",")
 			table.AddRow("ACL", acls)
 			table.AddSeparator()

--- a/internal/cmd/mongodbflex/instance/describe/describe_test.go
+++ b/internal/cmd/mongodbflex/instance/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -62,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiGetInstanceRequest)) mongodbflex.ApiGetInstanceRequest {
-	request := testClient.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.GetInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -166,7 +166,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/instance/list/list.go
+++ b/internal/cmd/mongodbflex/instance/list/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -66,7 +66,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get MongoDB Flex instances: %w", err)
 			}
-			instances := utils.GetSliceFromPointer(resp.Items)
+			instances := resp.Items
 
 			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
 			if err != nil {
@@ -115,7 +115,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiListInstancesRequest {
-	req := apiClient.ListInstances(ctx, model.ProjectId, model.Region).Tag("")
+	req := apiClient.DefaultAPI.ListInstances(ctx, model.ProjectId, model.Region).Tag("")
 	return req
 }
 

--- a/internal/cmd/mongodbflex/instance/list/list_test.go
+++ b/internal/cmd/mongodbflex/instance/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -53,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiListInstancesRequest)) mongodbflex.ApiListInstancesRequest {
-	request := testClient.ListInstances(testCtx, testProjectId, testRegion).Tag("")
+	request := testClient.DefaultAPI.ListInstances(testCtx, testProjectId, testRegion).Tag("")
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -142,7 +142,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -233,7 +233,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 			return req, err
 		}
 	} else if model.FlavorId != nil {
-		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, &flavors.Flavors)
+		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, flavors.Flavors)
 		if err != nil {
 			return req, err
 		}

--- a/internal/cmd/mongodbflex/instance/update/update.go
+++ b/internal/cmd/mongodbflex/instance/update/update.go
@@ -19,8 +19,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	wait "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api/wait"
 )
 
 const (
@@ -51,8 +51,8 @@ type inputModel struct {
 	ACL            *[]string
 	BackupSchedule *string
 	FlavorId       *string
-	CPU            *int64
-	RAM            *int64
+	CPU            *int32
+	RAM            *int32
 	StorageClass   *string
 	StorageSize    *int64
 	Version        *string
@@ -87,7 +87,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -100,7 +100,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			req, err := buildRequest(ctx, model, apiClient)
+			req, err := buildRequest(ctx, model, apiClient.DefaultAPI)
 			if err != nil {
 				return err
 			}
@@ -113,7 +113,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Updating instance", func() error {
-					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
+					_, err = wait.PartialUpdateInstanceWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, instanceId, model.Region).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -133,8 +133,8 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(flags.CIDRSliceFlag(), aclFlag, "Lists of IP networks in CIDR notation which are allowed to access this instance")
 	cmd.Flags().String(backupScheduleFlag, "", "Backup schedule")
 	cmd.Flags().String(flavorIdFlag, "", "ID of the flavor")
-	cmd.Flags().Int64(cpuFlag, 0, "Number of CPUs")
-	cmd.Flags().Int64(ramFlag, 0, "Amount of RAM (in GB)")
+	cmd.Flags().Int32(cpuFlag, 0, "Number of CPUs")
+	cmd.Flags().Int32(ramFlag, 0, "Amount of RAM (in GB)")
 	cmd.Flags().String(storageClassFlag, "", "Storage class")
 	cmd.Flags().Int64(storageSizeFlag, 0, "Storage size (in GB)")
 	cmd.Flags().String(versionFlag, "", "Version")
@@ -151,8 +151,8 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 	instanceName := flags.FlagToStringPointer(p, cmd, instanceNameFlag)
 	flavorId := flags.FlagToStringPointer(p, cmd, flavorIdFlag)
-	cpu := flags.FlagToInt64Pointer(p, cmd, cpuFlag)
-	ram := flags.FlagToInt64Pointer(p, cmd, ramFlag)
+	cpu := flags.FlagToInt32Pointer(p, cmd, cpuFlag)
+	ram := flags.FlagToInt32Pointer(p, cmd, ramFlag)
 	acl := flags.FlagToStringSlicePointer(p, cmd, aclFlag)
 	backupSchedule := flags.FlagToStringPointer(p, cmd, backupScheduleFlag)
 	storageClass := flags.FlagToStringPointer(p, cmd, storageClassFlag)
@@ -193,9 +193,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 
 type MongoDBFlexClient interface {
 	PartialUpdateInstance(ctx context.Context, projectId, instanceId, region string) mongodbflex.ApiPartialUpdateInstanceRequest
-	GetInstanceExecute(ctx context.Context, projectId, instanceId, region string) (*mongodbflex.InstanceResponse, error)
-	ListFlavorsExecute(ctx context.Context, projectId, region string) (*mongodbflex.ListFlavorsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId, region string) (*mongodbflex.ListStoragesResponse, error)
+	GetInstance(ctx context.Context, projectId, instanceId, region string) mongodbflex.ApiGetInstanceRequest
+	ListFlavors(ctx context.Context, projectId, region string) mongodbflex.ApiListFlavorsRequest
+	ListStorages(ctx context.Context, projectId, flavorId, region string) mongodbflex.ApiListStoragesRequest
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexClient) (mongodbflex.ApiPartialUpdateInstanceRequest, error) {
@@ -204,7 +204,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 	var flavorId *string
 	var err error
 
-	flavors, err := apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+	flavors, err := apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 	if err != nil {
 		return req, fmt.Errorf("get MongoDB Flex flavors: %w", err)
 	}
@@ -213,7 +213,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 		ram := model.RAM
 		cpu := model.CPU
 		if model.RAM == nil || model.CPU == nil {
-			currentInstance, err := apiClient.GetInstanceExecute(ctx, model.ProjectId, model.InstanceId, model.Region)
+			currentInstance, err := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region).Execute()
 			if err != nil {
 				return req, fmt.Errorf("get MongoDB Flex instance: %w", err)
 			}
@@ -224,7 +224,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 				cpu = currentInstance.Item.Flavor.Cpu
 			}
 		}
-		flavorId, err = mongodbflexUtils.LoadFlavorId(*cpu, *ram, flavors.Flavors)
+		flavorId, err = mongodbflexUtils.LoadFlavorId(*cpu, *ram, &flavors.Flavors)
 		if err != nil {
 			var dsaInvalidPlanError *cliErr.DSAInvalidPlanError
 			if !errors.As(err, &dsaInvalidPlanError) {
@@ -233,7 +233,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 			return req, err
 		}
 	} else if model.FlavorId != nil {
-		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, flavors.Flavors)
+		err := mongodbflexUtils.ValidateFlavorId(*model.FlavorId, &flavors.Flavors)
 		if err != nil {
 			return req, err
 		}
@@ -244,13 +244,13 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 	if model.StorageClass != nil || model.StorageSize != nil {
 		validationFlavorId := flavorId
 		if validationFlavorId == nil {
-			currentInstance, err := apiClient.GetInstanceExecute(ctx, model.ProjectId, model.InstanceId, model.Region)
+			currentInstance, err := apiClient.GetInstance(ctx, model.ProjectId, model.InstanceId, model.Region).Execute()
 			if err != nil {
 				return req, fmt.Errorf("get MongoDB Flex instance: %w", err)
 			}
 			validationFlavorId = currentInstance.Item.Flavor.Id
 		}
-		storages, err = apiClient.ListStoragesExecute(ctx, model.ProjectId, *validationFlavorId, model.Region)
+		storages, err = apiClient.ListStorages(ctx, model.ProjectId, *validationFlavorId, model.Region).Execute()
 		if err != nil {
 			return req, fmt.Errorf("get MongoDB Flex storages: %w", err)
 		}
@@ -262,7 +262,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 
 	var payloadAcl *mongodbflex.ACL
 	if model.ACL != nil {
-		payloadAcl = &mongodbflex.ACL{Items: model.ACL}
+		payloadAcl = &mongodbflex.ACL{Items: *model.ACL}
 	}
 
 	var payloadStorage *mongodbflex.Storage
@@ -273,7 +273,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient MongoDBFlexC
 		}
 	}
 
-	var replicas *int64
+	var replicas *int32
 	var payloadOptions *map[string]string
 	if model.Type != nil {
 		replicasInt, err := mongodbflexUtils.GetInstanceReplicas(*model.Type)

--- a/internal/cmd/mongodbflex/instance/update/update_test.go
+++ b/internal/cmd/mongodbflex/instance/update/update_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,9 +22,9 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 
-type mongoDBFlexClientMocked struct {
+type mockClientSettings struct {
 	listFlavorsFails  bool
 	listFlavorsResp   *mongodbflex.ListFlavorsResponse
 	listStoragesFails bool
@@ -33,29 +33,27 @@ type mongoDBFlexClientMocked struct {
 	getInstanceResp   *mongodbflex.InstanceResponse
 }
 
-func (c *mongoDBFlexClientMocked) PartialUpdateInstance(ctx context.Context, projectId, instanceId, region string) mongodbflex.ApiPartialUpdateInstanceRequest {
-	return testClient.PartialUpdateInstance(ctx, projectId, instanceId, region)
-}
-
-func (c *mongoDBFlexClientMocked) GetInstanceExecute(_ context.Context, _, _, _ string) (*mongodbflex.InstanceResponse, error) {
-	if c.getInstanceFails {
-		return nil, fmt.Errorf("get instance failed")
+func newAPIClientMock(c mockClientSettings) mongodbflex.DefaultAPI {
+	return mongodbflex.DefaultAPIServiceMock{
+		GetInstanceExecuteMock: utils.Ptr(func(_ mongodbflex.ApiGetInstanceRequest) (*mongodbflex.InstanceResponse, error) {
+			if c.getInstanceFails {
+				return nil, fmt.Errorf("get instance failed")
+			}
+			return c.getInstanceResp, nil
+		}),
+		ListStoragesExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListStoragesRequest) (*mongodbflex.ListStoragesResponse, error) {
+			if c.listFlavorsFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return c.listStoragesResp, nil
+		}),
+		ListFlavorsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListFlavorsRequest) (*mongodbflex.ListFlavorsResponse, error) {
+			if c.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return c.listFlavorsResp, nil
+		}),
 	}
-	return c.getInstanceResp, nil
-}
-
-func (c *mongoDBFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*mongodbflex.ListStoragesResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list storages failed")
-	}
-	return c.listStoragesResp, nil
-}
-
-func (c *mongoDBFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*mongodbflex.ListFlavorsResponse, error) {
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
-	}
-	return c.listFlavorsResp, nil
 }
 
 var testProjectId = uuid.NewString()
@@ -141,7 +139,7 @@ func fixtureStandardInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiPartialUpdateInstanceRequest)) mongodbflex.ApiPartialUpdateInstanceRequest {
-	request := testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.PartialUpdateInstancePayload(mongodbflex.PartialUpdateInstancePayload{})
 	for _, mod := range mods {
 		mod(&request)
@@ -201,8 +199,8 @@ func TestParseInput(t *testing.T) {
 			isValid: true,
 			expectedModel: fixtureStandardInputModel(func(model *inputModel) {
 				model.FlavorId = nil
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 		},
 		{
@@ -374,15 +372,15 @@ func TestBuildRequest(t *testing.T) {
 			}),
 			isValid: true,
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(mongodbflex.PartialUpdateInstancePayload{
 					FlavorId: utils.Ptr(testFlavorId),
 				}),
@@ -390,20 +388,20 @@ func TestBuildRequest(t *testing.T) {
 		{
 			description: "update flavor from cpu and ram",
 			model: fixtureRequiredInputModel(func(model *inputModel) {
-				model.CPU = utils.Ptr(int64(2))
-				model.RAM = utils.Ptr(int64(4))
+				model.CPU = utils.Ptr(int32(2))
+				model.RAM = utils.Ptr(int32(4))
 			}),
 			isValid: true,
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(mongodbflex.PartialUpdateInstancePayload{
 					FlavorId: utils.Ptr(testFlavorId),
 				}),
@@ -422,13 +420,13 @@ func TestBuildRequest(t *testing.T) {
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"class"},
+				StorageClasses: []string{"class"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(mongodbflex.PartialUpdateInstancePayload{
 					Storage: &mongodbflex.Storage{
 						Class: utils.Ptr("class"),
@@ -450,13 +448,13 @@ func TestBuildRequest(t *testing.T) {
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"class"},
+				StorageClasses: []string{"class"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
 				},
 			},
-			expectedRequest: testClient.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
+			expectedRequest: testClient.DefaultAPI.PartialUpdateInstance(testCtx, testProjectId, testInstanceId, testRegion).
 				PartialUpdateInstancePayload(mongodbflex.PartialUpdateInstancePayload{
 					Storage: &mongodbflex.Storage{
 						Class: utils.Ptr("class"),
@@ -468,8 +466,8 @@ func TestBuildRequest(t *testing.T) {
 			description: "get flavors fails",
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -479,21 +477,21 @@ func TestBuildRequest(t *testing.T) {
 			description: "flavor id not found",
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
-					model.CPU = utils.Ptr(int64(5))
-					model.RAM = utils.Ptr(int64(9))
+					model.CPU = utils.Ptr(int32(5))
+					model.RAM = utils.Ptr(int32(9))
 				},
 			),
 			listFlavorsResp: &mongodbflex.ListFlavorsResponse{
-				Flavors: &[]mongodbflex.InstanceFlavor{
+				Flavors: []mongodbflex.InstanceFlavor{
 					{
 						Id:     utils.Ptr(testFlavorId),
-						Cpu:    utils.Ptr(int64(2)),
-						Memory: utils.Ptr(int64(4)),
+						Cpu:    utils.Ptr(int32(2)),
+						Memory: utils.Ptr(int32(4)),
 					},
 					{
 						Id:     utils.Ptr("other-flavor"),
-						Cpu:    utils.Ptr(int64(1)),
-						Memory: utils.Ptr(int64(8)),
+						Cpu:    utils.Ptr(int32(1)),
+						Memory: utils.Ptr(int32(8)),
 					},
 				},
 			},
@@ -514,8 +512,8 @@ func TestBuildRequest(t *testing.T) {
 			model: fixtureRequiredInputModel(
 				func(model *inputModel) {
 					model.FlavorId = nil
-					model.CPU = utils.Ptr(int64(2))
-					model.RAM = utils.Ptr(int64(4))
+					model.CPU = utils.Ptr(int32(2))
+					model.RAM = utils.Ptr(int32(4))
 				},
 			),
 			listFlavorsFails: true,
@@ -536,7 +534,7 @@ func TestBuildRequest(t *testing.T) {
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"class"},
+				StorageClasses: []string{"class"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -559,7 +557,7 @@ func TestBuildRequest(t *testing.T) {
 				},
 			},
 			listStoragesResp: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"class"},
+				StorageClasses: []string{"class"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(10)),
 					Max: utils.Ptr(int64(100)),
@@ -571,7 +569,7 @@ func TestBuildRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mongoDBFlexClientMocked{
+			settings := mockClientSettings{
 				getInstanceFails:  tt.getInstanceFails,
 				getInstanceResp:   tt.getInstanceResp,
 				listFlavorsFails:  tt.listFlavorsFails,
@@ -579,7 +577,7 @@ func TestBuildRequest(t *testing.T) {
 				listStoragesFails: tt.listStoragesFails,
 				listStoragesResp:  tt.listStoragesResp,
 			}
-			request, err := buildRequest(testCtx, tt.model, client)
+			request, err := buildRequest(testCtx, tt.model, newAPIClientMock(settings))
 			if err != nil {
 				if !tt.isValid {
 					return
@@ -590,6 +588,7 @@ func TestBuildRequest(t *testing.T) {
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
 				cmpopts.EquateComparable(testCtx),
+				cmpopts.IgnoreFields(tt.expectedRequest, "ApiService"),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -77,7 +77,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			}
 
 			// Call API
-			err = buildAndExecuteRequest(ctx, params.Printer, model, apiClient)
+			err = buildAndExecuteRequest(ctx, params.Printer, model, apiClient.DefaultAPI)
 			if err != nil {
 				return fmt.Errorf("get MongoDB Flex options: %w", err)
 			}
@@ -129,9 +129,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 type mongoDBFlexOptionsClient interface {
-	ListFlavorsExecute(ctx context.Context, projectId, region string) (*mongodbflex.ListFlavorsResponse, error)
-	ListVersionsExecute(ctx context.Context, projectId, region string) (*mongodbflex.ListVersionsResponse, error)
-	ListStoragesExecute(ctx context.Context, projectId, flavorId, region string) (*mongodbflex.ListStoragesResponse, error)
+	ListFlavors(ctx context.Context, projectId, region string) mongodbflex.ApiListFlavorsRequest
+	ListVersions(ctx context.Context, projectId, region string) mongodbflex.ApiListVersionsRequest
+	ListStorages(ctx context.Context, projectId, flavorId, region string) mongodbflex.ApiListStoragesRequest
 }
 
 func buildAndExecuteRequest(ctx context.Context, p *print.Printer, model *inputModel, apiClient mongoDBFlexOptionsClient) error {
@@ -141,19 +141,19 @@ func buildAndExecuteRequest(ctx context.Context, p *print.Printer, model *inputM
 	var err error
 
 	if model.Flavors {
-		flavors, err = apiClient.ListFlavorsExecute(ctx, model.ProjectId, model.Region)
+		flavors, err = apiClient.ListFlavors(ctx, model.ProjectId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get MongoDB Flex flavors: %w", err)
 		}
 	}
 	if model.Versions {
-		versions, err = apiClient.ListVersionsExecute(ctx, model.ProjectId, model.Region)
+		versions, err = apiClient.ListVersions(ctx, model.ProjectId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get MongoDB Flex versions: %w", err)
 		}
 	}
 	if model.Storages {
-		storages, err = apiClient.ListStoragesExecute(ctx, model.ProjectId, *model.FlavorId, model.Region)
+		storages, err = apiClient.ListStorages(ctx, model.ProjectId, *model.FlavorId, model.Region).Execute()
 		if err != nil {
 			return fmt.Errorf("get MongoDB Flex storages: %w", err)
 		}
@@ -169,10 +169,10 @@ func outputResult(p *print.Printer, model *inputModel, flavors *mongodbflex.List
 
 	options := &options{}
 	if flavors != nil {
-		options.Flavors = flavors.Flavors
+		options.Flavors = &flavors.Flavors
 	}
 	if versions != nil {
-		options.Versions = versions.Versions
+		options.Versions = &versions.Versions
 	}
 	if storages != nil && model.FlavorId != nil {
 		options.Storages = &flavorStorages{
@@ -200,7 +200,7 @@ func outputResultAsTable(p *print.Printer, model *inputModel, options *options) 
 	if model.Versions && len(*options.Versions) != 0 {
 		content = append(content, buildVersionsTable(*options.Versions))
 	}
-	if model.Storages && options.Storages.Storages != nil && len(*options.Storages.Storages.StorageClasses) > 0 {
+	if model.Storages && options.Storages.Storages != nil && len(options.Storages.Storages.StorageClasses) > 0 {
 		content = append(content, buildStoragesTable(*options.Storages.Storages))
 	}
 
@@ -223,7 +223,8 @@ func buildFlavorsTable(flavors []mongodbflex.InstanceFlavor) tables.Table {
 			utils.PtrString(f.Cpu),
 			utils.PtrString(f.Memory),
 			utils.PtrString(f.Description),
-			utils.PtrString(f.Categories),
+			//TODO: check if this is ok
+			f.Categories,
 		)
 	}
 	return table
@@ -241,7 +242,7 @@ func buildVersionsTable(versions []string) tables.Table {
 }
 
 func buildStoragesTable(storagesResp mongodbflex.ListStoragesResponse) tables.Table {
-	storages := *storagesResp.StorageClasses
+	storages := storagesResp.StorageClasses
 	table := tables.NewTable()
 	table.SetTitle("Storages")
 	table.SetHeader("MINIMUM", "MAXIMUM", "STORAGE CLASS")

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -223,7 +223,6 @@ func buildFlavorsTable(flavors []mongodbflex.InstanceFlavor) tables.Table {
 			utils.PtrString(f.Cpu),
 			utils.PtrString(f.Memory),
 			utils.PtrString(f.Description),
-			//TODO: check if this is ok
 			f.Categories,
 		)
 	}

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -245,12 +245,11 @@ func buildStoragesTable(storagesResp mongodbflex.ListStoragesResponse) tables.Ta
 	table := tables.NewTable()
 	table.SetTitle("Storages")
 	table.SetHeader("MINIMUM", "MAXIMUM", "STORAGE CLASS")
-	for i := range storages {
-		sc := storages[i]
+	for _, storageClass := range storages {
 		table.AddRow(
 			utils.PtrString(storagesResp.StorageRange.Min),
 			utils.PtrString(storagesResp.StorageRange.Max),
-			sc,
+			storageClass,
 		)
 	}
 	table.EnableAutoMergeOnColumns(1, 2, 3)

--- a/internal/cmd/mongodbflex/options/options.go
+++ b/internal/cmd/mongodbflex/options/options.go
@@ -36,9 +36,9 @@ type inputModel struct {
 }
 
 type options struct {
-	Flavors  *[]mongodbflex.InstanceFlavor `json:"flavors,omitempty"`
-	Versions *[]string                     `json:"versions,omitempty"`
-	Storages *flavorStorages               `json:"flavorStorages,omitempty"`
+	Flavors  []mongodbflex.InstanceFlavor `json:"flavors,omitempty"`
+	Versions []string                     `json:"versions,omitempty"`
+	Storages *flavorStorages              `json:"flavorStorages,omitempty"`
 }
 
 type flavorStorages struct {
@@ -169,10 +169,10 @@ func outputResult(p *print.Printer, model *inputModel, flavors *mongodbflex.List
 
 	options := &options{}
 	if flavors != nil {
-		options.Flavors = &flavors.Flavors
+		options.Flavors = flavors.Flavors
 	}
 	if versions != nil {
-		options.Versions = &versions.Versions
+		options.Versions = versions.Versions
 	}
 	if storages != nil && model.FlavorId != nil {
 		options.Storages = &flavorStorages{
@@ -194,11 +194,11 @@ func outputResultAsTable(p *print.Printer, model *inputModel, options *options) 
 	}
 
 	content := []tables.Table{}
-	if model.Flavors && len(*options.Flavors) != 0 {
-		content = append(content, buildFlavorsTable(*options.Flavors))
+	if model.Flavors && len(options.Flavors) != 0 {
+		content = append(content, buildFlavorsTable(options.Flavors))
 	}
-	if model.Versions && len(*options.Versions) != 0 {
-		content = append(content, buildVersionsTable(*options.Versions))
+	if model.Versions && len(options.Versions) != 0 {
+		content = append(content, buildVersionsTable(options.Versions))
 	}
 	if model.Storages && options.Storages.Storages != nil && len(options.Storages.Storages.StorageClasses) > 0 {
 		content = append(content, buildStoragesTable(*options.Storages.Storages))

--- a/internal/cmd/mongodbflex/options/options_test.go
+++ b/internal/cmd/mongodbflex/options/options_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 
-type mongoDBFlexClientMocked struct {
+type mockClientSettings struct {
 	listFlavorsFails  bool
 	listVersionsFails bool
 	listStoragesFails bool
@@ -27,38 +27,40 @@ type mongoDBFlexClientMocked struct {
 	listStoragesCalled bool
 }
 
-func (c *mongoDBFlexClientMocked) ListFlavorsExecute(_ context.Context, _, _ string) (*mongodbflex.ListFlavorsResponse, error) {
-	c.listFlavorsCalled = true
-	if c.listFlavorsFails {
-		return nil, fmt.Errorf("list flavors failed")
+func newAPIClientMock(c *mockClientSettings) mongodbflex.DefaultAPI {
+	return mongodbflex.DefaultAPIServiceMock{
+		ListFlavorsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListFlavorsRequest) (*mongodbflex.ListFlavorsResponse, error) {
+			c.listFlavorsCalled = true
+			if c.listFlavorsFails {
+				return nil, fmt.Errorf("list flavors failed")
+			}
+			return utils.Ptr(mongodbflex.ListFlavorsResponse{
+				Flavors: []mongodbflex.InstanceFlavor{},
+			}), nil
+		}),
+		ListVersionsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListVersionsRequest) (*mongodbflex.ListVersionsResponse, error) {
+			c.listVersionsCalled = true
+			if c.listVersionsFails {
+				return nil, fmt.Errorf("list versions failed")
+			}
+			return utils.Ptr(mongodbflex.ListVersionsResponse{
+				Versions: []string{},
+			}), nil
+		}),
+		ListStoragesExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListStoragesRequest) (*mongodbflex.ListStoragesResponse, error) {
+			c.listStoragesCalled = true
+			if c.listStoragesFails {
+				return nil, fmt.Errorf("list storages failed")
+			}
+			return utils.Ptr(mongodbflex.ListStoragesResponse{
+				StorageClasses: []string{},
+				StorageRange: &mongodbflex.StorageRange{
+					Min: utils.Ptr(int64(10)),
+					Max: utils.Ptr(int64(100)),
+				},
+			}), nil
+		}),
 	}
-	return utils.Ptr(mongodbflex.ListFlavorsResponse{
-		Flavors: utils.Ptr([]mongodbflex.InstanceFlavor{}),
-	}), nil
-}
-
-func (c *mongoDBFlexClientMocked) ListVersionsExecute(_ context.Context, _, _ string) (*mongodbflex.ListVersionsResponse, error) {
-	c.listVersionsCalled = true
-	if c.listVersionsFails {
-		return nil, fmt.Errorf("list versions failed")
-	}
-	return utils.Ptr(mongodbflex.ListVersionsResponse{
-		Versions: utils.Ptr([]string{}),
-	}), nil
-}
-
-func (c *mongoDBFlexClientMocked) ListStoragesExecute(_ context.Context, _, _, _ string) (*mongodbflex.ListStoragesResponse, error) {
-	c.listStoragesCalled = true
-	if c.listStoragesFails {
-		return nil, fmt.Errorf("list storages failed")
-	}
-	return utils.Ptr(mongodbflex.ListStoragesResponse{
-		StorageClasses: utils.Ptr([]string{}),
-		StorageRange: &mongodbflex.StorageRange{
-			Min: utils.Ptr(int64(10)),
-			Max: utils.Ptr(int64(100)),
-		},
-	}), nil
 }
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -253,13 +255,13 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			params := testparams.NewTestParams()
-			client := &mongoDBFlexClientMocked{
+			settings := mockClientSettings{
 				listFlavorsFails:  tt.listFlavorsFails,
 				listVersionsFails: tt.listVersionsFails,
 				listStoragesFails: tt.listStoragesFails,
 			}
 
-			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, client)
+			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, newAPIClientMock(&settings))
 			if err != nil && tt.isValid {
 				t.Fatalf("error building and executing request: %v", err)
 			}
@@ -270,14 +272,14 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 				return
 			}
 
-			if tt.expectListFlavorsCalled != client.listFlavorsCalled {
-				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, client.listFlavorsCalled)
+			if tt.expectListFlavorsCalled != settings.listFlavorsCalled {
+				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, settings.listFlavorsCalled)
 			}
-			if tt.expectListVersionsCalled != client.listVersionsCalled {
-				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, client.listVersionsCalled)
+			if tt.expectListVersionsCalled != settings.listVersionsCalled {
+				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, settings.listVersionsCalled)
 			}
-			if tt.expectListStoragesCalled != client.listStoragesCalled {
-				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, client.listStoragesCalled)
+			if tt.expectListStoragesCalled != settings.listStoragesCalled {
+				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, settings.listStoragesCalled)
 			}
 		})
 	}

--- a/internal/cmd/mongodbflex/options/options_test.go
+++ b/internal/cmd/mongodbflex/options/options_test.go
@@ -17,7 +17,7 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 
-type mockClientSettings struct {
+type mockSettings struct {
 	listFlavorsFails  bool
 	listVersionsFails bool
 	listStoragesFails bool
@@ -27,7 +27,7 @@ type mockClientSettings struct {
 	listStoragesCalled bool
 }
 
-func newAPIClientMock(c *mockClientSettings) mongodbflex.DefaultAPI {
+func newAPIClientMock(c *mockSettings) mongodbflex.DefaultAPI {
 	return mongodbflex.DefaultAPIServiceMock{
 		ListFlavorsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListFlavorsRequest) (*mongodbflex.ListFlavorsResponse, error) {
 			c.listFlavorsCalled = true
@@ -179,9 +179,7 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 		description              string
 		model                    *inputModel
 		isValid                  bool
-		listFlavorsFails         bool
-		listVersionsFails        bool
-		listStoragesFails        bool
+		mockClientSettings       mockSettings
 		expectListFlavorsCalled  bool
 		expectListVersionsCalled bool
 		expectListStoragesCalled bool
@@ -224,28 +222,34 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 			expectListStoragesCalled: true,
 		},
 		{
-			description:              "list flavors fails",
-			model:                    fixtureInputModelAllTrue(),
-			isValid:                  false,
-			listFlavorsFails:         true,
+			description: "list flavors fails",
+			model:       fixtureInputModelAllTrue(),
+			isValid:     false,
+			mockClientSettings: mockSettings{
+				listFlavorsFails: true,
+			},
 			expectListFlavorsCalled:  true,
 			expectListVersionsCalled: false,
 			expectListStoragesCalled: false,
 		},
 		{
-			description:              "list versions fails",
-			model:                    fixtureInputModelAllTrue(),
-			isValid:                  false,
-			listVersionsFails:        true,
+			description: "list versions fails",
+			model:       fixtureInputModelAllTrue(),
+			isValid:     false,
+			mockClientSettings: mockSettings{
+				listVersionsFails: true,
+			},
 			expectListFlavorsCalled:  true,
 			expectListVersionsCalled: true,
 			expectListStoragesCalled: false,
 		},
 		{
-			description:              "list storages fails",
-			model:                    fixtureInputModelAllTrue(),
-			isValid:                  false,
-			listStoragesFails:        true,
+			description: "list storages fails",
+			model:       fixtureInputModelAllTrue(),
+			isValid:     false,
+			mockClientSettings: mockSettings{
+				listStoragesFails: true,
+			},
 			expectListFlavorsCalled:  true,
 			expectListVersionsCalled: true,
 			expectListStoragesCalled: true,
@@ -255,13 +259,8 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			params := testparams.NewTestParams()
-			settings := mockClientSettings{
-				listFlavorsFails:  tt.listFlavorsFails,
-				listVersionsFails: tt.listVersionsFails,
-				listStoragesFails: tt.listStoragesFails,
-			}
 
-			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, newAPIClientMock(&settings))
+			err := buildAndExecuteRequest(testCtx, params.Printer, tt.model, newAPIClientMock(&tt.mockClientSettings))
 			if err != nil && tt.isValid {
 				t.Fatalf("error building and executing request: %v", err)
 			}
@@ -272,14 +271,14 @@ func TestBuildAndExecuteRequest(t *testing.T) {
 				return
 			}
 
-			if tt.expectListFlavorsCalled != settings.listFlavorsCalled {
-				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, settings.listFlavorsCalled)
+			if tt.expectListFlavorsCalled != (tt.mockClientSettings).listFlavorsCalled {
+				t.Fatalf("expected listFlavorsCalled to be %v, got %v", tt.expectListFlavorsCalled, (tt.mockClientSettings).listFlavorsCalled)
 			}
-			if tt.expectListVersionsCalled != settings.listVersionsCalled {
-				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, settings.listVersionsCalled)
+			if tt.expectListVersionsCalled != (tt.mockClientSettings).listVersionsCalled {
+				t.Fatalf("expected listVersionsCalled to be %v, got %v", tt.expectListVersionsCalled, (tt.mockClientSettings).listVersionsCalled)
 			}
-			if tt.expectListStoragesCalled != settings.listStoragesCalled {
-				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, settings.listStoragesCalled)
+			if tt.expectListStoragesCalled != (tt.mockClientSettings).listStoragesCalled {
+				t.Fatalf("expected listStoragesCalled to be %v, got %v", tt.expectListStoragesCalled, (tt.mockClientSettings).listStoragesCalled)
 			}
 		})
 	}

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -77,7 +77,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
@@ -134,11 +134,11 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiCreateUserRequest {
-	req := apiClient.CreateUser(ctx, model.ProjectId, model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.CreateUser(ctx, model.ProjectId, model.InstanceId, model.Region)
 	req = req.CreateUserPayload(mongodbflex.CreateUserPayload{
 		Username: model.Username,
-		Database: model.Database,
-		Roles:    model.Roles,
+		Database: *model.Database,
+		Roles:    *model.Roles,
 	})
 	return req
 }
@@ -152,7 +152,8 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *mo
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
-		p.Outputf("Roles: %v\n", utils.PtrString(user.Roles))
+		//TODO: check if this is ok
+		p.Outputf("Roles: %v\n", user.Roles)
 		p.Outputf("Database: %s\n", utils.PtrString(user.Database))
 		p.Outputf("Host: %s\n", utils.PtrString(user.Host))
 		p.Outputf("Port: %s\n", utils.PtrString(user.Port))

--- a/internal/cmd/mongodbflex/user/create/create.go
+++ b/internal/cmd/mongodbflex/user/create/create.go
@@ -152,7 +152,6 @@ func outputResult(p *print.Printer, outputFormat, instanceLabel string, user *mo
 		p.Outputf("Created user for instance %q. User ID: %s\n\n", instanceLabel, utils.PtrString(user.Id))
 		p.Outputf("Username: %s\n", utils.PtrString(user.Username))
 		p.Outputf("Password: %s\n", utils.PtrString(user.Password))
-		//TODO: check if this is ok
 		p.Outputf("Roles: %v\n", user.Roles)
 		p.Outputf("Database: %s\n", utils.PtrString(user.Database))
 		p.Outputf("Host: %s\n", utils.PtrString(user.Host))

--- a/internal/cmd/mongodbflex/user/create/create_test.go
+++ b/internal/cmd/mongodbflex/user/create/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -59,11 +59,11 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiCreateUserRequest)) mongodbflex.ApiCreateUserRequest {
-	request := testClient.CreateUser(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.CreateUser(testCtx, testProjectId, testInstanceId, testRegion)
 	request = request.CreateUserPayload(mongodbflex.CreateUserPayload{
 		Username: utils.Ptr("johndoe"),
-		Database: utils.Ptr("default"),
-		Roles:    utils.Ptr([]string{"read"}),
+		Database: "default",
+		Roles:    []string{"read"},
 	})
 
 	for _, mod := range mods {
@@ -187,8 +187,8 @@ func TestBuildRequest(t *testing.T) {
 				model.Username = nil
 			}),
 			expectedRequest: fixtureRequest().CreateUserPayload(mongodbflex.CreateUserPayload{
-				Database: utils.Ptr("default"),
-				Roles:    utils.Ptr([]string{"read"}),
+				Database: "default",
+				Roles:    []string{"read"},
 			}),
 		},
 	}
@@ -199,7 +199,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/user/delete/delete.go
+++ b/internal/cmd/mongodbflex/user/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -60,13 +60,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user name: %v", err)
 				userLabel = model.UserId
@@ -119,6 +119,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiDeleteUserRequest {
-	req := apiClient.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.DeleteUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }

--- a/internal/cmd/mongodbflex/user/delete/delete_test.go
+++ b/internal/cmd/mongodbflex/user/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -64,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiDeleteUserRequest)) mongodbflex.ApiDeleteUserRequest {
-	request := testClient.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.DeleteUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -192,7 +192,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -116,7 +116,6 @@ func outputResult(p *print.Printer, outputFormat string, user mongodbflex.Instan
 		table.AddSeparator()
 		table.AddRow("USERNAME", utils.PtrString(user.Username))
 		table.AddSeparator()
-		//TODO: check if this is ok
 		table.AddRow("ROLES", user.Roles)
 		table.AddSeparator()
 		table.AddRow("DATABASE", utils.PtrString(user.Database))

--- a/internal/cmd/mongodbflex/user/describe/describe.go
+++ b/internal/cmd/mongodbflex/user/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -105,7 +105,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiGetUserRequest {
-	req := apiClient.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.GetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }
 
@@ -116,7 +116,8 @@ func outputResult(p *print.Printer, outputFormat string, user mongodbflex.Instan
 		table.AddSeparator()
 		table.AddRow("USERNAME", utils.PtrString(user.Username))
 		table.AddSeparator()
-		table.AddRow("ROLES", utils.PtrString(user.Roles))
+		//TODO: check if this is ok
+		table.AddRow("ROLES", user.Roles)
 		table.AddSeparator()
 		table.AddRow("DATABASE", utils.PtrString(user.Database))
 		table.AddSeparator()

--- a/internal/cmd/mongodbflex/user/describe/describe_test.go
+++ b/internal/cmd/mongodbflex/user/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiGetUserRequest)) mongodbflex.ApiGetUserRequest {
-	request := testClient.GetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.GetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -193,7 +193,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/user/list/list.go
+++ b/internal/cmd/mongodbflex/user/list/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -69,9 +69,9 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get MongoDB Flex users: %w", err)
 			}
-			users := utils.GetSliceFromPointer(resp.Items)
+			users := resp.Items
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, *model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, *model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = *model.InstanceId
@@ -123,7 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiListUsersRequest {
-	req := apiClient.ListUsers(ctx, model.ProjectId, *model.InstanceId, model.Region)
+	req := apiClient.DefaultAPI.ListUsers(ctx, model.ProjectId, *model.InstanceId, model.Region)
 	return req
 }
 

--- a/internal/cmd/mongodbflex/user/list/list_test.go
+++ b/internal/cmd/mongodbflex/user/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiListUsersRequest)) mongodbflex.ApiListUsersRequest {
-	request := testClient.ListUsers(testCtx, testProjectId, testInstanceId, testRegion)
+	request := testClient.DefaultAPI.ListUsers(testCtx, testProjectId, testInstanceId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -159,7 +159,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -60,13 +60,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user name: %v", err)
 				userLabel = model.UserId
@@ -119,7 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiResetUserRequest {
-	req := apiClient.ResetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.ResetUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	return req
 }
 

--- a/internal/cmd/mongodbflex/user/reset-password/reset_password_test.go
+++ b/internal/cmd/mongodbflex/user/reset-password/reset_password_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiResetUserRequest)) mongodbflex.ApiResetUserRequest {
-	request := testClient.ResetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.ResetUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -193,7 +193,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/mongodbflex/user/update/update.go
+++ b/internal/cmd/mongodbflex/user/update/update.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -39,7 +39,7 @@ type inputModel struct {
 	InstanceId string
 	UserId     string
 	Database   *string
-	Roles      *[]string
+	Roles      []string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -66,13 +66,13 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient, model.ProjectId, model.InstanceId, model.Region)
+			instanceLabel, err := mongodbflexUtils.GetInstanceName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get instance name: %v", err)
 				instanceLabel = model.InstanceId
 			}
 
-			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+			userLabel, err := mongodbflexUtils.GetUserName(ctx, apiClient.DefaultAPI, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get user name: %v", err)
 				userLabel = model.UserId
@@ -105,6 +105,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().String(databaseFlag, "", "The database inside the MongoDB instance that the user has access to. If it does not exist, it will be created once the user writes to it")
 	roleFlag.Register(cmd)
 
+	cmd.MarkFlagsOneRequired(databaseFlag, roleFlag.Name())
 	err := flags.MarkFlagsRequired(cmd, instanceIdFlag)
 	cobra.CheckErr(err)
 }
@@ -118,11 +119,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	}
 
 	database := flags.FlagToStringPointer(p, cmd, databaseFlag)
-	roles := roleFlag.Ptr()
-
-	if database == nil && roles == nil {
-		return nil, &errors.EmptyUpdateError{}
-	}
+	roles := roleFlag.Get()
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
@@ -137,7 +134,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *mongodbflex.APIClient) mongodbflex.ApiPartialUpdateUserRequest {
-	req := apiClient.PartialUpdateUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
+	req := apiClient.DefaultAPI.PartialUpdateUser(ctx, model.ProjectId, model.InstanceId, model.UserId, model.Region)
 	req = req.PartialUpdateUserPayload(mongodbflex.PartialUpdateUserPayload{
 		Database: model.Database,
 		Roles:    model.Roles,

--- a/internal/cmd/mongodbflex/user/update/update_test.go
+++ b/internal/cmd/mongodbflex/user/update/update_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &mongodbflex.APIClient{}
+var testClient = &mongodbflex.APIClient{DefaultAPI: &mongodbflex.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testInstanceId = uuid.NewString()
 var testUserId = uuid.NewString()
@@ -67,7 +67,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *mongodbflex.ApiPartialUpdateUserRequest)) mongodbflex.ApiPartialUpdateUserRequest {
-	request := testClient.PartialUpdateUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
+	request := testClient.DefaultAPI.PartialUpdateUser(testCtx, testProjectId, testInstanceId, testUserId, testRegion)
 	request = request.PartialUpdateUserPayload(mongodbflex.PartialUpdateUserPayload{
 		Database: utils.Ptr("default"),
 	})
@@ -113,7 +113,7 @@ func TestParseInput(t *testing.T) {
 			}),
 			isValid: true,
 			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.Roles = utils.Ptr([]string{"read"})
+				model.Roles = []string{"read"}
 			}),
 		},
 		{
@@ -220,10 +220,10 @@ func TestBuildRequest(t *testing.T) {
 			description: "update roles only",
 			model: fixtureInputModel(func(model *inputModel) {
 				model.Database = nil
-				model.Roles = &[]string{"default"}
+				model.Roles = []string{"default"}
 			}),
 			expectedRequest: fixtureRequest().PartialUpdateUserPayload(mongodbflex.PartialUpdateUserPayload{
-				Roles: &[]string{"default"},
+				Roles: []string{"default"},
 			}),
 		},
 	}
@@ -234,7 +234,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, mongodbflex.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/mongodbflex/client/client.go
+++ b/internal/pkg/services/mongodbflex/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/config"
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"

--- a/internal/pkg/services/mongodbflex/utils/utils.go
+++ b/internal/pkg/services/mongodbflex/utils/utils.go
@@ -58,12 +58,12 @@ func GetInstanceType(numReplicas int32) (string, error) {
 	return "", fmt.Errorf("invalid number of replicas: %v", numReplicas)
 }
 
-func ValidateFlavorId(flavorId string, flavors *[]mongodbflex.InstanceFlavor) error {
+func ValidateFlavorId(flavorId string, flavors []mongodbflex.InstanceFlavor) error {
 	if flavors == nil {
 		return fmt.Errorf("nil flavors")
 	}
 
-	for _, f := range *flavors {
+	for _, f := range flavors {
 		if f.Id != nil && strings.EqualFold(*f.Id, flavorId) {
 			return nil
 		}

--- a/internal/pkg/services/mongodbflex/utils/utils.go
+++ b/internal/pkg/services/mongodbflex/utils/utils.go
@@ -11,21 +11,21 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 // The number of replicas is enforced by the API according to the instance type
-var instanceTypeToReplicas = map[string]int64{
+var instanceTypeToReplicas = map[string]int32{
 	"Single":  1,
 	"Replica": 3,
 	"Sharded": 9,
 }
 
 type MongoDBFlexClient interface {
-	ListVersionsExecute(ctx context.Context, projectId, region string) (*mongodbflex.ListVersionsResponse, error)
-	GetInstanceExecute(ctx context.Context, projectId, instanceId, region string) (*mongodbflex.InstanceResponse, error)
-	GetUserExecute(ctx context.Context, projectId, instanceId, userId, region string) (*mongodbflex.GetUserResponse, error)
-	ListRestoreJobsExecute(ctx context.Context, projectId string, instanceId, region string) (*mongodbflex.ListRestoreJobsResponse, error)
+	ListVersions(ctx context.Context, projectId, region string) mongodbflex.ApiListVersionsRequest
+	GetInstance(ctx context.Context, projectId, instanceId, region string) mongodbflex.ApiGetInstanceRequest
+	GetUser(ctx context.Context, projectId, instanceId, userId, region string) mongodbflex.ApiGetUserRequest
+	ListRestoreJobs(ctx context.Context, projectId string, instanceId, region string) mongodbflex.ApiListRestoreJobsRequest
 }
 
 func AvailableInstanceTypes() []string {
@@ -41,7 +41,7 @@ func AvailableInstanceTypes() []string {
 	return instanceTypes
 }
 
-func GetInstanceReplicas(instanceType string) (int64, error) {
+func GetInstanceReplicas(instanceType string) (int32, error) {
 	numReplicas, ok := instanceTypeToReplicas[instanceType]
 	if !ok {
 		return 0, fmt.Errorf("invalid instance type: %v", instanceType)
@@ -49,7 +49,7 @@ func GetInstanceReplicas(instanceType string) (int64, error) {
 	return numReplicas, nil
 }
 
-func GetInstanceType(numReplicas int64) (string, error) {
+func GetInstanceType(numReplicas int32) (string, error) {
 	for k, v := range instanceTypeToReplicas {
 		if v == numReplicas {
 			return k, nil
@@ -90,7 +90,7 @@ func ValidateStorage(storageClass *string, storageSize *int64, storages *mongodb
 		return nil
 	}
 
-	for _, sc := range *storages.StorageClasses {
+	for _, sc := range storages.StorageClasses {
 		if strings.EqualFold(*storageClass, sc) {
 			return nil
 		}
@@ -102,7 +102,7 @@ func ValidateStorage(storageClass *string, storageSize *int64, storages *mongodb
 	}
 }
 
-func LoadFlavorId(cpu, ram int64, flavors *[]mongodbflex.InstanceFlavor) (*string, error) {
+func LoadFlavorId(cpu, ram int32, flavors *[]mongodbflex.InstanceFlavor) (*string, error) {
 	if flavors == nil {
 		return nil, fmt.Errorf("nil flavors")
 	}
@@ -124,20 +124,19 @@ func LoadFlavorId(cpu, ram int64, flavors *[]mongodbflex.InstanceFlavor) (*strin
 }
 
 func GetLatestMongoDBVersion(ctx context.Context, apiClient MongoDBFlexClient, projectId, region string) (string, error) {
-	resp, err := apiClient.ListVersionsExecute(ctx, projectId, region)
+	resp, err := apiClient.ListVersions(ctx, projectId, region).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get MongoDB versions: %w", err)
 	}
-	versions := *resp.Versions
 
 	latestVersion := "0"
-	for i := range versions {
+	for i := range resp.Versions {
 		oldSemVer := fmt.Sprintf("v%s", latestVersion)
-		newSemVer := fmt.Sprintf("v%s", versions[i])
+		newSemVer := fmt.Sprintf("v%s", resp.Versions[i])
 		if semver.Compare(newSemVer, oldSemVer) != 1 {
 			continue
 		}
-		latestVersion = versions[i]
+		latestVersion = resp.Versions[i]
 	}
 	if latestVersion == "0" {
 		return "", fmt.Errorf("no MongoDB versions found")
@@ -146,7 +145,7 @@ func GetLatestMongoDBVersion(ctx context.Context, apiClient MongoDBFlexClient, p
 }
 
 func GetInstanceName(ctx context.Context, apiClient MongoDBFlexClient, projectId, instanceId, region string) (string, error) {
-	resp, err := apiClient.GetInstanceExecute(ctx, projectId, instanceId, region)
+	resp, err := apiClient.GetInstance(ctx, projectId, instanceId, region).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get MongoDB Flex instance: %w", err)
 	}
@@ -154,7 +153,7 @@ func GetInstanceName(ctx context.Context, apiClient MongoDBFlexClient, projectId
 }
 
 func GetUserName(ctx context.Context, apiClient MongoDBFlexClient, projectId, instanceId, userId, region string) (string, error) {
-	resp, err := apiClient.GetUserExecute(ctx, projectId, instanceId, userId, region)
+	resp, err := apiClient.GetUser(ctx, projectId, instanceId, userId, region).Execute()
 	if err != nil {
 		return "", fmt.Errorf("get MongoDB Flex user: %w", err)
 	}
@@ -167,7 +166,7 @@ func GetRestoreStatus(backupId string, restoreJobs *mongodbflex.ListRestoreJobsR
 		return state
 	}
 
-	restoreJobsSlice := *restoreJobs.Items
+	restoreJobsSlice := restoreJobs.Items
 
 	// sort array by descending date
 	slices.SortFunc(restoreJobsSlice, func(i, j mongodbflex.RestoreInstanceStatus) int {
@@ -175,7 +174,7 @@ func GetRestoreStatus(backupId string, restoreJobs *mongodbflex.ListRestoreJobsR
 		return cmp.Compare(*j.Date, *i.Date)
 	})
 
-	for _, restoreJob := range *restoreJobs.Items {
+	for _, restoreJob := range restoreJobs.Items {
 		if *restoreJob.BackupID == backupId {
 			state = *restoreJob.Status
 			break

--- a/internal/pkg/services/mongodbflex/utils/utils_test.go
+++ b/internal/pkg/services/mongodbflex/utils/utils_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 )
 
 var (
@@ -25,7 +25,36 @@ const (
 	testUserName     = "user"
 )
 
-type mongoDBFlexClientMocked struct {
+func newAPIClientMock(m clientMockSettings) mongodbflex.DefaultAPI {
+	return mongodbflex.DefaultAPIServiceMock{
+		ListVersionsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListVersionsRequest) (*mongodbflex.ListVersionsResponse, error) {
+			if m.listVersionsFails {
+				return nil, fmt.Errorf("could not list versions")
+			}
+			return m.listVersionsResp, nil
+		}),
+		ListRestoreJobsExecuteMock: utils.Ptr(func(_ mongodbflex.ApiListRestoreJobsRequest) (*mongodbflex.ListRestoreJobsResponse, error) {
+			if m.listRestoreJobsFails {
+				return nil, fmt.Errorf("could not list versions")
+			}
+			return m.listRestoreJobsResp, nil
+		}),
+		GetInstanceExecuteMock: utils.Ptr(func(_ mongodbflex.ApiGetInstanceRequest) (*mongodbflex.InstanceResponse, error) {
+			if m.getInstanceFails {
+				return nil, fmt.Errorf("could not get instance")
+			}
+			return m.getInstanceResp, nil
+		}),
+		GetUserExecuteMock: utils.Ptr(func(_ mongodbflex.ApiGetUserRequest) (*mongodbflex.GetUserResponse, error) {
+			if m.getUserFails {
+				return nil, fmt.Errorf("could not get user")
+			}
+			return m.getUserResp, nil
+		}),
+	}
+}
+
+type clientMockSettings struct {
 	listVersionsFails    bool
 	listVersionsResp     *mongodbflex.ListVersionsResponse
 	getInstanceFails     bool
@@ -34,34 +63,6 @@ type mongoDBFlexClientMocked struct {
 	getUserResp          *mongodbflex.GetUserResponse
 	listRestoreJobsFails bool
 	listRestoreJobsResp  *mongodbflex.ListRestoreJobsResponse
-}
-
-func (m *mongoDBFlexClientMocked) ListVersionsExecute(_ context.Context, _, _ string) (*mongodbflex.ListVersionsResponse, error) {
-	if m.listVersionsFails {
-		return nil, fmt.Errorf("could not list versions")
-	}
-	return m.listVersionsResp, nil
-}
-
-func (m *mongoDBFlexClientMocked) ListRestoreJobsExecute(_ context.Context, _, _, _ string) (*mongodbflex.ListRestoreJobsResponse, error) {
-	if m.listRestoreJobsFails {
-		return nil, fmt.Errorf("could not list versions")
-	}
-	return m.listRestoreJobsResp, nil
-}
-
-func (m *mongoDBFlexClientMocked) GetInstanceExecute(_ context.Context, _, _, _ string) (*mongodbflex.InstanceResponse, error) {
-	if m.getInstanceFails {
-		return nil, fmt.Errorf("could not get instance")
-	}
-	return m.getInstanceResp, nil
-}
-
-func (m *mongoDBFlexClientMocked) GetUserExecute(_ context.Context, _, _, _, _ string) (*mongodbflex.GetUserResponse, error) {
-	if m.getUserFails {
-		return nil, fmt.Errorf("could not get user")
-	}
-	return m.getUserResp, nil
 }
 
 func TestValidateStorage(t *testing.T) {
@@ -77,7 +78,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(10)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -97,7 +98,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(1)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -110,7 +111,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(200)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -123,7 +124,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(5)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -136,7 +137,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(20)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "foo"},
+				StorageClasses: []string{"bar-1", "bar-2", "foo"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -149,7 +150,7 @@ func TestValidateStorage(t *testing.T) {
 			storageClass: utils.Ptr("foo"),
 			storageSize:  utils.Ptr(int64(10)),
 			storages: &mongodbflex.ListStoragesResponse{
-				StorageClasses: &[]string{"bar-1", "bar-2", "bar-3"},
+				StorageClasses: []string{"bar-1", "bar-2", "bar-3"},
 				StorageRange: &mongodbflex.StorageRange{
 					Min: utils.Ptr(int64(5)),
 					Max: utils.Ptr(int64(20)),
@@ -239,8 +240,8 @@ func TestValidateFlavorId(t *testing.T) {
 func TestLoadFlavorId(t *testing.T) {
 	tests := []struct {
 		description    string
-		cpu            int64
-		ram            int64
+		cpu            int32
+		ram            int32
 		flavors        *[]mongodbflex.InstanceFlavor
 		isValid        bool
 		expectedOutput *string
@@ -252,18 +253,18 @@ func TestLoadFlavorId(t *testing.T) {
 			flavors: &[]mongodbflex.InstanceFlavor{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     utils.Ptr("foo"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid:        true,
@@ -295,13 +296,13 @@ func TestLoadFlavorId(t *testing.T) {
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     utils.Ptr("foo"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid:        true,
@@ -314,18 +315,18 @@ func TestLoadFlavorId(t *testing.T) {
 			flavors: &[]mongodbflex.InstanceFlavor{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 				{
 					Id:     nil,
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid: false,
@@ -337,13 +338,13 @@ func TestLoadFlavorId(t *testing.T) {
 			flavors: &[]mongodbflex.InstanceFlavor{
 				{
 					Id:     utils.Ptr("bar-1"),
-					Cpu:    utils.Ptr(int64(2)),
-					Memory: utils.Ptr(int64(2)),
+					Cpu:    utils.Ptr(int32(2)),
+					Memory: utils.Ptr(int32(2)),
 				},
 				{
 					Id:     utils.Ptr("bar-2"),
-					Cpu:    utils.Ptr(int64(4)),
-					Memory: utils.Ptr(int64(4)),
+					Cpu:    utils.Ptr(int32(4)),
+					Memory: utils.Ptr(int32(4)),
 				},
 			},
 			isValid: false,
@@ -386,7 +387,7 @@ func TestGetLatestMongoDBFlexVersion(t *testing.T) {
 		{
 			description: "base",
 			listVersionsResp: &mongodbflex.ListVersionsResponse{
-				Versions: &[]string{"8", "10", "9"},
+				Versions: []string{"8", "10", "9"},
 			},
 			isValid:        true,
 			expectedOutput: "10",
@@ -399,7 +400,7 @@ func TestGetLatestMongoDBFlexVersion(t *testing.T) {
 		{
 			description: "no versions",
 			listVersionsResp: &mongodbflex.ListVersionsResponse{
-				Versions: &[]string{},
+				Versions: []string{},
 			},
 			isValid: false,
 		},
@@ -407,12 +408,12 @@ func TestGetLatestMongoDBFlexVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mongoDBFlexClientMocked{
+			settings := clientMockSettings{
 				listVersionsFails: tt.listVersionsFails,
 				listVersionsResp:  tt.listVersionsResp,
 			}
 
-			output, err := GetLatestMongoDBVersion(context.Background(), client, testProjectId, testRegion)
+			output, err := GetLatestMongoDBVersion(context.Background(), newAPIClientMock(settings), testProjectId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -457,12 +458,12 @@ func TestGetInstanceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mongoDBFlexClientMocked{
+			settings := clientMockSettings{
 				getInstanceFails: tt.getInstanceFails,
 				getInstanceResp:  tt.getInstanceResp,
 			}
 
-			output, err := GetInstanceName(context.Background(), client, testProjectId, testInstanceId, testRegion)
+			output, err := GetInstanceName(context.Background(), newAPIClientMock(settings), testProjectId, testInstanceId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -507,12 +508,12 @@ func TestGetUserName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &mongoDBFlexClientMocked{
+			settings := clientMockSettings{
 				getUserFails: tt.getUserFails,
 				getUserResp:  tt.getUserResp,
 			}
 
-			output, err := GetUserName(context.Background(), client, testProjectId, testInstanceId, testUserId, testRegion)
+			output, err := GetUserName(context.Background(), newAPIClientMock(settings), testProjectId, testInstanceId, testUserId, testRegion)
 
 			if tt.isValid && err != nil {
 				t.Errorf("failed on valid input")
@@ -539,7 +540,7 @@ func TestGetRestoreStatus(t *testing.T) {
 		{
 			description: "base",
 			listRestoreJobsResp: &mongodbflex.ListRestoreJobsResponse{
-				Items: &[]mongodbflex.RestoreInstanceStatus{
+				Items: []mongodbflex.RestoreInstanceStatus{
 					{
 						BackupID: utils.Ptr(testBackupId),
 						Date:     utils.Ptr("2024-05-14T12:01:11Z"),
@@ -557,7 +558,7 @@ func TestGetRestoreStatus(t *testing.T) {
 		{
 			description: "get latest restore, ordered array",
 			listRestoreJobsResp: &mongodbflex.ListRestoreJobsResponse{
-				Items: &[]mongodbflex.RestoreInstanceStatus{
+				Items: []mongodbflex.RestoreInstanceStatus{
 					{
 						BackupID: utils.Ptr(testBackupId),
 						Date:     utils.Ptr("2024-05-14T12:01:11Z"),
@@ -575,7 +576,7 @@ func TestGetRestoreStatus(t *testing.T) {
 		{
 			description: "get latest restore, unordered array",
 			listRestoreJobsResp: &mongodbflex.ListRestoreJobsResponse{
-				Items: &[]mongodbflex.RestoreInstanceStatus{
+				Items: []mongodbflex.RestoreInstanceStatus{
 					{
 						BackupID: utils.Ptr(testBackupId),
 						Date:     utils.Ptr("2024-05-13T12:01:11Z"),
@@ -593,7 +594,7 @@ func TestGetRestoreStatus(t *testing.T) {
 		{
 			description: "get latest restore, another date format",
 			listRestoreJobsResp: &mongodbflex.ListRestoreJobsResponse{
-				Items: &[]mongodbflex.RestoreInstanceStatus{
+				Items: []mongodbflex.RestoreInstanceStatus{
 					{
 						BackupID: utils.Ptr(testBackupId),
 						Date:     utils.Ptr("2009-11-10 23:00:00 +0000 UTC m=+0.000000001"),
@@ -611,7 +612,7 @@ func TestGetRestoreStatus(t *testing.T) {
 		{
 			description: "no restore job for that backup",
 			listRestoreJobsResp: &mongodbflex.ListRestoreJobsResponse{
-				Items: &[]mongodbflex.RestoreInstanceStatus{
+				Items: []mongodbflex.RestoreInstanceStatus{
 					{
 						BackupID: utils.Ptr("bar"),
 						Date:     utils.Ptr("2024-05-13T12:01:11Z"),
@@ -649,7 +650,7 @@ func TestGetRestoreStatus(t *testing.T) {
 func TestGetInstanceType(t *testing.T) {
 	tests := []struct {
 		description    string
-		numReplicas    int64
+		numReplicas    int32
 		expectedOutput string
 		isValid        bool
 	}{

--- a/internal/pkg/services/mongodbflex/utils/utils_test.go
+++ b/internal/pkg/services/mongodbflex/utils/utils_test.go
@@ -177,13 +177,13 @@ func TestValidateFlavorId(t *testing.T) {
 	tests := []struct {
 		description string
 		flavorId    string
-		flavors     *[]mongodbflex.InstanceFlavor
+		flavors     []mongodbflex.InstanceFlavor
 		isValid     bool
 	}{
 		{
 			description: "base",
 			flavorId:    "foo",
-			flavors: &[]mongodbflex.InstanceFlavor{
+			flavors: []mongodbflex.InstanceFlavor{
 				{Id: utils.Ptr("bar-1")},
 				{Id: utils.Ptr("bar-2")},
 				{Id: utils.Ptr("foo")},
@@ -199,13 +199,13 @@ func TestValidateFlavorId(t *testing.T) {
 		{
 			description: "no flavors",
 			flavorId:    "foo",
-			flavors:     &[]mongodbflex.InstanceFlavor{},
+			flavors:     []mongodbflex.InstanceFlavor{},
 			isValid:     false,
 		},
 		{
 			description: "nil flavor id",
 			flavorId:    "foo",
-			flavors: &[]mongodbflex.InstanceFlavor{
+			flavors: []mongodbflex.InstanceFlavor{
 				{Id: utils.Ptr("bar-1")},
 				{Id: nil},
 				{Id: utils.Ptr("foo")},
@@ -215,7 +215,7 @@ func TestValidateFlavorId(t *testing.T) {
 		{
 			description: "invalid flavor",
 			flavorId:    "foo",
-			flavors: &[]mongodbflex.InstanceFlavor{
+			flavors: []mongodbflex.InstanceFlavor{
 				{Id: utils.Ptr("bar-1")},
 				{Id: utils.Ptr("bar-2")},
 				{Id: utils.Ptr("bar-3")},


### PR DESCRIPTION
## Description
Migrates mongodbflex to V2 API
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-379

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
