### PR TITLE
chore(iaas): remove deprecated SNA region flags from SNA cmds

### DIFF
--- a/internal/cmd/network-area/create/create.go
+++ b/internal/cmd/network-area/create/create.go
@@ -3,15 +3,12 @@ package create
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
-	wait "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
-	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/flags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -19,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	rmClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/client"
 	rmUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/resourcemanager/utils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
@@ -28,40 +24,14 @@ import (
 const (
 	nameFlag           = "name"
 	organizationIdFlag = "organization-id"
-	// Deprecated: dnsNameServersFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	dnsNameServersFlag = "dns-name-servers"
-	// Deprecated: networkRangesFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	networkRangesFlag = "network-ranges"
-	// Deprecated: transferNetworkFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	transferNetworkFlag = "transfer-network"
-	// Deprecated: defaultPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	defaultPrefixLengthFlag = "default-prefix-length"
-	// Deprecated: maxPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	maxPrefixLengthFlag = "max-prefix-length"
-	// Deprecated: minPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	minPrefixLengthFlag = "min-prefix-length"
-	labelFlag           = "labels"
-
-	deprecationMessage = "Deprecated and will be removed after April 2026. Use instead the new command `$ stackit network-area region` to configure these options for a network area."
+	labelFlag          = "labels"
 )
 
 type inputModel struct {
 	*globalflags.GlobalFlagModel
 	Name           string
 	OrganizationId string
-	// Deprecated: DnsNameServers is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	DnsNameServers *[]string
-	// Deprecated: NetworkRanges is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	NetworkRanges *[]string
-	// Deprecated: TransferNetwork is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	TransferNetwork *string
-	// Deprecated: DefaultPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	DefaultPrefixLength *int64
-	// Deprecated: MaxPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	MaxPrefixLength *int64
-	// Deprecated: MinPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	MinPrefixLength *int64
-	Labels          map[string]any
+	Labels         map[string]any
 }
 
 // NetworkAreaResponses is a workaround, to keep the two responses of the iaas v2 api together for the json and yaml output
@@ -134,29 +104,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				NetworkArea: *resp,
 			}
 
-			if hasDeprecatedFlagsSet(model) {
-				deprecatedFlags := getConfiguredDeprecatedFlags(model)
-				params.Printer.Warn("the flags %q are deprecated and will be removed after April 2026. Use `$ stackit network-area region` to configure these options for a network area.\n", strings.Join(deprecatedFlags, ","))
-				if resp == nil || resp.Id == nil {
-					return fmt.Errorf("create network area: empty response")
-				}
-				reqNetworkArea := buildRequestNetworkAreaRegion(ctx, model, *resp.Id, apiClient)
-				respNetworkArea, err := reqNetworkArea.Execute()
-				if err != nil {
-					return fmt.Errorf("create network area region: %w", err)
-				}
-				if !model.Async {
-					err := spinner.Run(params.Printer, "Create network area region", func() error {
-						_, err = wait.CreateNetworkAreaRegionWaitHandler(ctx, apiClient.DefaultAPI, model.OrganizationId, *resp.Id, model.Region).WaitWithContext(ctx)
-						return err
-					})
-					if err != nil {
-						return fmt.Errorf("wait for creating network area region %w", err)
-					}
-				}
-				responses.RegionalArea = respNetworkArea
-			}
-
 			return outputResult(params.Printer, model.OutputFormat, orgLabel, responses)
 		},
 	}
@@ -168,78 +115,19 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(nameFlag, "n", "", "Network area name")
 	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
 	cmd.Flags().StringToString(labelFlag, nil, "Labels are key-value string pairs which can be attached to a network-area. E.g. '--labels key1=value1,key2=value2,...'")
-	cmd.Flags().StringSlice(dnsNameServersFlag, nil, "List of DNS name server IPs")
-	cmd.Flags().Var(flags.CIDRSliceFlag(), networkRangesFlag, "List of network ranges")
-	cmd.Flags().Var(flags.CIDRFlag(), transferNetworkFlag, "Transfer network in CIDR notation")
-	cmd.Flags().Int64(defaultPrefixLengthFlag, 0, "The default prefix length for networks in the network area")
-	cmd.Flags().Int64(maxPrefixLengthFlag, 0, "The maximum prefix length for networks in the network area")
-	cmd.Flags().Int64(minPrefixLengthFlag, 0, "The minimum prefix length for networks in the network area")
-
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(dnsNameServersFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(networkRangesFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(transferNetworkFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(defaultPrefixLengthFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(maxPrefixLengthFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(minPrefixLengthFlag, deprecationMessage))
-
-	cmd.MarkFlagsRequiredTogether(networkRangesFlag, transferNetworkFlag)
 
 	err := flags.MarkFlagsRequired(cmd, nameFlag, organizationIdFlag)
 	cobra.CheckErr(err)
-}
-
-func hasDeprecatedFlagsSet(model *inputModel) bool {
-	deprecatedFlags := getConfiguredDeprecatedFlags(model)
-	return len(deprecatedFlags) > 0
-}
-
-func getConfiguredDeprecatedFlags(model *inputModel) []string {
-	var result []string
-	if model.DnsNameServers != nil {
-		result = append(result, dnsNameServersFlag)
-	}
-	if model.NetworkRanges != nil {
-		result = append(result, networkRangesFlag)
-	}
-	if model.TransferNetwork != nil {
-		result = append(result, transferNetworkFlag)
-	}
-	if model.DefaultPrefixLength != nil {
-		result = append(result, defaultPrefixLengthFlag)
-	}
-	if model.MaxPrefixLength != nil {
-		result = append(result, maxPrefixLengthFlag)
-	}
-	if model.MinPrefixLength != nil {
-		result = append(result, minPrefixLengthFlag)
-	}
-	return result
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
 	globalFlags := globalflags.Parse(p, cmd)
 
 	model := inputModel{
-		GlobalFlagModel:     globalFlags,
-		Name:                flags.FlagToStringValue(p, cmd, nameFlag),
-		OrganizationId:      flags.FlagToStringValue(p, cmd, organizationIdFlag),
-		DnsNameServers:      flags.FlagToStringSlicePointer(p, cmd, dnsNameServersFlag),
-		NetworkRanges:       flags.FlagToStringSlicePointer(p, cmd, networkRangesFlag),
-		TransferNetwork:     flags.FlagToStringPointer(p, cmd, transferNetworkFlag),
-		DefaultPrefixLength: flags.FlagToInt64Pointer(p, cmd, defaultPrefixLengthFlag),
-		MaxPrefixLength:     flags.FlagToInt64Pointer(p, cmd, maxPrefixLengthFlag),
-		MinPrefixLength:     flags.FlagToInt64Pointer(p, cmd, minPrefixLengthFlag),
-		Labels:              flags.FlagToStringToAny(p, cmd, labelFlag),
-	}
-
-	// Check if any of the deprecated **optional** fields are set and if no of the associated deprecated **required** fields is set.
-	hasAllRequiredRegionalAreaFieldsSet := model.NetworkRanges != nil && model.TransferNetwork != nil
-	hasOptionalRegionalAreaFieldsSet := model.DnsNameServers != nil || model.DefaultPrefixLength != nil || model.MaxPrefixLength != nil || model.MinPrefixLength != nil
-	if hasOptionalRegionalAreaFieldsSet && !hasAllRequiredRegionalAreaFieldsSet {
-		return nil, &cliErr.MultipleFlagsAreMissing{
-			MissingFlags: []string{networkRangesFlag, transferNetworkFlag},
-			SetFlags:     []string{dnsNameServersFlag, defaultPrefixLengthFlag, minPrefixLengthFlag, maxPrefixLengthFlag},
-		}
+		GlobalFlagModel: globalFlags,
+		Name:            flags.FlagToStringValue(p, cmd, nameFlag),
+		OrganizationId:  flags.FlagToStringValue(p, cmd, organizationIdFlag),
+		Labels:          flags.FlagToStringToAny(p, cmd, labelFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -255,45 +143,6 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	}
 
 	return req.CreateNetworkAreaPayload(payload)
-}
-
-func buildRequestNetworkAreaRegion(ctx context.Context, model *inputModel, networkAreaId string, apiClient *iaas.APIClient) iaas.ApiCreateNetworkAreaRegionRequest {
-	req := apiClient.DefaultAPI.CreateNetworkAreaRegion(ctx, model.OrganizationId, networkAreaId, model.Region)
-
-	var networkRanges []iaas.NetworkRange
-	if model.NetworkRanges != nil {
-		networkRanges = make([]iaas.NetworkRange, len(*model.NetworkRanges))
-		for i, networkRange := range *model.NetworkRanges {
-			networkRanges[i] = iaas.NetworkRange{
-				Prefix: networkRange,
-			}
-		}
-	}
-
-	ipv4 := &iaas.RegionalAreaIPv4{
-		NetworkRanges: networkRanges,
-	}
-	if model.DnsNameServers != nil {
-		ipv4.DefaultNameservers = *model.DnsNameServers
-	}
-	if model.TransferNetwork != nil {
-		ipv4.TransferNetwork = *model.TransferNetwork
-	}
-	if model.DefaultPrefixLength != nil {
-		ipv4.DefaultPrefixLen = *model.DefaultPrefixLength
-	}
-	if model.MaxPrefixLength != nil {
-		ipv4.MaxPrefixLen = *model.MaxPrefixLength
-	}
-	if model.MinPrefixLength != nil {
-		ipv4.MinPrefixLen = *model.MinPrefixLength
-	}
-
-	payload := iaas.CreateNetworkAreaRegionPayload{
-		Ipv4: ipv4,
-	}
-
-	return req.CreateNetworkAreaRegionPayload(payload)
 }
 
 func outputResult(p *print.Printer, outputFormat, orgLabel string, responses *NetworkAreaResponses) error {

--- a/internal/cmd/network-area/create/create_test.go
+++ b/internal/cmd/network-area/create/create_test.go
@@ -2,19 +2,16 @@ package create
 
 import (
 	"context"
-	"strconv"
-	"strings"
 	"testing"
-
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 const (
@@ -30,13 +27,7 @@ type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
 var testClient = &iaas.APIClient{DefaultAPI: &iaas.DefaultAPIService{}}
-
-var (
-	testOrgId          = uuid.NewString()
-	testAreaId         = uuid.NewString()
-	testDnsNameservers = []string{"1.1.1.0", "1.1.2.0"}
-	testNetworkRanges  = []string{"192.0.0.0/24", "102.0.0.0/24"}
-)
+var testOrgId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -92,40 +83,6 @@ func fixturePayload(mods ...func(payload *iaas.CreateNetworkAreaPayload)) iaas.C
 	return payload
 }
 
-func fixtureRequestRegionalArea(mods ...func(request *iaas.ApiCreateNetworkAreaRegionRequest)) iaas.ApiCreateNetworkAreaRegionRequest {
-	req := testClient.DefaultAPI.CreateNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
-	req = req.CreateNetworkAreaRegionPayload(fixtureRegionalAreaPayload())
-	for _, mod := range mods {
-		mod(&req)
-	}
-	return req
-}
-
-func fixtureRegionalAreaPayload(mods ...func(request *iaas.CreateNetworkAreaRegionPayload)) iaas.CreateNetworkAreaRegionPayload {
-	var networkRanges []iaas.NetworkRange
-	for _, networkRange := range testNetworkRanges {
-		networkRanges = append(networkRanges, iaas.NetworkRange{
-			Prefix: networkRange,
-		})
-	}
-
-	payload := iaas.CreateNetworkAreaRegionPayload{
-		Ipv4: &iaas.RegionalAreaIPv4{
-			DefaultNameservers: testDnsNameservers,
-			DefaultPrefixLen:   testDefaultPrefixLength,
-			MaxPrefixLen:       testMaxPrefixLength,
-			MinPrefixLen:       testMinPrefixLength,
-			NetworkRanges:      networkRanges,
-			TransferNetwork:    testTransferNetwork,
-		},
-		Status: nil,
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
@@ -142,76 +99,9 @@ func TestParseInput(t *testing.T) {
 			expectedModel: fixtureInputModel(),
 		},
 		{
-			description: "with deprecated flags",
-			flagValues: map[string]string{
-				nameFlag:           testName,
-				organizationIdFlag: testOrgId,
-
-				// Deprecated flags
-				dnsNameServersFlag:      strings.Join(testDnsNameservers, ","),
-				networkRangesFlag:       strings.Join(testNetworkRanges, ","),
-				transferNetworkFlag:     testTransferNetwork,
-				defaultPrefixLengthFlag: strconv.FormatInt(testDefaultPrefixLength, 10),
-				maxPrefixLengthFlag:     strconv.FormatInt(testMaxPrefixLength, 10),
-				minPrefixLengthFlag:     strconv.FormatInt(testMinPrefixLength, 10),
-			},
-			isValid: true,
-			expectedModel: &inputModel{
-				GlobalFlagModel: &globalflags.GlobalFlagModel{
-					Verbosity: globalflags.VerbosityDefault,
-				},
-				Name:           testName,
-				OrganizationId: testOrgId,
-
-				// Deprecated fields
-				DnsNameServers:      utils.Ptr(testDnsNameservers),
-				NetworkRanges:       utils.Ptr(testNetworkRanges),
-				TransferNetwork:     utils.Ptr(testTransferNetwork),
-				DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
-				MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
-				MinPrefixLength:     utils.Ptr(testMinPrefixLength),
-			},
-		},
-		{
 			description: "name missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
 				delete(flagValues, nameFlag)
-			}),
-			isValid: false,
-		},
-		{
-			description: "set deprecated network ranges - missing transfer network",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[networkRangesFlag] = strings.Join(testNetworkRanges, ",")
-			}),
-			isValid: false,
-		},
-		{
-			description: "set deprecated transfer network - missing network ranges",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[transferNetworkFlag] = testTransferNetwork
-			}),
-			isValid: false,
-		},
-		{
-			description: "set deprecated transfer network and network ranges",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[networkRangesFlag] = strings.Join(testNetworkRanges, ",")
-				flagValues[transferNetworkFlag] = testTransferNetwork
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.NetworkRanges = utils.Ptr(testNetworkRanges)
-				model.TransferNetwork = utils.Ptr(testTransferNetwork)
-			}),
-		},
-		{
-			description: "set deprecated optional flags",
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[dnsNameServersFlag] = strings.Join(testDnsNameservers, ",")
-				flagValues[defaultPrefixLengthFlag] = strconv.FormatInt(testDefaultPrefixLength, 10)
-				flagValues[maxPrefixLengthFlag] = strconv.FormatInt(testMaxPrefixLength, 10)
-				flagValues[minPrefixLengthFlag] = strconv.FormatInt(testMinPrefixLength, 10)
 			}),
 			isValid: false,
 		},
@@ -288,58 +178,6 @@ func TestBuildRequest(t *testing.T) {
 	}
 }
 
-func TestBuildRequestNetworkAreaRegion(t *testing.T) {
-	tests := []struct {
-		description     string
-		model           *inputModel
-		areaId          string
-		expectedRequest iaas.ApiCreateNetworkAreaRegionRequest
-	}{
-		{
-			description: "base",
-			model: fixtureInputModel(func(model *inputModel) {
-				// Deprecated fields
-				model.DnsNameServers = utils.Ptr(testDnsNameservers)
-				model.NetworkRanges = utils.Ptr(testNetworkRanges)
-				model.TransferNetwork = utils.Ptr(testTransferNetwork)
-				model.DefaultPrefixLength = utils.Ptr(testDefaultPrefixLength)
-				model.MaxPrefixLength = utils.Ptr(testMaxPrefixLength)
-				model.MinPrefixLength = utils.Ptr(testMinPrefixLength)
-			}),
-			areaId:          testAreaId,
-			expectedRequest: fixtureRequestRegionalArea(),
-		},
-		{
-			description: "base without network ranges",
-			model: fixtureInputModel(func(model *inputModel) {
-				// Deprecated fields
-				model.DnsNameServers = utils.Ptr(testDnsNameservers)
-				model.NetworkRanges = utils.Ptr(testNetworkRanges)
-				model.TransferNetwork = utils.Ptr(testTransferNetwork)
-				model.DefaultPrefixLength = utils.Ptr(testDefaultPrefixLength)
-				model.MaxPrefixLength = utils.Ptr(testMaxPrefixLength)
-				model.MinPrefixLength = utils.Ptr(testMinPrefixLength)
-			}),
-			areaId:          testAreaId,
-			expectedRequest: fixtureRequestRegionalArea(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			request := buildRequestNetworkAreaRegion(testCtx, tt.model, testAreaId, testClient)
-
-			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, iaas.DefaultAPIService{}),
-			)
-			if diff != "" {
-				t.Fatalf("Data does not match: %s", diff)
-			}
-		})
-	}
-}
-
 func Test_outputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
@@ -378,137 +216,6 @@ func Test_outputResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.orgLabel, tt.args.responses); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestGetConfiguredDeprecatedFlags(t *testing.T) {
-	type args struct {
-		model *inputModel
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "no deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           testName,
-					OrganizationId: testOrgId,
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      nil,
-					NetworkRanges:       nil,
-					TransferNetwork:     nil,
-					DefaultPrefixLength: nil,
-					MaxPrefixLength:     nil,
-					MinPrefixLength:     nil,
-				},
-			},
-			want: nil,
-		},
-		{
-			name: "deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           testName,
-					OrganizationId: testOrgId,
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      utils.Ptr(testDnsNameservers),
-					NetworkRanges:       utils.Ptr(testNetworkRanges),
-					TransferNetwork:     utils.Ptr(testTransferNetwork),
-					DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
-					MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
-					MinPrefixLength:     utils.Ptr(testMinPrefixLength),
-				},
-			},
-			want: []string{dnsNameServersFlag, networkRangesFlag, transferNetworkFlag, defaultPrefixLengthFlag, minPrefixLengthFlag, maxPrefixLengthFlag},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getConfiguredDeprecatedFlags(tt.args.model)
-
-			less := func(a, b string) bool {
-				return a < b
-			}
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(less)); diff != "" {
-				t.Fatalf("Data does not match: %s", diff)
-			}
-		})
-	}
-}
-
-func TestHasDeprecatedFlagsSet(t *testing.T) {
-	type args struct {
-		model *inputModel
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "no deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           testName,
-					OrganizationId: testOrgId,
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      nil,
-					NetworkRanges:       nil,
-					TransferNetwork:     nil,
-					DefaultPrefixLength: nil,
-					MaxPrefixLength:     nil,
-					MinPrefixLength:     nil,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           testName,
-					OrganizationId: testOrgId,
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      utils.Ptr(testDnsNameservers),
-					NetworkRanges:       utils.Ptr(testNetworkRanges),
-					TransferNetwork:     utils.Ptr(testTransferNetwork),
-					DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
-					MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
-					MinPrefixLength:     utils.Ptr(testMinPrefixLength),
-				},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasDeprecatedFlagsSet(tt.args.model); got != tt.want {
-				t.Errorf("hasDeprecatedFlagsSet() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/network-area/delete/delete.go
+++ b/internal/cmd/network-area/delete/delete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
-	wait "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -23,11 +22,6 @@ import (
 const (
 	areaIdArg          = "AREA_ID"
 	organizationIdFlag = "organization-id"
-
-	deprecationMessage = "The regional network area configuration %q for the area %q still exists.\n" +
-		"The regional configuration of the network area was moved to the new command group `$ stackit network-area region`.\n" +
-		"The regional area will be automatically deleted. This behavior is deprecated and will be removed after April 2026.\n" +
-		"Use in the future the command `$ stackit network-area region delete` to delete the regional network area and afterwards delete the network-area with the command `$ stackit network-area delete`.\n"
 )
 
 type inputModel struct {
@@ -74,23 +68,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			err = params.Printer.PromptForConfirmation(prompt)
 			if err != nil {
 				return err
-			}
-
-			// Check if the network area has a regional configuration
-			regionalArea, err := apiClient.DefaultAPI.GetNetworkAreaRegion(ctx, *model.OrganizationId, model.AreaId, model.Region).Execute()
-			if err != nil {
-				params.Printer.Debug(print.ErrorLevel, "get regional area: %v", err)
-			}
-			if regionalArea != nil {
-				params.Printer.Warn(deprecationMessage, model.Region, networkAreaLabel)
-				err = apiClient.DefaultAPI.DeleteNetworkAreaRegion(ctx, *model.OrganizationId, model.AreaId, model.Region).Execute()
-				if err != nil {
-					return fmt.Errorf("delete network area region: %w", err)
-				}
-				_, err := wait.DeleteNetworkAreaRegionWaitHandler(ctx, apiClient.DefaultAPI, *model.OrganizationId, model.AreaId, model.Region).WaitWithContext(ctx)
-				if err != nil {
-					return fmt.Errorf("wait delete network area region: %w", err)
-				}
 			}
 
 			// Call API

--- a/internal/cmd/network-area/update/update.go
+++ b/internal/cmd/network-area/update/update.go
@@ -3,7 +3,6 @@ package update
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -28,17 +27,7 @@ const (
 	nameFlag           = "name"
 	organizationIdFlag = "organization-id"
 	areaIdFlag         = "area-id"
-	// Deprecated: dnsNameServersFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	dnsNameServersFlag = "dns-name-servers"
-	// Deprecated: defaultPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	defaultPrefixLengthFlag = "default-prefix-length"
-	// Deprecated: maxPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	maxPrefixLengthFlag = "max-prefix-length"
-	// Deprecated: minPrefixLengthFlag is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	minPrefixLengthFlag = "min-prefix-length"
-	labelFlag           = "labels"
-
-	deprecationMessage = "Deprecated and will be removed after April 2026. Use instead the new command `$ stackit network-area region` to configure these options for a network area."
+	labelFlag          = "labels"
 )
 
 // NetworkAreaResponses is a workaround, to keep the two responses of the iaas v2 api together for the json and yaml output
@@ -53,15 +42,7 @@ type inputModel struct {
 	AreaId         string
 	Name           *string
 	OrganizationId *string
-	// Deprecated: DnsNameServers is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	DnsNameServers []string
-	// Deprecated: DefaultPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	DefaultPrefixLength *int64
-	// Deprecated: MaxPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	MaxPrefixLength *int64
-	// Deprecated: MinPrefixLength is deprecated, because with iaas v2 the create endpoint for network area was separated, remove this after April 2026.
-	MinPrefixLength *int64
-	Labels          map[string]any
+	Labels         map[string]any
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -124,17 +105,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				NetworkArea: *resp,
 			}
 
-			if hasDeprecatedFlagsSet(model) {
-				deprecatedFlags := getConfiguredDeprecatedFlags(model)
-				params.Printer.Warn("the flags %q are deprecated and will be removed after April 2026. Use `$ stackit network-area region` to configure these options for a network area.\n", strings.Join(deprecatedFlags, ","))
-				reqNetworkArea := buildRequestNetworkAreaRegion(ctx, model, apiClient)
-				respNetworkArea, err := reqNetworkArea.Execute()
-				if err != nil {
-					return fmt.Errorf("create network area region: %w", err)
-				}
-				responses.RegionalArea = respNetworkArea
-			}
-
 			return outputResult(params.Printer, model.OutputFormat, orgLabel, responses)
 		},
 	}
@@ -145,16 +115,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(nameFlag, "n", "", "Network area name")
 	cmd.Flags().Var(flags.UUIDFlag(), organizationIdFlag, "Organization ID")
-	cmd.Flags().StringSlice(dnsNameServersFlag, nil, "List of DNS name server IPs")
-	cmd.Flags().Int64(defaultPrefixLengthFlag, 0, "The default prefix length for networks in the network area")
-	cmd.Flags().Int64(maxPrefixLengthFlag, 0, "The maximum prefix length for networks in the network area")
-	cmd.Flags().Int64(minPrefixLengthFlag, 0, "The minimum prefix length for networks in the network area")
 	cmd.Flags().StringToString(labelFlag, nil, "Labels are key-value string pairs which can be attached to a network-area. E.g. '--labels key1=value1,key2=value2,...'")
-
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(dnsNameServersFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(defaultPrefixLengthFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(maxPrefixLengthFlag, deprecationMessage))
-	cobra.CheckErr(cmd.Flags().MarkDeprecated(minPrefixLengthFlag, deprecationMessage))
 
 	err := flags.MarkFlagsRequired(cmd, organizationIdFlag)
 	cobra.CheckErr(err)
@@ -166,41 +127,15 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 	globalFlags := globalflags.Parse(p, cmd)
 
 	model := inputModel{
-		GlobalFlagModel:     globalFlags,
-		Name:                flags.FlagToStringPointer(p, cmd, nameFlag),
-		OrganizationId:      flags.FlagToStringPointer(p, cmd, organizationIdFlag),
-		AreaId:              areaId,
-		DnsNameServers:      flags.FlagToStringSliceValue(p, cmd, dnsNameServersFlag),
-		DefaultPrefixLength: flags.FlagToInt64Pointer(p, cmd, defaultPrefixLengthFlag),
-		MaxPrefixLength:     flags.FlagToInt64Pointer(p, cmd, maxPrefixLengthFlag),
-		MinPrefixLength:     flags.FlagToInt64Pointer(p, cmd, minPrefixLengthFlag),
-		Labels:              flags.FlagToStringToAny(p, cmd, labelFlag),
+		GlobalFlagModel: globalFlags,
+		Name:            flags.FlagToStringPointer(p, cmd, nameFlag),
+		OrganizationId:  flags.FlagToStringPointer(p, cmd, organizationIdFlag),
+		AreaId:          areaId,
+		Labels:          flags.FlagToStringToAny(p, cmd, labelFlag),
 	}
 
 	p.DebugInputModel(model)
 	return &model, nil
-}
-
-func hasDeprecatedFlagsSet(model *inputModel) bool {
-	deprecatedFlags := getConfiguredDeprecatedFlags(model)
-	return len(deprecatedFlags) > 0
-}
-
-func getConfiguredDeprecatedFlags(model *inputModel) []string {
-	var result []string
-	if model.DnsNameServers != nil {
-		result = append(result, dnsNameServersFlag)
-	}
-	if model.DefaultPrefixLength != nil {
-		result = append(result, defaultPrefixLengthFlag)
-	}
-	if model.MaxPrefixLength != nil {
-		result = append(result, maxPrefixLengthFlag)
-	}
-	if model.MinPrefixLength != nil {
-		result = append(result, minPrefixLengthFlag)
-	}
-	return result
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiPartialUpdateNetworkAreaRequest {
@@ -212,21 +147,6 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	}
 
 	return req.PartialUpdateNetworkAreaPayload(payload)
-}
-
-func buildRequestNetworkAreaRegion(ctx context.Context, model *inputModel, apiClient *iaas.APIClient) iaas.ApiUpdateNetworkAreaRegionRequest {
-	req := apiClient.DefaultAPI.UpdateNetworkAreaRegion(ctx, *model.OrganizationId, model.AreaId, model.Region)
-
-	payload := iaas.UpdateNetworkAreaRegionPayload{
-		Ipv4: &iaas.UpdateRegionalAreaIPv4{
-			DefaultNameservers: model.DnsNameServers,
-			DefaultPrefixLen:   model.DefaultPrefixLength,
-			MaxPrefixLen:       model.MaxPrefixLength,
-			MinPrefixLen:       model.MinPrefixLength,
-		},
-	}
-
-	return req.UpdateNetworkAreaRegionPayload(payload)
 }
 
 func outputResult(p *print.Printer, outputFormat, projectLabel string, responses NetworkAreaResponses) error {

--- a/internal/cmd/network-area/update/update_test.go
+++ b/internal/cmd/network-area/update/update_test.go
@@ -2,8 +2,6 @@ package update
 
 import (
 	"context"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -32,8 +30,6 @@ var testClient = &iaas.APIClient{DefaultAPI: &iaas.DefaultAPIService{}}
 var (
 	testOrgId  = uuid.NewString()
 	testAreaId = uuid.NewString()
-
-	testDnsNameservers = []string{"1.1.1.0", "1.1.2.0"}
 )
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
@@ -101,30 +97,6 @@ func fixturePayload(mods ...func(payload *iaas.PartialUpdateNetworkAreaPayload))
 	return payload
 }
 
-func fixtureRequestRegionalArea(mods ...func(request *iaas.ApiUpdateNetworkAreaRegionRequest)) iaas.ApiUpdateNetworkAreaRegionRequest {
-	request := testClient.DefaultAPI.UpdateNetworkAreaRegion(testCtx, testOrgId, testAreaId, testRegion)
-	request = request.UpdateNetworkAreaRegionPayload(fixturePayloadRegionalArea())
-	for _, mod := range mods {
-		mod(&request)
-	}
-	return request
-}
-
-func fixturePayloadRegionalArea(mods ...func(payload *iaas.UpdateNetworkAreaRegionPayload)) iaas.UpdateNetworkAreaRegionPayload {
-	payload := iaas.UpdateNetworkAreaRegionPayload{
-		Ipv4: &iaas.UpdateRegionalAreaIPv4{
-			DefaultNameservers: testDnsNameservers,
-			DefaultPrefixLen:   utils.Ptr(testDefaultPrefixLength),
-			MaxPrefixLen:       utils.Ptr(testMaxPrefixLength),
-			MinPrefixLen:       utils.Ptr(testMinPrefixLength),
-		},
-	}
-	for _, mod := range mods {
-		mod(&payload)
-	}
-	return payload
-}
-
 func TestParseInput(t *testing.T) {
 	tests := []struct {
 		description   string
@@ -141,24 +113,6 @@ func TestParseInput(t *testing.T) {
 			isValid:       true,
 			expectedModel: fixtureInputModel(),
 		},
-		{
-			description: "with deprecated flags",
-			argValues:   fixtureArgValues(),
-			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[dnsNameServersFlag] = strings.Join(testDnsNameservers, ",")
-				flagValues[defaultPrefixLengthFlag] = strconv.FormatInt(testDefaultPrefixLength, 10)
-				flagValues[maxPrefixLengthFlag] = strconv.FormatInt(testMaxPrefixLength, 10)
-				flagValues[minPrefixLengthFlag] = strconv.FormatInt(testMinPrefixLength, 10)
-			}),
-			isValid: true,
-			expectedModel: fixtureInputModel(func(model *inputModel) {
-				model.DnsNameServers = testDnsNameservers
-				model.DefaultPrefixLength = utils.Ptr(testDefaultPrefixLength)
-				model.MaxPrefixLength = utils.Ptr(testMaxPrefixLength)
-				model.MinPrefixLength = utils.Ptr(testMinPrefixLength)
-			}),
-		},
-
 		{
 			description: "no values",
 			argValues:   []string{},
@@ -310,39 +264,6 @@ func TestBuildRequest(t *testing.T) {
 	}
 }
 
-func TestBuildRequestNetworkAreaRegion(t *testing.T) {
-	tests := []struct {
-		description     string
-		model           *inputModel
-		expectedRequest iaas.ApiUpdateNetworkAreaRegionRequest
-	}{
-		{
-			description: "base",
-			model: fixtureInputModel(func(model *inputModel) {
-				model.DnsNameServers = testDnsNameservers
-				model.DefaultPrefixLength = utils.Ptr(testDefaultPrefixLength)
-				model.MaxPrefixLength = utils.Ptr(testMaxPrefixLength)
-				model.MinPrefixLength = utils.Ptr(testMinPrefixLength)
-			}),
-			expectedRequest: fixtureRequestRegionalArea(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			request := buildRequestNetworkAreaRegion(testCtx, tt.model, testClient)
-
-			diff := cmp.Diff(request, tt.expectedRequest,
-				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx, iaas.DefaultAPIService{}),
-			)
-			if diff != "" {
-				t.Fatalf("Data does not match: %s", diff)
-			}
-		})
-	}
-}
-
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
@@ -375,129 +296,6 @@ func TestOutputResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.responses); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestGetConfiguredDeprecatedFlags(t *testing.T) {
-	type args struct {
-		model *inputModel
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "no deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           utils.Ptr(testName),
-					OrganizationId: utils.Ptr(testOrgId),
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      nil,
-					DefaultPrefixLength: nil,
-					MaxPrefixLength:     nil,
-					MinPrefixLength:     nil,
-				},
-			},
-			want: nil,
-		},
-		{
-			name: "deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           utils.Ptr(testName),
-					OrganizationId: utils.Ptr(testOrgId),
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      testDnsNameservers,
-					DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
-					MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
-					MinPrefixLength:     utils.Ptr(testMinPrefixLength),
-				},
-			},
-			want: []string{dnsNameServersFlag, defaultPrefixLengthFlag, minPrefixLengthFlag, maxPrefixLengthFlag},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getConfiguredDeprecatedFlags(tt.args.model)
-
-			less := func(a, b string) bool {
-				return a < b
-			}
-			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(less)); diff != "" {
-				t.Fatalf("Data does not match: %s", diff)
-			}
-		})
-	}
-}
-
-func TestHasDeprecatedFlagsSet(t *testing.T) {
-	type args struct {
-		model *inputModel
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "no deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           utils.Ptr(testName),
-					OrganizationId: utils.Ptr(testOrgId),
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      nil,
-					DefaultPrefixLength: nil,
-					MaxPrefixLength:     nil,
-					MinPrefixLength:     nil,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "deprecated flags",
-			args: args{
-				model: &inputModel{
-					GlobalFlagModel: &globalflags.GlobalFlagModel{
-						Verbosity: globalflags.VerbosityDefault,
-					},
-					Name:           utils.Ptr(testName),
-					OrganizationId: utils.Ptr(testOrgId),
-					Labels: map[string]any{
-						"key": "value",
-					},
-					DnsNameServers:      testDnsNameservers,
-					DefaultPrefixLength: utils.Ptr(testDefaultPrefixLength),
-					MaxPrefixLength:     utils.Ptr(testMaxPrefixLength),
-					MinPrefixLength:     utils.Ptr(testMinPrefixLength),
-				},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasDeprecatedFlagsSet(tt.args.model); got != tt.want {
-				t.Errorf("hasDeprecatedFlagsSet() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-283

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
