### PR TITLE
chore(serverbackup): switch to new sdk structure

### DIFF
--- a/docs/stackit_server_backup_create.md
+++ b/docs/stackit_server_backup_create.md
@@ -23,11 +23,11 @@ stackit server backup create [flags]
 ### Options
 
 ```
-  -h, --help                   Help for "stackit server backup create"
-  -b, --name string            Backup name
-  -d, --retention-period int   Backup retention period (in days) (default 14)
-  -s, --server-id string       Server ID
-  -i, --volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
+  -h, --help                     Help for "stackit server backup create"
+  -b, --name string              Backup name
+  -d, --retention-period int32   Backup retention period (in days) (default 14)
+  -s, --server-id string         Server ID
+  -i, --volume-ids strings       Backup volume IDs, as comma separated UUID values. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_server_backup_schedule_create.md
+++ b/docs/stackit_server_backup_schedule_create.md
@@ -23,14 +23,14 @@ stackit server backup schedule create [flags]
 ### Options
 
 ```
-  -b, --backup-name string            Backup name
-  -d, --backup-retention-period int   Backup retention period (in days) (default 14)
-  -n, --backup-schedule-name string   Backup schedule name
-  -i, --backup-volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
-  -e, --enabled                       Is the server backup schedule enabled (default true)
-  -h, --help                          Help for "stackit server backup schedule create"
-  -r, --rrule string                  Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
-  -s, --server-id string              Server ID
+  -b, --backup-name string              Backup name
+  -d, --backup-retention-period int32   Backup retention period (in days) (default 14)
+  -n, --backup-schedule-name string     Backup schedule name
+  -i, --backup-volume-ids strings       Backup volume IDs, as comma separated UUID values. (default [])
+  -e, --enabled                         Is the server backup schedule enabled (default true)
+  -h, --help                            Help for "stackit server backup schedule create"
+  -r, --rrule string                    Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
+  -s, --server-id string                Server ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_server_backup_schedule_update.md
+++ b/docs/stackit_server_backup_schedule_update.md
@@ -23,14 +23,14 @@ stackit server backup schedule update SCHEDULE_ID [flags]
 ### Options
 
 ```
-  -b, --backup-name string            Backup name
-  -d, --backup-retention-period int   Backup retention period (in days) (default 14)
-  -n, --backup-schedule-name string   Backup schedule name
-  -i, --backup-volume-ids strings     Backup volume IDs, as comma separated UUID values. (default [])
-  -e, --enabled                       Is the server backup schedule enabled (default true)
-  -h, --help                          Help for "stackit server backup schedule update"
-  -r, --rrule string                  Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
-  -s, --server-id string              Server ID
+  -b, --backup-name string              Backup name
+  -d, --backup-retention-period int32   Backup retention period (in days) (default 14)
+  -n, --backup-schedule-name string     Backup schedule name
+  -i, --backup-volume-ids strings       Backup volume IDs, as comma separated UUID values. (default [])
+  -e, --enabled                         Is the server backup schedule enabled (default true)
+  -h, --help                            Help for "stackit server backup schedule update"
+  -r, --rrule string                    Backup RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
+  -s, --server-id string                Server ID
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0
 	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1
-	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8
+	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0 h1:T5gy5i+Nxrp
 github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0/go.mod h1:iB27HtF0UcAugURc9w+nlNrtbAj7Mukw/ptAz+7p2WE=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1 h1:U5rstX5e6Am2t+Ukv5K1Sbftzxt5aFALMa9YS4jCJoo=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1/go.mod h1:2XA8PE05Qg6BL2YXO4XgfGI9qskJ3cicLE5Qq0aqDdY=
-github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8 h1:LLyANBzE8sQa0/49tQBqq4sVLhNgwdqCeQm76srJHWw=
-github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8/go.mod h1:/bmg57XZu+bGczzcoumrukiGMPGzI2mOyTT4BVIQUBs=
+github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0 h1:U3bm+RVHD1USpB6Fk9WNfPQxK0x0DY7ubusmRSh/A/8=
+github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0/go.mod h1:BJeafbecuocdirGCAJ2Vz/rPSK/LRrB5lPBEacqd1eU=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2 h1:6C/iTPoYPCrZOc3JMmvyDNs4hm+JR5p9O3DIfFGgnbo=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2/go.mod h1:/OHYZXQb9KXDdZK5J9C2YS6DJUD2i6ednZ1rK7zpDZ0=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0 h1:l1EDIlXce2C8JcbBDHVa6nZ4SjPTqmnALTgrhms+NKI=

--- a/internal/cmd/server/backup/create/create.go
+++ b/internal/cmd/server/backup/create/create.go
@@ -8,6 +8,9 @@ import (
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
+	"github.com/spf13/cobra"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,10 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 )
 
 const (
@@ -36,7 +35,7 @@ type inputModel struct {
 
 	ServerId              string
 	BackupName            string
-	BackupRetentionPeriod int64
+	BackupRetentionPeriod int32
 	BackupVolumeIds       []string
 }
 
@@ -105,7 +104,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
 	cmd.Flags().StringP(backupNameFlag, "b", "", "Backup name")
-	cmd.Flags().Int64P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
+	cmd.Flags().Int32P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
 	cmd.Flags().VarP(flags.UUIDSliceFlag(), backupVolumeIdsFlag, "i", "Backup volume IDs, as comma separated UUID values.")
 
 	err := flags.MarkFlagsRequired(cmd, serverIdFlag, backupNameFlag)
@@ -121,7 +120,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel:       globalFlags,
 		ServerId:              flags.FlagToStringValue(p, cmd, serverIdFlag),
-		BackupRetentionPeriod: flags.FlagWithDefaultToInt64Value(p, cmd, backupRetentionPeriodFlag),
+		BackupRetentionPeriod: flags.FlagWithDefaultToInt32Value(p, cmd, backupRetentionPeriodFlag),
 		BackupName:            flags.FlagToStringValue(p, cmd, backupNameFlag),
 		BackupVolumeIds:       flags.FlagToStringSliceValue(p, cmd, backupVolumeIdsFlag),
 	}
@@ -131,11 +130,11 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) (serverbackup.ApiCreateBackupRequest, error) {
-	req := apiClient.CreateBackup(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.CreateBackup(ctx, model.ProjectId, model.ServerId, model.Region)
 	payload := serverbackup.CreateBackupPayload{
-		Name:            &model.BackupName,
-		RetentionPeriod: &model.BackupRetentionPeriod,
-		VolumeIds:       &model.BackupVolumeIds,
+		Name:            model.BackupName,
+		RetentionPeriod: model.BackupRetentionPeriod,
+		VolumeIds:       model.BackupVolumeIds,
 	}
 	if model.BackupVolumeIds == nil {
 		payload.VolumeIds = nil
@@ -146,7 +145,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverbackup.BackupJob) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Triggered creation of server backup for server %s. Backup ID: %s\n", serverLabel, utils.PtrString(resp.Id))
+		p.Outputf("Triggered creation of server backup for server %s. Backup ID: %s\n", serverLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/backup/create/create_test.go
+++ b/internal/cmd/server/backup/create/create_test.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
@@ -49,7 +48,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		},
 		ServerId:              testServerId,
 		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
+		BackupRetentionPeriod: int32(14),
 		BackupVolumeIds:       []string{testBackupVolumeId},
 	}
 	for _, mod := range mods {
@@ -59,7 +58,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupRequest)) serverbackup.ApiCreateBackupRequest {
-	request := testClient.CreateBackup(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.CreateBackup(testCtx, testProjectId, testServerId, testRegion)
 	request = request.CreateBackupPayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -69,9 +68,9 @@ func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupRequest)) 
 
 func fixturePayload(mods ...func(payload *serverbackup.CreateBackupPayload)) serverbackup.CreateBackupPayload {
 	payload := serverbackup.CreateBackupPayload{
-		Name:            utils.Ptr("example-backup-name"),
-		RetentionPeriod: utils.Ptr(int64(14)),
-		VolumeIds:       utils.Ptr([]string{testBackupVolumeId}),
+		Name:            "example-backup-name",
+		RetentionPeriod: int32(14),
+		VolumeIds:       []string{testBackupVolumeId},
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -164,7 +163,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/delete/delete.go
+++ b/internal/cmd/server/backup/delete/delete.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -101,6 +101,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDeleteBackupRequest {
-	req := apiClient.DeleteBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
+	req := apiClient.DefaultAPI.DeleteBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
 	return req
 }

--- a/internal/cmd/server/backup/delete/delete_test.go
+++ b/internal/cmd/server/backup/delete/delete_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupId = uuid.NewString()
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiDeleteBackupRequest)) serverbackup.ApiDeleteBackupRequest {
-	request := testClient.DeleteBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
+	request := testClient.DefaultAPI.DeleteBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/describe/describe.go
+++ b/internal/cmd/server/backup/describe/describe.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -65,7 +65,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("read server backup: %w", err)
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, *resp)
+			return outputResult(params.Printer, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -98,24 +98,28 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiGetBackupRequest {
-	req := apiClient.GetBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
+	req := apiClient.DefaultAPI.GetBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, backup serverbackup.Backup) error {
+func outputResult(p *print.Printer, outputFormat string, backup *serverbackup.Backup) error {
 	return p.OutputResult(outputFormat, backup, func() error {
+		if backup == nil {
+			return fmt.Errorf("backup is nil")
+		}
+
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(backup.Id))
+		table.AddRow("ID", backup.Id)
 		table.AddSeparator()
-		table.AddRow("NAME", utils.PtrString(backup.Name))
+		table.AddRow("NAME", backup.Name)
 		table.AddSeparator()
 		table.AddRow("SIZE (GB)", utils.PtrString(backup.Size))
 		table.AddSeparator()
-		table.AddRow("STATUS", utils.PtrString(backup.Status))
+		table.AddRow("STATUS", backup.Status)
 		table.AddSeparator()
-		table.AddRow("CREATED AT", utils.PtrString(backup.CreatedAt))
+		table.AddRow("CREATED AT", backup.CreatedAt)
 		table.AddSeparator()
-		table.AddRow("EXPIRES AT", utils.PtrString(backup.ExpireAt))
+		table.AddRow("EXPIRES AT", backup.ExpireAt)
 		table.AddSeparator()
 
 		lastRestored := utils.PtrStringDefault(backup.LastRestoredAt, "")
@@ -123,7 +127,7 @@ func outputResult(p *print.Printer, outputFormat string, backup serverbackup.Bac
 		table.AddSeparator()
 		volBackups := ""
 		if backups := backup.VolumeBackups; backups != nil {
-			volBackups = strconv.Itoa(len(*backups))
+			volBackups = strconv.Itoa(len(backups))
 		}
 		table.AddRow("VOLUME BACKUPS", volBackups)
 		table.AddSeparator()

--- a/internal/cmd/server/backup/describe/describe_test.go
+++ b/internal/cmd/server/backup/describe/describe_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupId = uuid.NewString()
@@ -63,7 +63,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiGetBackupRequest)) serverbackup.ApiGetBackupRequest {
-	request := testClient.GetBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
+	request := testClient.DefaultAPI.GetBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -157,7 +157,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -169,7 +169,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
-		backup       serverbackup.Backup
+		backup       *serverbackup.Backup
 	}
 	tests := []struct {
 		name    string
@@ -177,15 +177,26 @@ func TestOutputResult(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
-			args:    args{},
+			name: "backup is nil",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				backup:       nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				backup:       &serverbackup.Backup{},
+			},
 			wantErr: false,
 		},
 		{
 			name: "output format json",
 			args: args{
 				outputFormat: print.JSONOutputFormat,
-				backup:       serverbackup.Backup{},
+				backup:       &serverbackup.Backup{},
 			},
 			wantErr: false,
 		},

--- a/internal/cmd/server/backup/disable/disable.go
+++ b/internal/cmd/server/backup/disable/disable.go
@@ -18,7 +18,7 @@ import (
 	serverbackupUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -65,7 +65,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				}
 			}
 
-			canDisable, err := serverbackupUtils.CanDisableBackupService(ctx, apiClient, model.ProjectId, model.ServerId, model.Region)
+			canDisable, err := serverbackupUtils.CanDisableBackupService(ctx, apiClient.DefaultAPI, model.ProjectId, model.ServerId, model.Region)
 			if err != nil {
 				return err
 			}
@@ -118,6 +118,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDisableServiceResourceRequest {
-	req := apiClient.DisableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.DisableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }

--- a/internal/cmd/server/backup/disable/disable_test.go
+++ b/internal/cmd/server/backup/disable/disable_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testRegion = "eu01"
@@ -49,7 +49,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiDisableServiceResourceRequest)) serverbackup.ApiDisableServiceResourceRequest {
-	request := testClient.DisableServiceResource(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.DisableServiceResource(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -131,7 +131,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/enable/enable.go
+++ b/internal/cmd/server/backup/enable/enable.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -112,6 +112,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiEnableServiceResourceRequest {
 	payload := serverbackup.EnableServiceResourcePayload{}
-	req := apiClient.EnableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region).EnableServiceResourcePayload(payload)
+	req := apiClient.DefaultAPI.EnableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region).EnableServiceResourcePayload(payload)
 	return req
 }

--- a/internal/cmd/server/backup/enable/enable_test.go
+++ b/internal/cmd/server/backup/enable/enable_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testRegion = "eu01"
@@ -49,7 +49,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiEnableServiceResourceRequest)) serverbackup.ApiEnableServiceResourceRequest {
-	request := testClient.EnableServiceResource(testCtx, testProjectId, testServerId, testRegion).EnableServiceResourcePayload(serverbackup.EnableServiceResourcePayload{})
+	request := testClient.DefaultAPI.EnableServiceResource(testCtx, testProjectId, testServerId, testRegion).EnableServiceResourcePayload(serverbackup.EnableServiceResourcePayload{})
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -131,7 +131,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/list/list.go
+++ b/internal/cmd/server/backup/list/list.go
@@ -9,7 +9,7 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,7 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiListBackupsRequest {
-	req := apiClient.ListBackups(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.ListBackups(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }
 
@@ -134,24 +134,23 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, backups []
 			p.Outputf("No backups found for server %s\n", serverLabel)
 			return nil
 		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "NAME", "SIZE (GB)", "STATUS", "CREATED AT", "EXPIRES AT", "LAST RESTORED AT", "VOLUME BACKUPS")
-		for i := range backups {
-			s := backups[i]
-
-			lastRestored := utils.PtrStringDefault(s.LastRestoredAt, "")
+		for _, s := range backups {
 			var volBackups int
 			if s.VolumeBackups != nil {
-				volBackups = len(*s.VolumeBackups)
+				volBackups = len(s.VolumeBackups)
 			}
+
 			table.AddRow(
-				utils.PtrString(s.Id),
-				utils.PtrString(s.Name),
+				s.Id,
+				s.Name,
 				utils.PtrString(s.Size),
-				utils.PtrString(s.Status),
-				utils.PtrString(s.CreatedAt),
-				utils.PtrString(s.ExpireAt),
-				lastRestored,
+				s.Status,
+				s.CreatedAt,
+				s.ExpireAt,
+				utils.PtrString(s.LastRestoredAt),
 				volBackups,
 			)
 		}

--- a/internal/cmd/server/backup/list/list_test.go
+++ b/internal/cmd/server/backup/list/list_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testRegion = "eu01"
@@ -53,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiListBackupsRequest)) serverbackup.ApiListBackupsRequest {
-	request := testClient.ListBackups(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.ListBackups(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -142,7 +142,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/restore/restore.go
+++ b/internal/cmd/server/backup/restore/restore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -114,10 +114,10 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiRestoreBackupRequest {
-	req := apiClient.RestoreBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
+	req := apiClient.DefaultAPI.RestoreBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId)
 	payload := serverbackup.RestoreBackupPayload{
-		StartServerAfterRestore: &model.StartServerAfterRestore,
-		VolumeIds:               &model.BackupVolumeIds,
+		StartServerAfterRestore: model.StartServerAfterRestore,
+		VolumeIds:               model.BackupVolumeIds,
 	}
 	if model.BackupVolumeIds == nil {
 		payload.VolumeIds = nil

--- a/internal/cmd/server/backup/restore/restore_test.go
+++ b/internal/cmd/server/backup/restore/restore_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupId = uuid.NewString()
@@ -61,9 +61,8 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiRestoreBackupRequest)) serverbackup.ApiRestoreBackupRequest {
-	request := testClient.RestoreBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
-	startServerAfterRestore := false
-	request = request.RestoreBackupPayload(serverbackup.RestoreBackupPayload{StartServerAfterRestore: &startServerAfterRestore})
+	request := testClient.DefaultAPI.RestoreBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId)
+	request = request.RestoreBackupPayload(serverbackup.RestoreBackupPayload{StartServerAfterRestore: false})
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -155,7 +154,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/schedule/create/create.go
+++ b/internal/cmd/server/backup/schedule/create/create.go
@@ -8,6 +8,9 @@ import (
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
+	"github.com/spf13/cobra"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,10 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 )
 
 const (
@@ -44,7 +43,7 @@ type inputModel struct {
 	Enabled               bool
 	Rrule                 string
 	BackupName            string
-	BackupRetentionPeriod int64
+	BackupRetentionPeriod int32
 	BackupVolumeIds       []string
 }
 
@@ -114,7 +113,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
 	cmd.Flags().StringP(backupScheduleNameFlag, "n", "", "Backup schedule name")
 	cmd.Flags().StringP(backupNameFlag, "b", "", "Backup name")
-	cmd.Flags().Int64P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
+	cmd.Flags().Int32P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
 	cmd.Flags().BoolP(enabledFlag, "e", defaultEnabled, "Is the server backup schedule enabled")
 	cmd.Flags().StringP(rruleFlag, "r", defaultRrule, "Backup RRULE (recurrence rule)")
 	cmd.Flags().VarP(flags.UUIDSliceFlag(), backupVolumeIdsFlag, "i", "Backup volume IDs, as comma separated UUID values.")
@@ -132,7 +131,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel:       globalFlags,
 		ServerId:              flags.FlagToStringValue(p, cmd, serverIdFlag),
-		BackupRetentionPeriod: flags.FlagWithDefaultToInt64Value(p, cmd, backupRetentionPeriodFlag),
+		BackupRetentionPeriod: flags.FlagWithDefaultToInt32Value(p, cmd, backupRetentionPeriodFlag),
 		BackupScheduleName:    flags.FlagToStringValue(p, cmd, backupScheduleNameFlag),
 		BackupName:            flags.FlagToStringValue(p, cmd, backupNameFlag),
 		Rrule:                 flags.FlagWithDefaultToStringValue(p, cmd, rruleFlag),
@@ -145,19 +144,19 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) (serverbackup.ApiCreateBackupScheduleRequest, error) {
-	req := apiClient.CreateBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.CreateBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region)
 	backupProperties := serverbackup.BackupProperties{
-		Name:            &model.BackupName,
-		RetentionPeriod: &model.BackupRetentionPeriod,
-		VolumeIds:       &model.BackupVolumeIds,
+		Name:            model.BackupName,
+		RetentionPeriod: model.BackupRetentionPeriod,
+		VolumeIds:       model.BackupVolumeIds,
 	}
 	if model.BackupVolumeIds == nil {
 		backupProperties.VolumeIds = nil
 	}
 	req = req.CreateBackupSchedulePayload(serverbackup.CreateBackupSchedulePayload{
-		Enabled:          &model.Enabled,
-		Name:             &model.BackupScheduleName,
-		Rrule:            &model.Rrule,
+		Enabled:          model.Enabled,
+		Name:             model.BackupScheduleName,
+		Rrule:            model.Rrule,
 		BackupProperties: &backupProperties,
 	})
 	return req, nil
@@ -165,7 +164,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverbackup.BackupSchedule) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Created server backup schedule for server %s. Backup Schedule ID: %s\n", serverLabel, utils.PtrString(resp.Id))
+		p.Outputf("Created server backup schedule for server %s. Backup Schedule ID: %d\n", serverLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/backup/schedule/create/create_test.go
+++ b/internal/cmd/server/backup/schedule/create/create_test.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
@@ -55,7 +54,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		Enabled:               defaultEnabled,
 		Rrule:                 defaultRrule,
 		BackupName:            "example-backup-name",
-		BackupRetentionPeriod: int64(14),
+		BackupRetentionPeriod: int32(14),
 		BackupVolumeIds:       []string{testVolumeId},
 	}
 	for _, mod := range mods {
@@ -65,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRequest)) serverbackup.ApiCreateBackupScheduleRequest {
-	request := testClient.CreateBackupSchedule(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.CreateBackupSchedule(testCtx, testProjectId, testServerId, testRegion)
 	request = request.CreateBackupSchedulePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -75,13 +74,13 @@ func fixtureRequest(mods ...func(request *serverbackup.ApiCreateBackupScheduleRe
 
 func fixturePayload(mods ...func(payload *serverbackup.CreateBackupSchedulePayload)) serverbackup.CreateBackupSchedulePayload {
 	payload := serverbackup.CreateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
+		Name:    "example-backup-schedule-name",
+		Enabled: defaultEnabled,
+		Rrule:   "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1",
 		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
+			Name:            "example-backup-name",
+			RetentionPeriod: int32(14),
+			VolumeIds:       []string{testVolumeId},
 		},
 	}
 	for _, mod := range mods {
@@ -175,7 +174,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/schedule/delete/delete.go
+++ b/internal/cmd/server/backup/schedule/delete/delete.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -113,6 +113,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDeleteBackupScheduleRequest {
-	req := apiClient.DeleteBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.ScheduleId)
+	req := apiClient.DefaultAPI.DeleteBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.ScheduleId)
 	return req
 }

--- a/internal/cmd/server/backup/schedule/delete/delete_test.go
+++ b/internal/cmd/server/backup/schedule/delete/delete_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupScheduleId = "5"
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiDeleteBackupScheduleRequest)) serverbackup.ApiDeleteBackupScheduleRequest {
-	request := testClient.DeleteBackupSchedule(testCtx, testProjectId, testServerId, testRegion, testBackupScheduleId)
+	request := testClient.DefaultAPI.DeleteBackupSchedule(testCtx, testProjectId, testServerId, testRegion, testBackupScheduleId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -153,7 +153,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/schedule/describe/describe.go
+++ b/internal/cmd/server/backup/schedule/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -97,28 +97,28 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiGetBackupScheduleRequest {
-	req := apiClient.GetBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId)
+	req := apiClient.DefaultAPI.GetBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId)
 	return req
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedule serverbackup.BackupSchedule) error {
 	return p.OutputResult(outputFormat, schedule, func() error {
 		table := tables.NewTable()
-		table.AddRow("SCHEDULE ID", utils.PtrString(schedule.Id))
+		table.AddRow("SCHEDULE ID", schedule.Id)
 		table.AddSeparator()
-		table.AddRow("SCHEDULE NAME", utils.PtrString(schedule.Name))
+		table.AddRow("SCHEDULE NAME", schedule.Name)
 		table.AddSeparator()
-		table.AddRow("ENABLED", utils.PtrString(schedule.Enabled))
+		table.AddRow("ENABLED", schedule.Enabled)
 		table.AddSeparator()
-		table.AddRow("RRULE", utils.PtrString(schedule.Rrule))
+		table.AddRow("RRULE", schedule.Rrule)
 		table.AddSeparator()
 		if schedule.BackupProperties != nil {
-			table.AddRow("BACKUP NAME", utils.PtrString(schedule.BackupProperties.Name))
+			table.AddRow("BACKUP NAME", schedule.BackupProperties.Name)
 			table.AddSeparator()
-			table.AddRow("BACKUP RETENTION DAYS", utils.PtrString(schedule.BackupProperties.RetentionPeriod))
+			table.AddRow("BACKUP RETENTION DAYS", schedule.BackupProperties.RetentionPeriod)
 			table.AddSeparator()
 			ids := schedule.BackupProperties.VolumeIds
-			table.AddRow("BACKUP VOLUME IDS", utils.JoinStringPtr(ids, "\n"))
+			table.AddRow("BACKUP VOLUME IDS", utils.JoinStringPtr(&ids, "\n"))
 		}
 		err := table.Display(p)
 		if err != nil {

--- a/internal/cmd/server/backup/schedule/describe/describe_test.go
+++ b/internal/cmd/server/backup/schedule/describe/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
@@ -17,7 +17,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupScheduleId = "5"
@@ -62,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiGetBackupScheduleRequest)) serverbackup.ApiGetBackupScheduleRequest {
-	request := testClient.GetBackupSchedule(testCtx, testProjectId, testServerId, testRegion, testBackupScheduleId)
+	request := testClient.DefaultAPI.GetBackupSchedule(testCtx, testProjectId, testServerId, testRegion, testBackupScheduleId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -156,7 +156,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -211,7 +211,7 @@ func TestOutputResult(t *testing.T) {
 			args: args{
 				schedule: serverbackup.BackupSchedule{
 					BackupProperties: &serverbackup.BackupProperties{
-						VolumeIds: &[]string{},
+						VolumeIds: []string{},
 					},
 				},
 			},

--- a/internal/cmd/server/backup/schedule/list/list.go
+++ b/internal/cmd/server/backup/schedule/list/list.go
@@ -9,7 +9,7 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -124,7 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiListBackupSchedulesRequest {
-	req := apiClient.ListBackupSchedules(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.ListBackupSchedules(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }
 
@@ -143,16 +143,16 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, schedules 
 			retentionPeriod := ""
 			ids := ""
 			if s.BackupProperties != nil {
-				backupName = utils.PtrString(s.BackupProperties.Name)
-				retentionPeriod = utils.PtrString(s.BackupProperties.RetentionPeriod)
+				backupName = s.BackupProperties.Name
+				retentionPeriod = string(s.BackupProperties.RetentionPeriod)
 
-				ids = utils.JoinStringPtr(s.BackupProperties.VolumeIds, ",")
+				ids = utils.JoinStringPtr(&s.BackupProperties.VolumeIds, ",")
 			}
 			table.AddRow(
-				utils.PtrString(s.Id),
-				utils.PtrString(s.Name),
-				utils.PtrString(s.Enabled),
-				utils.PtrString(s.Rrule),
+				s.Id,
+				s.Name,
+				s.Enabled,
+				s.Rrule,
 				backupName,
 				retentionPeriod,
 				ids,

--- a/internal/cmd/server/backup/schedule/list/list_test.go
+++ b/internal/cmd/server/backup/schedule/list/list_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testRegion = "eu01"
@@ -54,7 +54,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiListBackupSchedulesRequest)) serverbackup.ApiListBackupSchedulesRequest {
-	request := testClient.ListBackupSchedules(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.ListBackupSchedules(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -143,7 +143,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/schedule/update/update.go
+++ b/internal/cmd/server/backup/schedule/update/update.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -13,10 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverbackup/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 )
 
 const (
@@ -44,7 +43,7 @@ type inputModel struct {
 	Enabled               *bool
 	Rrule                 *string
 	BackupName            *string
-	BackupRetentionPeriod *int64
+	BackupRetentionPeriod *int32
 	BackupVolumeIds       []string
 }
 
@@ -76,7 +75,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			currentBackupSchedule, err := apiClient.GetBackupScheduleExecute(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId)
+			currentBackupSchedule, err := apiClient.DefaultAPI.GetBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get current server backup schedule: %v", err)
 				return err
@@ -110,7 +109,7 @@ func configureFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringP(backupScheduleNameFlag, "n", "", "Backup schedule name")
 	cmd.Flags().StringP(backupNameFlag, "b", "", "Backup name")
-	cmd.Flags().Int64P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
+	cmd.Flags().Int32P(backupRetentionPeriodFlag, "d", defaultRetentionPeriod, "Backup retention period (in days)")
 	cmd.Flags().BoolP(enabledFlag, "e", defaultEnabled, "Is the server backup schedule enabled")
 	cmd.Flags().StringP(rruleFlag, "r", defaultRrule, "Backup RRULE (recurrence rule)")
 	cmd.Flags().VarP(flags.UUIDSliceFlag(), backupVolumeIdsFlag, "i", "Backup volume IDs, as comma separated UUID values.")
@@ -131,7 +130,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		GlobalFlagModel:       globalFlags,
 		BackupScheduleId:      scheduleId,
 		ServerId:              flags.FlagToStringValue(p, cmd, serverIdFlag),
-		BackupRetentionPeriod: flags.FlagToInt64Pointer(p, cmd, backupRetentionPeriodFlag),
+		BackupRetentionPeriod: flags.FlagToInt32Pointer(p, cmd, backupRetentionPeriodFlag),
 		BackupScheduleName:    flags.FlagToStringPointer(p, cmd, backupScheduleNameFlag),
 		BackupName:            flags.FlagToStringPointer(p, cmd, backupNameFlag),
 		Rrule:                 flags.FlagToStringPointer(p, cmd, rruleFlag),
@@ -144,25 +143,25 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient, old serverbackup.BackupSchedule) (serverbackup.ApiUpdateBackupScheduleRequest, error) {
-	req := apiClient.UpdateBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId)
+	req := apiClient.DefaultAPI.UpdateBackupSchedule(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupScheduleId)
 
 	if model.BackupName != nil {
-		old.BackupProperties.Name = model.BackupName
+		old.BackupProperties.Name = *model.BackupName
 	}
 	if model.BackupRetentionPeriod != nil {
-		old.BackupProperties.RetentionPeriod = model.BackupRetentionPeriod
+		old.BackupProperties.RetentionPeriod = *model.BackupRetentionPeriod
 	}
 	if model.BackupVolumeIds != nil {
-		old.BackupProperties.VolumeIds = &model.BackupVolumeIds
+		old.BackupProperties.VolumeIds = model.BackupVolumeIds
 	}
 	if model.Enabled != nil {
-		old.Enabled = model.Enabled
+		old.Enabled = *model.Enabled
 	}
 	if model.BackupScheduleName != nil {
-		old.Name = model.BackupScheduleName
+		old.Name = *model.BackupScheduleName
 	}
 	if model.Rrule != nil {
-		old.Rrule = model.Rrule
+		old.Rrule = *model.Rrule
 	}
 
 	req = req.UpdateBackupSchedulePayload(serverbackup.UpdateBackupSchedulePayload{
@@ -176,7 +175,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbacku
 
 func outputResult(p *print.Printer, outputFormat string, resp serverbackup.BackupSchedule) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Info("Updated server backup schedule %s\n", utils.PtrString(resp.Id))
+		p.Outputf("Updated server backup schedule %d\n", resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/backup/schedule/update/update_test.go
+++ b/internal/cmd/server/backup/schedule/update/update_test.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -12,22 +11,22 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testVolumeId = uuid.NewString()
-var testBackupScheduleId = "5"
+var testBackupScheduleId = int32(5)
 var testRegion = "eu01"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
-		testBackupScheduleId,
+		string(testBackupScheduleId),
 	}
 	for _, mod := range mods {
 		mod(argValues)
@@ -60,13 +59,13 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		BackupScheduleId:      testBackupScheduleId,
+		BackupScheduleId:      string(testBackupScheduleId),
 		ServerId:              testServerId,
 		BackupScheduleName:    utils.Ptr("example-backup-schedule-name"),
 		Enabled:               utils.Ptr(defaultEnabled),
 		Rrule:                 utils.Ptr(defaultRrule),
 		BackupName:            utils.Ptr("example-backup-name"),
-		BackupRetentionPeriod: utils.Ptr(int64(14)),
+		BackupRetentionPeriod: utils.Ptr(int32(14)),
 		BackupVolumeIds:       []string{testVolumeId},
 	}
 	for _, mod := range mods {
@@ -76,16 +75,15 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureBackupSchedule(mods ...func(schedule *serverbackup.BackupSchedule)) *serverbackup.BackupSchedule {
-	id, _ := strconv.ParseInt(testBackupScheduleId, 10, 64)
 	schedule := &serverbackup.BackupSchedule{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Id:      utils.Ptr(id),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr(defaultRrule),
+		Name:    "example-backup-schedule-name",
+		Id:      testBackupScheduleId,
+		Enabled: defaultEnabled,
+		Rrule:   defaultRrule,
 		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
+			Name:            "example-backup-name",
+			RetentionPeriod: int32(14),
+			VolumeIds:       []string{testVolumeId},
 		},
 	}
 	for _, mod := range mods {
@@ -96,13 +94,13 @@ func fixtureBackupSchedule(mods ...func(schedule *serverbackup.BackupSchedule)) 
 
 func fixturePayload(mods ...func(payload *serverbackup.UpdateBackupSchedulePayload)) serverbackup.UpdateBackupSchedulePayload {
 	payload := serverbackup.UpdateBackupSchedulePayload{
-		Name:    utils.Ptr("example-backup-schedule-name"),
-		Enabled: utils.Ptr(defaultEnabled),
-		Rrule:   utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
+		Name:    "example-backup-schedule-name",
+		Enabled: defaultEnabled,
+		Rrule:   "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1",
 		BackupProperties: &serverbackup.BackupProperties{
-			Name:            utils.Ptr("example-backup-name"),
-			RetentionPeriod: utils.Ptr(int64(14)),
-			VolumeIds:       utils.Ptr([]string{testVolumeId}),
+			Name:            "example-backup-name",
+			RetentionPeriod: int32(14),
+			VolumeIds:       []string{testVolumeId},
 		},
 	}
 	for _, mod := range mods {
@@ -112,7 +110,7 @@ func fixturePayload(mods ...func(payload *serverbackup.UpdateBackupSchedulePaylo
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiUpdateBackupScheduleRequest)) serverbackup.ApiUpdateBackupScheduleRequest {
-	request := testClient.UpdateBackupSchedule(testCtx, testProjectId, testServerId, testRegion, testBackupScheduleId)
+	request := testClient.DefaultAPI.UpdateBackupSchedule(testCtx, testProjectId, testServerId, testRegion, string(testBackupScheduleId))
 	request = request.UpdateBackupSchedulePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -269,7 +267,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/volume-backup/delete/delete.go
+++ b/internal/cmd/server/backup/volume-backup/delete/delete.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -105,6 +105,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiDeleteVolumeBackupRequest {
-	req := apiClient.DeleteVolumeBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId, model.VolumeId)
+	req := apiClient.DefaultAPI.DeleteVolumeBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId, model.VolumeId)
 	return req
 }

--- a/internal/cmd/server/backup/volume-backup/delete/delete_test.go
+++ b/internal/cmd/server/backup/volume-backup/delete/delete_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupId = uuid.NewString()
@@ -64,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiDeleteVolumeBackupRequest)) serverbackup.ApiDeleteVolumeBackupRequest {
-	request := testClient.DeleteVolumeBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId, testVolumeId)
+	request := testClient.DefaultAPI.DeleteVolumeBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId, testVolumeId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -156,7 +156,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/backup/volume-backup/restore/restore.go
+++ b/internal/cmd/server/backup/volume-backup/restore/restore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 const (
@@ -109,9 +109,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverbackup.APIClient) serverbackup.ApiRestoreVolumeBackupRequest {
-	req := apiClient.RestoreVolumeBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId, model.VolumeBackupId)
+	req := apiClient.DefaultAPI.RestoreVolumeBackup(ctx, model.ProjectId, model.ServerId, model.Region, model.BackupId, model.VolumeBackupId)
 	payload := serverbackup.RestoreVolumeBackupPayload{
-		RestoreVolumeId: &model.RestoreVolumeId,
+		RestoreVolumeId: model.RestoreVolumeId,
 	}
 	req = req.RestoreVolumeBackupPayload(payload)
 	return req

--- a/internal/cmd/server/backup/volume-backup/restore/restore_test.go
+++ b/internal/cmd/server/backup/volume-backup/restore/restore_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverbackup.APIClient{}
+var testClient = &serverbackup.APIClient{DefaultAPI: &serverbackup.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testBackupId = uuid.NewString()
@@ -67,9 +67,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverbackup.ApiRestoreVolumeBackupRequest)) serverbackup.ApiRestoreVolumeBackupRequest {
-	request := testClient.RestoreVolumeBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId, testVolumeBackupId)
+	request := testClient.DefaultAPI.RestoreVolumeBackup(testCtx, testProjectId, testServerId, testRegion, testBackupId, testVolumeBackupId)
 	request = request.RestoreVolumeBackupPayload(serverbackup.RestoreVolumeBackupPayload{
-		RestoreVolumeId: &testRestoreVolumeId,
+		RestoreVolumeId: testRestoreVolumeId,
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -162,7 +162,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverbackup.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/serverbackup/client/client.go
+++ b/internal/pkg/services/serverbackup/client/client.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serverbackup.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServerBackupCustomEndpointKey), true, genericclient.CreateApiClient[*serverbackup.APIClient](serverbackup.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServerBackupCustomEndpointKey), false, genericclient.CreateApiClient[*serverbackup.APIClient](serverbackup.NewAPIClient))
 }

--- a/internal/pkg/services/serverbackup/utils/utils.go
+++ b/internal/pkg/services/serverbackup/utils/utils.go
@@ -4,28 +4,23 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
 
-type ServerBackupClient interface {
-	ListBackupSchedulesExecute(ctx context.Context, projectId, serverId, region string) (*serverbackup.GetBackupSchedulesResponse, error)
-	ListBackupsExecute(ctx context.Context, projectId, serverId, region string) (*serverbackup.GetBackupsListResponse, error)
-}
-
-func CanDisableBackupService(ctx context.Context, client ServerBackupClient, projectId, serverId, region string) (bool, error) {
-	schedules, err := client.ListBackupSchedulesExecute(ctx, projectId, serverId, region)
+func CanDisableBackupService(ctx context.Context, client serverbackup.DefaultAPI, projectId, serverId, region string) (bool, error) {
+	schedules, err := client.ListBackupSchedules(ctx, projectId, serverId, region).Execute()
 	if err != nil {
 		return false, fmt.Errorf("list backup schedules: %w", err)
 	}
-	if len(*schedules.Items) > 0 {
+	if len(schedules.Items) > 0 {
 		return false, nil
 	}
 
-	backups, err := client.ListBackupsExecute(ctx, projectId, serverId, region)
+	backups, err := client.ListBackups(ctx, projectId, serverId, region).Execute()
 	if err != nil {
 		return false, fmt.Errorf("list backups: %w", err)
 	}
-	if len(*backups.Items) > 0 {
+	if len(backups.Items) > 0 {
 		return false, nil
 	}
 

--- a/internal/pkg/services/serverbackup/utils/utils_test.go
+++ b/internal/pkg/services/serverbackup/utils/utils_test.go
@@ -8,108 +8,119 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 )
+
+const testRegion = "eu01"
 
 var (
 	testProjectId = uuid.NewString()
 	testServerId  = uuid.NewString()
-	testRegion    = "eu01"
 )
 
-type serverbackupClientMocked struct {
+type mockSettings struct {
 	listBackupSchedulesFails bool
 	listBackupSchedulesResp  *serverbackup.GetBackupSchedulesResponse
 	listBackupsFails         bool
 	listBackupsResp          *serverbackup.GetBackupsListResponse
 }
 
-func (m *serverbackupClientMocked) ListBackupSchedulesExecute(_ context.Context, _, _, _ string) (*serverbackup.GetBackupSchedulesResponse, error) {
-	if m.listBackupSchedulesFails {
-		return nil, fmt.Errorf("could not list backup schedules")
+func newServerbackupClientMock(s mockSettings) serverbackup.DefaultAPI {
+	return &serverbackup.DefaultAPIServiceMock{
+		ListBackupSchedulesExecuteMock: utils.Ptr(func(_ serverbackup.ApiListBackupSchedulesRequest) (*serverbackup.GetBackupSchedulesResponse, error) {
+			if s.listBackupSchedulesFails {
+				return nil, fmt.Errorf("could not list backup schedules")
+			}
+			return s.listBackupSchedulesResp, nil
+		}),
+		ListBackupsExecuteMock: utils.Ptr(func(_ serverbackup.ApiListBackupsRequest) (*serverbackup.GetBackupsListResponse, error) {
+			if s.listBackupsFails {
+				return nil, fmt.Errorf("could not list backups")
+			}
+			return s.listBackupsResp, nil
+		}),
 	}
-	return m.listBackupSchedulesResp, nil
-}
-
-func (m *serverbackupClientMocked) ListBackupsExecute(_ context.Context, _, _, _ string) (*serverbackup.GetBackupsListResponse, error) {
-	if m.listBackupsFails {
-		return nil, fmt.Errorf("could not list backups")
-	}
-	return m.listBackupsResp, nil
 }
 
 func TestCanDisableBackupService(t *testing.T) {
 	tests := []struct {
-		description              string
-		listBackupsFails         bool
-		listBackupSchedulesFails bool
-		listBackups              *serverbackup.GetBackupsListResponse
-		listBackupSchedules      *serverbackup.GetBackupSchedulesResponse
-		isValid                  bool // isValid ==> err == nil
-		expectedOutput           bool // expectedCanDisable
+		description    string
+		mockSettings   mockSettings
+		isValid        bool // isValid ==> err == nil
+		expectedOutput bool // expectedCanDisable
 	}{
 		{
-			description:              "base-ok-can-disable-backups-service-no-backups-no-backup-schedules",
-			listBackupsFails:         false,
-			listBackupSchedulesFails: false,
-			listBackups:              &serverbackup.GetBackupsListResponse{Items: &[]serverbackup.Backup{}},
-			listBackupSchedules:      &serverbackup.GetBackupSchedulesResponse{Items: &[]serverbackup.BackupSchedule{}},
-			isValid:                  true,
-			expectedOutput:           true,
+			description: "base-ok-can-disable-backups-service-no-backups-no-backup-schedules",
+			mockSettings: mockSettings{
+				listBackupsFails:         false,
+				listBackupSchedulesFails: false,
+				listBackupsResp:          &serverbackup.GetBackupsListResponse{Items: []serverbackup.Backup{}},
+				listBackupSchedulesResp:  &serverbackup.GetBackupSchedulesResponse{Items: []serverbackup.BackupSchedule{}},
+			},
+			isValid:        true,
+			expectedOutput: true,
 		},
 		{
-			description:              "not-ok-api-error-list-backups",
-			listBackupsFails:         true,
-			listBackupSchedulesFails: false,
-			listBackups:              &serverbackup.GetBackupsListResponse{Items: &[]serverbackup.Backup{}},
-			listBackupSchedules:      &serverbackup.GetBackupSchedulesResponse{Items: &[]serverbackup.BackupSchedule{}},
-			isValid:                  false,
-			expectedOutput:           false,
+			description: "not-ok-api-error-list-backups",
+			mockSettings: mockSettings{
+				listBackupsFails:         true,
+				listBackupSchedulesFails: false,
+				listBackupsResp:          &serverbackup.GetBackupsListResponse{Items: []serverbackup.Backup{}},
+				listBackupSchedulesResp:  &serverbackup.GetBackupSchedulesResponse{Items: []serverbackup.BackupSchedule{}},
+			},
+			isValid:        false,
+			expectedOutput: false,
 		},
 		{
-			description:              "not-ok-api-error-list-backup-schedules",
-			listBackupsFails:         true,
-			listBackupSchedulesFails: false,
-			listBackups:              &serverbackup.GetBackupsListResponse{Items: &[]serverbackup.Backup{}},
-			listBackupSchedules:      &serverbackup.GetBackupSchedulesResponse{Items: &[]serverbackup.BackupSchedule{}},
-			isValid:                  false,
-			expectedOutput:           false,
+			description: "not-ok-api-error-list-backup-schedules",
+			mockSettings: mockSettings{
+				listBackupsFails:         true,
+				listBackupSchedulesFails: false,
+				listBackupsResp:          &serverbackup.GetBackupsListResponse{Items: []serverbackup.Backup{}},
+				listBackupSchedulesResp:  &serverbackup.GetBackupSchedulesResponse{Items: []serverbackup.BackupSchedule{}},
+			},
+			isValid:        false,
+			expectedOutput: false,
 		},
 		{
-			description:              "not-ok-has-backups-cannot-disable",
-			listBackupsFails:         false,
-			listBackupSchedulesFails: false,
-			listBackups: &serverbackup.GetBackupsListResponse{
-				Items: &[]serverbackup.Backup{
-					{
-						CreatedAt:      utils.Ptr("test timestamp"),
-						ExpireAt:       utils.Ptr("test timestamp"),
-						Id:             utils.Ptr("5"),
-						LastRestoredAt: utils.Ptr("test timestamp"),
-						Name:           utils.Ptr("test name"),
-						Size:           utils.Ptr(int64(5)),
-						Status:         serverbackup.BACKUPSTATUS_IN_PROGRESS.Ptr(),
-						VolumeBackups:  nil,
+			description: "not-ok-has-backups-cannot-disable",
+			mockSettings: mockSettings{
+				listBackupsFails:         false,
+				listBackupSchedulesFails: false,
+				listBackupsResp: &serverbackup.GetBackupsListResponse{
+					Items: []serverbackup.Backup{
+						{
+							CreatedAt:      "test timestamp",
+							ExpireAt:       "test timestamp",
+							Id:             "5",
+							LastRestoredAt: utils.Ptr("test timestamp"),
+							Name:           "test name",
+							Size:           utils.Ptr(int32(5)),
+							Status:         serverbackup.BACKUPSTATUS_IN_PROGRESS,
+							VolumeBackups:  nil,
+						},
 					},
 				},
+				listBackupSchedulesResp: &serverbackup.GetBackupSchedulesResponse{Items: []serverbackup.BackupSchedule{}},
 			},
-			listBackupSchedules: &serverbackup.GetBackupSchedulesResponse{Items: &[]serverbackup.BackupSchedule{}},
-			isValid:             true,
-			expectedOutput:      false,
+			isValid:        true,
+			expectedOutput: false,
 		},
 		{
-			description:              "not-ok-has-backups-schedules-cannot-disable",
-			listBackupsFails:         false,
-			listBackupSchedulesFails: false,
-			listBackups:              &serverbackup.GetBackupsListResponse{Items: &[]serverbackup.Backup{}},
-			listBackupSchedules: &serverbackup.GetBackupSchedulesResponse{
-				Items: &[]serverbackup.BackupSchedule{
-					{
-						BackupProperties: nil,
-						Enabled:          utils.Ptr(false),
-						Id:               utils.Ptr(int64(5)),
-						Name:             utils.Ptr("some name"),
-						Rrule:            utils.Ptr("some rrule"),
+			description: "not-ok-has-backups-schedules-cannot-disable",
+			mockSettings: mockSettings{
+				listBackupsFails:         false,
+				listBackupSchedulesFails: false,
+				listBackupsResp:          &serverbackup.GetBackupsListResponse{Items: []serverbackup.Backup{}},
+				listBackupSchedulesResp: &serverbackup.GetBackupSchedulesResponse{
+					Items: []serverbackup.BackupSchedule{
+						{
+							BackupProperties: nil,
+							Enabled:          false,
+							Id:               int32(5),
+							Name:             "some name",
+							Rrule:            "some rrule",
+						},
 					},
 				},
 			},
@@ -120,12 +131,7 @@ func TestCanDisableBackupService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &serverbackupClientMocked{
-				listBackupsFails:         tt.listBackupsFails,
-				listBackupSchedulesFails: tt.listBackupSchedulesFails,
-				listBackupsResp:          tt.listBackups,
-				listBackupSchedulesResp:  tt.listBackupSchedules,
-			}
+			client := newServerbackupClientMock(tt.mockSettings)
 
 			output, err := CanDisableBackupService(context.Background(), client, testProjectId, testServerId, testRegion)
 


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-354

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
