### PR TITLE
chore(runcommand): switch to new sdk structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.1.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0
-	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3
+	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/stackitcloud/stackit-sdk-go/services/redis v1.1.0 h1:ckYMRXAGE2/vaxPe
 github.com/stackitcloud/stackit-sdk-go/services/redis v1.1.0/go.mod h1:yjej6QfYoYdRIyKXlmbVz8fZYxbuUdl+QBkvLDPgA4k=
 github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0 h1:JPP6a0ME1tZXr4iB69d/LtJsCAr58ENBadFaK9f48/c=
 github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0/go.mod h1:NEz3f+GV5G++BE9/MmZCsXJyCih7jtg0pZuSyG2sLEs=
-github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3 h1:AiGNJmpQ/f9cglaIQQ4SyePbtCI3K1DQLNvqVN9jKSo=
-github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.4.3/go.mod h1:U/q0V89fvCF2O1ZJfi68/Chie9YY/5s7xBHI1Klq7wA=
+github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0 h1:T5gy5i+NxrpJPYDEJNjGjljhfD7PWTFia7us8A4mL/c=
+github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0/go.mod h1:iB27HtF0UcAugURc9w+nlNrtbAj7Mukw/ptAz+7p2WE=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1 h1:U5rstX5e6Am2t+Ukv5K1Sbftzxt5aFALMa9YS4jCJoo=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1/go.mod h1:2XA8PE05Qg6BL2YXO4XgfGI9qskJ3cicLE5Qq0aqDdY=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8 h1:LLyANBzE8sQa0/49tQBqq4sVLhNgwdqCeQm76srJHWw=

--- a/internal/cmd/server/command/create/create.go
+++ b/internal/cmd/server/command/create/create.go
@@ -9,7 +9,7 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -135,9 +135,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.APIClient) (runcommand.ApiCreateCommandRequest, error) {
-	req := apiClient.CreateCommand(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.CreateCommand(ctx, model.ProjectId, model.ServerId, model.Region)
 	req = req.CreateCommandPayload(runcommand.CreateCommandPayload{
-		CommandTemplateName: &model.CommandTemplateName,
+		CommandTemplateName: model.CommandTemplateName,
 		Parameters:          model.Params,
 	})
 	return req, nil

--- a/internal/cmd/server/command/create/create_test.go
+++ b/internal/cmd/server/command/create/create_test.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &runcommand.APIClient{}
+var testClient = &runcommand.APIClient{DefaultAPI: &runcommand.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
@@ -59,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *runcommand.ApiCreateCommandRequest)) runcommand.ApiCreateCommandRequest {
-	request := testClient.CreateCommand(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.CreateCommand(testCtx, testProjectId, testServerId, testRegion)
 	request = request.CreateCommandPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -69,7 +68,7 @@ func fixtureRequest(mods ...func(request *runcommand.ApiCreateCommandRequest)) r
 
 func fixturePayload(mods ...func(payload *runcommand.CreateCommandPayload)) runcommand.CreateCommandPayload {
 	payload := runcommand.CreateCommandPayload{
-		CommandTemplateName: utils.Ptr("RunShellScript"),
+		CommandTemplateName: "RunShellScript",
 		Parameters:          &map[string]string{"script": "'echo hello'"},
 	}
 	for _, mod := range mods {
@@ -170,7 +169,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, runcommand.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/command/describe/describe.go
+++ b/internal/cmd/server/command/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -64,7 +64,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("read server command: %w", err)
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, *resp)
+			return outputResult(params.Printer, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -97,12 +97,16 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.APIClient) runcommand.ApiGetCommandRequest {
-	req := apiClient.GetCommand(ctx, model.ProjectId, model.Region, model.ServerId, model.CommandId)
+	req := apiClient.DefaultAPI.GetCommand(ctx, model.ProjectId, model.Region, model.ServerId, model.CommandId)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, command runcommand.CommandDetails) error {
+func outputResult(p *print.Printer, outputFormat string, command *runcommand.CommandDetails) error {
 	return p.OutputResult(outputFormat, command, func() error {
+		if command == nil {
+			return fmt.Errorf("command is nil")
+		}
+
 		table := tables.NewTable()
 		table.AddRow("ID", utils.PtrString(command.Id))
 		table.AddSeparator()

--- a/internal/cmd/server/command/describe/describe_test.go
+++ b/internal/cmd/server/command/describe/describe_test.go
@@ -5,19 +5,20 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &runcommand.APIClient{}
+var testClient = &runcommand.APIClient{DefaultAPI: &runcommand.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -65,7 +66,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *runcommand.ApiGetCommandRequest)) runcommand.ApiGetCommandRequest {
-	request := testClient.GetCommand(testCtx, testProjectId, testRegion, testServerId, testCommandId)
+	request := testClient.DefaultAPI.GetCommand(testCtx, testProjectId, testRegion, testServerId, testCommandId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -189,7 +190,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, runcommand.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -201,7 +202,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
-		command      runcommand.CommandDetails
+		command      *runcommand.CommandDetails
 	}
 	tests := []struct {
 		name    string
@@ -209,9 +210,20 @@ func TestOutputResult(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
-			args:    args{},
+			name: "empty",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				command:      &runcommand.CommandDetails{},
+			},
 			wantErr: false,
+		},
+		{
+			name: "command is nil",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				command:      nil,
+			},
+			wantErr: true,
 		},
 	}
 	params := testparams.NewTestParams()

--- a/internal/cmd/server/command/list/list.go
+++ b/internal/cmd/server/command/list/list.go
@@ -9,7 +9,7 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -125,7 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.APIClient) runcommand.ApiListCommandsRequest {
-	req := apiClient.ListCommands(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.ListCommands(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }
 

--- a/internal/cmd/server/command/list/list_test.go
+++ b/internal/cmd/server/command/list/list_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &runcommand.APIClient{}
+var testClient = &runcommand.APIClient{DefaultAPI: &runcommand.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *runcommand.ApiListCommandsRequest)) runcommand.ApiListCommandsRequest {
-	request := testClient.ListCommands(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.ListCommands(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -145,7 +145,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, runcommand.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/command/template/describe/describe.go
+++ b/internal/cmd/server/command/template/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -97,7 +97,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *runcommand.APIClient) runcommand.ApiGetCommandTemplateRequest {
-	req := apiClient.GetCommandTemplate(ctx, model.ProjectId, model.ServerId, model.CommandTemplateName, model.Region)
+	req := apiClient.DefaultAPI.GetCommandTemplate(ctx, model.ProjectId, model.ServerId, model.CommandTemplateName, model.Region)
 	return req
 }
 
@@ -111,7 +111,7 @@ func outputResult(p *print.Printer, outputFormat string, commandTemplate runcomm
 		table.AddRow("DESCRIPTION", utils.PtrString(commandTemplate.Description))
 		table.AddSeparator()
 		if commandTemplate.OsType != nil {
-			table.AddRow("OS TYPE", utils.JoinStringPtr(commandTemplate.OsType, "\n"))
+			table.AddRow("OS TYPE", utils.JoinStringPtr(&commandTemplate.OsType, "\n"))
 			table.AddSeparator()
 		}
 		if commandTemplate.ParametersSchema != nil {

--- a/internal/cmd/server/command/template/describe/describe_test.go
+++ b/internal/cmd/server/command/template/describe/describe_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &runcommand.APIClient{}
+var testClient = &runcommand.APIClient{DefaultAPI: &runcommand.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *runcommand.ApiGetCommandTemplateRequest)) runcommand.ApiGetCommandTemplateRequest {
-	request := testClient.GetCommandTemplate(testCtx, testProjectId, testServerId, testCommandTemplateName, testRegion)
+	request := testClient.DefaultAPI.GetCommandTemplate(testCtx, testProjectId, testServerId, testCommandTemplateName, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -189,7 +189,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, runcommand.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/command/template/list/list.go
+++ b/internal/cmd/server/command/template/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, _ *inputModel, apiClient *runcommand.APIClient) runcommand.ApiListCommandTemplatesRequest {
-	req := apiClient.ListCommandTemplates(ctx)
+	req := apiClient.DefaultAPI.ListCommandTemplates(ctx)
 	return req
 }
 
@@ -116,12 +116,10 @@ func outputResult(p *print.Printer, outputFormat string, templates []runcommand.
 		}
 		table := tables.NewTable()
 		table.SetHeader("NAME", "OS TYPE", "TITLE")
-		for i := range templates {
-			s := templates[i]
-
+		for _, s := range templates {
 			var osType string
-			if s.OsType != nil && len(*s.OsType) > 0 {
-				osType = utils.JoinStringPtr(s.OsType, ",")
+			if len(s.OsType) > 0 {
+				osType = utils.JoinStringPtr(&s.OsType, ",")
 			}
 
 			table.AddRow(

--- a/internal/cmd/server/command/template/list/list_test.go
+++ b/internal/cmd/server/command/template/list/list_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &runcommand.APIClient{}
+var testClient = &runcommand.APIClient{DefaultAPI: &runcommand.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -47,7 +47,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *runcommand.ApiListCommandTemplatesRequest)) runcommand.ApiListCommandTemplatesRequest {
-	request := testClient.ListCommandTemplates(testCtx)
+	request := testClient.DefaultAPI.ListCommandTemplates(testCtx)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -136,7 +136,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, runcommand.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/runcommand/client/client.go
+++ b/internal/pkg/services/runcommand/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/runcommand"
+	runcommand "github.com/stackitcloud/stackit-sdk-go/services/runcommand/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*runcommand.APIClient, error) {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-354

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
