### PR TITLE
chore(serverupdate): switch to new sdk structure

### DIFF
--- a/docs/stackit_server_os-update_create.md
+++ b/docs/stackit_server_os-update_create.md
@@ -23,9 +23,9 @@ stackit server os-update create [flags]
 ### Options
 
 ```
-  -h, --help                     Help for "stackit server os-update create"
-  -m, --maintenance-window int   Maintenance window (in hours, 1-24) (default 23)
-  -s, --server-id string         Server ID
+  -h, --help                       Help for "stackit server os-update create"
+  -m, --maintenance-window int32   Maintenance window (in hours, 1-24) (default 23)
+  -s, --server-id string           Server ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_server_os-update_schedule_create.md
+++ b/docs/stackit_server_os-update_schedule_create.md
@@ -23,12 +23,12 @@ stackit server os-update schedule create [flags]
 ### Options
 
 ```
-  -e, --enabled                  Is the server os-update schedule enabled (default true)
-  -h, --help                     Help for "stackit server os-update schedule create"
-  -d, --maintenance-window int   os-update maintenance window (in hours, 1-24) (default 23)
-  -n, --name string              os-update schedule name
-  -r, --rrule string             os-update RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
-  -s, --server-id string         Server ID
+  -e, --enabled                    Is the server os-update schedule enabled (default true)
+  -h, --help                       Help for "stackit server os-update schedule create"
+  -d, --maintenance-window int32   os-update maintenance window (in hours, 1-24) (default 23)
+  -n, --name string                os-update schedule name
+  -r, --rrule string               os-update RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
+  -s, --server-id string           Server ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/stackit_server_os-update_schedule_update.md
+++ b/docs/stackit_server_os-update_schedule_update.md
@@ -20,12 +20,12 @@ stackit server os-update schedule update SCHEDULE_ID [flags]
 ### Options
 
 ```
-  -e, --enabled                  Is the server os-update schedule enabled (default true)
-  -h, --help                     Help for "stackit server os-update schedule update"
-  -d, --maintenance-window int   Maintenance window (in hours, 1-24) (default 23)
-  -n, --name string              os-update schedule name
-  -r, --rrule string             os-update RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
-  -s, --server-id string         Server ID
+  -e, --enabled                    Is the server os-update schedule enabled (default true)
+  -h, --help                       Help for "stackit server os-update schedule update"
+  -d, --maintenance-window int32   Maintenance window (in hours, 1-24) (default 23)
+  -n, --name string                os-update schedule name
+  -r, --rrule string               os-update RRULE (recurrence rule) (default "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1")
+  -s, --server-id string           Server ID
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/runcommand v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8
-	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6
+	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1 h1:U5rstX
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1/go.mod h1:2XA8PE05Qg6BL2YXO4XgfGI9qskJ3cicLE5Qq0aqDdY=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8 h1:LLyANBzE8sQa0/49tQBqq4sVLhNgwdqCeQm76srJHWw=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8/go.mod h1:/bmg57XZu+bGczzcoumrukiGMPGzI2mOyTT4BVIQUBs=
-github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6 h1:sQ3fdtUjgIL2Ul8nRYVVacHOwi5aSMTGGbYVL30oQBU=
-github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.2.6/go.mod h1:3fjlL+9YtuI9Oocl1ZeYIK48ImtY4DwPggFhqAygr7o=
+github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2 h1:6C/iTPoYPCrZOc3JMmvyDNs4hm+JR5p9O3DIfFGgnbo=
+github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2/go.mod h1:/OHYZXQb9KXDdZK5J9C2YS6DJUD2i6ednZ1rK7zpDZ0=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0 h1:l1EDIlXce2C8JcbBDHVa6nZ4SjPTqmnALTgrhms+NKI=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0/go.mod h1:EXq8/J7t9p8zPmdIq+atuxyAbnQwxrQT18fI+Qpv98k=
 github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7 h1:M2PYLF8k3zmAwYWSKfUiCTNTXr7ROGuJganVVEQA3YI=

--- a/internal/cmd/server/os-update/create/create.go
+++ b/internal/cmd/server/os-update/create/create.go
@@ -8,6 +8,9 @@ import (
 
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
+	"github.com/spf13/cobra"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -16,10 +19,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 )
 
 const (
@@ -32,7 +31,7 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 
 	ServerId          string
-	MaintenanceWindow int64
+	MaintenanceWindow int32
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -90,7 +89,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("create Server os-update: %w", err)
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, serverLabel, *resp)
+			return outputResult(params.Printer, model.OutputFormat, serverLabel, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -99,7 +98,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
-	cmd.Flags().Int64P(maintenanceWindowFlag, "m", defaultMaintenanceWindow, "Maintenance window (in hours, 1-24)")
+	cmd.Flags().Int32P(maintenanceWindowFlag, "m", defaultMaintenanceWindow, "Maintenance window (in hours, 1-24)")
 }
 
 func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, error) {
@@ -111,7 +110,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel:   globalFlags,
 		ServerId:          flags.FlagToStringValue(p, cmd, serverIdFlag),
-		MaintenanceWindow: flags.FlagWithDefaultToInt64Value(p, cmd, maintenanceWindowFlag),
+		MaintenanceWindow: flags.FlagWithDefaultToInt32Value(p, cmd, maintenanceWindowFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -119,17 +118,21 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) (serverupdate.ApiCreateUpdateRequest, error) {
-	req := apiClient.CreateUpdate(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.CreateUpdate(ctx, model.ProjectId, model.ServerId, model.Region)
 	payload := serverupdate.CreateUpdatePayload{
-		MaintenanceWindow: &model.MaintenanceWindow,
+		MaintenanceWindow: model.MaintenanceWindow,
 	}
 	req = req.CreateUpdatePayload(payload)
 	return req, nil
 }
 
-func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverupdate.Update) error {
+func outputResult(p *print.Printer, outputFormat, serverLabel string, resp *serverupdate.Update) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Triggered creation of server os-update for server %s. Update ID: %s\n", serverLabel, utils.PtrString(resp.Id))
+		if resp == nil {
+			return fmt.Errorf("response is nil")
+		}
+
+		p.Outputf("Triggered creation of server os-update for server %s. Update ID: %d\n", serverLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/os-update/create/create_test.go
+++ b/internal/cmd/server/os-update/create/create_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
@@ -48,7 +48,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		ServerId:          testServerId,
-		MaintenanceWindow: int64(13),
+		MaintenanceWindow: int32(13),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiCreateUpdateRequest)) serverupdate.ApiCreateUpdateRequest {
-	request := testClient.CreateUpdate(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.CreateUpdate(testCtx, testProjectId, testServerId, testRegion)
 	request = request.CreateUpdatePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -67,7 +67,7 @@ func fixtureRequest(mods ...func(request *serverupdate.ApiCreateUpdateRequest)) 
 
 func fixturePayload(mods ...func(payload *serverupdate.CreateUpdatePayload)) serverupdate.CreateUpdatePayload {
 	payload := serverupdate.CreateUpdatePayload{
-		MaintenanceWindow: utils.Ptr(int64(13)),
+		MaintenanceWindow: int32(13),
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -162,7 +162,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -175,7 +175,7 @@ func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
 		serverLabel  string
-		resp         serverupdate.Update
+		resp         *serverupdate.Update
 	}
 	tests := []struct {
 		name    string
@@ -183,9 +183,20 @@ func TestOutputResult(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
-			args:    args{},
+			name: "empty",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				resp:         &serverupdate.Update{},
+			},
 			wantErr: false,
+		},
+		{
+			name: "nil",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				resp:         nil,
+			},
+			wantErr: true,
 		},
 	}
 	params := testparams.NewTestParams()

--- a/internal/cmd/server/os-update/describe/describe.go
+++ b/internal/cmd/server/os-update/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -64,7 +64,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("read server os-update: %w", err)
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, *resp)
+			return outputResult(params.Printer, model.OutputFormat, resp)
 		},
 	}
 	configureFlags(cmd)
@@ -97,16 +97,20 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiGetUpdateRequest {
-	req := apiClient.GetUpdate(ctx, model.ProjectId, model.ServerId, model.UpdateId, model.Region)
+	req := apiClient.DefaultAPI.GetUpdate(ctx, model.ProjectId, model.ServerId, model.UpdateId, model.Region)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, update serverupdate.Update) error {
+func outputResult(p *print.Printer, outputFormat string, update *serverupdate.Update) error {
 	return p.OutputResult(outputFormat, update, func() error {
+		if update == nil {
+			return fmt.Errorf("update is nil")
+		}
+
 		table := tables.NewTable()
-		table.AddRow("ID", utils.PtrString(update.Id))
+		table.AddRow("ID", update.Id)
 		table.AddSeparator()
-		table.AddRow("STATUS", utils.PtrString(update.Status))
+		table.AddRow("STATUS", update.Status)
 		table.AddSeparator()
 		installedUpdates := utils.PtrStringDefault(update.InstalledUpdates, "n/a")
 		table.AddRow("INSTALLED UPDATES", installedUpdates)
@@ -114,7 +118,7 @@ func outputResult(p *print.Printer, outputFormat string, update serverupdate.Upd
 		failedUpdates := utils.PtrStringDefault(update.FailedUpdates, "n/a")
 		table.AddRow("FAILED UPDATES", failedUpdates)
 
-		table.AddRow("START DATE", utils.PtrString(update.StartDate))
+		table.AddRow("START DATE", update.StartDate)
 		table.AddSeparator()
 		table.AddRow("END DATE", utils.PtrString(update.EndDate))
 		table.AddSeparator()

--- a/internal/cmd/server/os-update/describe/describe_test.go
+++ b/internal/cmd/server/os-update/describe/describe_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 )
 
 const (
@@ -21,7 +23,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 var testUpdateId = uuid.NewString()
@@ -65,7 +67,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiGetUpdateRequest)) serverupdate.ApiGetUpdateRequest {
-	request := testClient.GetUpdate(testCtx, testProjectId, testServerId, testUpdateId, testRegion)
+	request := testClient.DefaultAPI.GetUpdate(testCtx, testProjectId, testServerId, testUpdateId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -159,7 +161,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -171,7 +173,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat string
-		update       serverupdate.Update
+		update       *serverupdate.Update
 	}
 	tests := []struct {
 		name    string
@@ -179,9 +181,20 @@ func TestOutputResult(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
-			args:    args{},
+			name: "empty",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				update:       &serverupdate.Update{},
+			},
 			wantErr: false,
+		},
+		{
+			name: "nil",
+			args: args{
+				outputFormat: print.PrettyOutputFormat,
+				update:       nil,
+			},
+			wantErr: true,
 		},
 	}
 	params := testparams.NewTestParams()

--- a/internal/cmd/server/os-update/disable/disable.go
+++ b/internal/cmd/server/os-update/disable/disable.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -108,6 +108,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiDisableServiceResourceRequest {
-	req := apiClient.DisableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.DisableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }

--- a/internal/cmd/server/os-update/disable/disable_test.go
+++ b/internal/cmd/server/os-update/disable/disable_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -52,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiDisableServiceResourceRequest)) serverupdate.ApiDisableServiceResourceRequest {
-	request := testClient.DisableServiceResource(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.DisableServiceResource(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -134,7 +134,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/enable/enable.go
+++ b/internal/cmd/server/os-update/enable/enable.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -112,6 +112,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiEnableServiceResourceRequest {
 	payload := serverupdate.EnableServiceResourcePayload{}
-	req := apiClient.EnableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region).EnableServiceResourcePayload(payload)
+	req := apiClient.DefaultAPI.EnableServiceResource(ctx, model.ProjectId, model.ServerId, model.Region).EnableServiceResourcePayload(payload)
 	return req
 }

--- a/internal/cmd/server/os-update/enable/enable_test.go
+++ b/internal/cmd/server/os-update/enable/enable_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -52,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiEnableServiceResourceRequest)) serverupdate.ApiEnableServiceResourceRequest {
-	request := testClient.EnableServiceResource(testCtx, testProjectId, testServerId, testRegion).EnableServiceResourcePayload(serverupdate.EnableServiceResourcePayload{})
+	request := testClient.DefaultAPI.EnableServiceResource(testCtx, testProjectId, testServerId, testRegion).EnableServiceResourcePayload(serverupdate.EnableServiceResourcePayload{})
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -134,7 +134,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/list/list.go
+++ b/internal/cmd/server/os-update/list/list.go
@@ -3,7 +3,6 @@ package list
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
@@ -20,7 +19,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -124,7 +123,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiListUpdatesRequest {
-	req := apiClient.ListUpdates(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.ListUpdates(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }
 
@@ -143,20 +142,20 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, updates []
 
 			installed := "n/a"
 			if s.InstalledUpdates != nil {
-				installed = strconv.FormatInt(*s.InstalledUpdates, 10)
+				installed = utils.PtrString(s.InstalledUpdates)
 			}
 
 			failed := "n/a"
 			if s.FailedUpdates != nil {
-				failed = strconv.FormatInt(*s.FailedUpdates, 10)
+				failed = utils.PtrString(s.FailedUpdates)
 			}
 
 			table.AddRow(
-				utils.PtrString(s.Id),
-				utils.PtrString(s.Status),
+				s.Id,
+				s.Status,
 				installed,
 				failed,
-				utils.PtrString(s.StartDate),
+				s.StartDate,
 				endDate,
 			)
 		}

--- a/internal/cmd/server/os-update/list/list_test.go
+++ b/internal/cmd/server/os-update/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiListUpdatesRequest)) serverupdate.ApiListUpdatesRequest {
-	request := testClient.ListUpdates(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.ListUpdates(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -145,7 +145,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/schedule/create/create.go
+++ b/internal/cmd/server/os-update/schedule/create/create.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,10 +18,6 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 )
 
 const (
@@ -40,7 +39,7 @@ type inputModel struct {
 	ScheduleName      string
 	Enabled           bool
 	Rrule             string
-	MaintenanceWindow int64
+	MaintenanceWindow int32
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -108,7 +107,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
 	cmd.Flags().StringP(nameFlag, "n", "", "os-update schedule name")
-	cmd.Flags().Int64P(maintenanceWindowFlag, "d", defaultMaintenanceWindow, "os-update maintenance window (in hours, 1-24)")
+	cmd.Flags().Int32P(maintenanceWindowFlag, "d", defaultMaintenanceWindow, "os-update maintenance window (in hours, 1-24)")
 	cmd.Flags().BoolP(enabledFlag, "e", defaultEnabled, "Is the server os-update schedule enabled")
 	cmd.Flags().StringP(rruleFlag, "r", defaultRrule, "os-update RRULE (recurrence rule)")
 
@@ -125,7 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel:   globalFlags,
 		ServerId:          flags.FlagToStringValue(p, cmd, serverIdFlag),
-		MaintenanceWindow: flags.FlagWithDefaultToInt64Value(p, cmd, maintenanceWindowFlag),
+		MaintenanceWindow: flags.FlagWithDefaultToInt32Value(p, cmd, maintenanceWindowFlag),
 		ScheduleName:      flags.FlagToStringValue(p, cmd, nameFlag),
 		Rrule:             flags.FlagWithDefaultToStringValue(p, cmd, rruleFlag),
 		Enabled:           flags.FlagToBoolValue(p, cmd, enabledFlag),
@@ -136,19 +135,19 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) (serverupdate.ApiCreateUpdateScheduleRequest, error) {
-	req := apiClient.CreateUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.CreateUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.Region)
 	req = req.CreateUpdateSchedulePayload(serverupdate.CreateUpdateSchedulePayload{
-		Enabled:           &model.Enabled,
-		Name:              &model.ScheduleName,
-		Rrule:             &model.Rrule,
-		MaintenanceWindow: &model.MaintenanceWindow,
+		Enabled:           model.Enabled,
+		Name:              model.ScheduleName,
+		Rrule:             model.Rrule,
+		MaintenanceWindow: model.MaintenanceWindow,
 	})
 	return req, nil
 }
 
 func outputResult(p *print.Printer, outputFormat, serverLabel string, resp serverupdate.UpdateSchedule) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Outputf("Created server os-update schedule for server %s. os-update Schedule ID: %s\n", serverLabel, utils.PtrString(resp.Id))
+		p.Outputf("Created server os-update schedule for server %s. os-update Schedule ID: %d\n", serverLabel, resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/os-update/schedule/create/create_test.go
+++ b/internal/cmd/server/os-update/schedule/create/create_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 const (
@@ -22,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
@@ -54,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 		ScheduleName:      "example-schedule-name",
 		Enabled:           defaultEnabled,
 		Rrule:             defaultRrule,
-		MaintenanceWindow: int64(23),
+		MaintenanceWindow: int32(23),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -63,7 +62,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiCreateUpdateScheduleRequest)) serverupdate.ApiCreateUpdateScheduleRequest {
-	request := testClient.CreateUpdateSchedule(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.CreateUpdateSchedule(testCtx, testProjectId, testServerId, testRegion)
 	request = request.CreateUpdateSchedulePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -73,10 +72,10 @@ func fixtureRequest(mods ...func(request *serverupdate.ApiCreateUpdateScheduleRe
 
 func fixturePayload(mods ...func(payload *serverupdate.CreateUpdateSchedulePayload)) serverupdate.CreateUpdateSchedulePayload {
 	payload := serverupdate.CreateUpdateSchedulePayload{
-		Name:              utils.Ptr("example-schedule-name"),
-		Enabled:           utils.Ptr(defaultEnabled),
-		Rrule:             utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		MaintenanceWindow: utils.Ptr(int64(23)),
+		Name:              "example-schedule-name",
+		Enabled:           defaultEnabled,
+		Rrule:             "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1",
+		MaintenanceWindow: int32(23),
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -169,7 +168,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/schedule/delete/delete.go
+++ b/internal/cmd/server/os-update/schedule/delete/delete.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -100,6 +100,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiDeleteUpdateScheduleRequest {
-	req := apiClient.DeleteUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
+	req := apiClient.DefaultAPI.DeleteUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
 	return req
 }

--- a/internal/cmd/server/os-update/schedule/delete/delete_test.go
+++ b/internal/cmd/server/os-update/schedule/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -64,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiDeleteUpdateScheduleRequest)) serverupdate.ApiDeleteUpdateScheduleRequest {
-	request := testClient.DeleteUpdateSchedule(testCtx, testProjectId, testServerId, testUpdateScheduleId, testRegion)
+	request := testClient.DefaultAPI.DeleteUpdateSchedule(testCtx, testProjectId, testServerId, testUpdateScheduleId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -156,7 +156,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/schedule/describe/describe.go
+++ b/internal/cmd/server/os-update/schedule/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -17,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -97,22 +96,22 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiGetUpdateScheduleRequest {
-	req := apiClient.GetUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
+	req := apiClient.DefaultAPI.GetUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
 	return req
 }
 
 func outputResult(p *print.Printer, outputFormat string, schedule serverupdate.UpdateSchedule) error {
 	return p.OutputResult(outputFormat, schedule, func() error {
 		table := tables.NewTable()
-		table.AddRow("SCHEDULE ID", utils.PtrString(schedule.Id))
+		table.AddRow("SCHEDULE ID", schedule.Id)
 		table.AddSeparator()
-		table.AddRow("SCHEDULE NAME", utils.PtrString(schedule.Name))
+		table.AddRow("SCHEDULE NAME", schedule.Name)
 		table.AddSeparator()
-		table.AddRow("ENABLED", utils.PtrString(schedule.Enabled))
+		table.AddRow("ENABLED", schedule.Enabled)
 		table.AddSeparator()
-		table.AddRow("RRULE", utils.PtrString(schedule.Rrule))
+		table.AddRow("RRULE", schedule.Rrule)
 		table.AddSeparator()
-		table.AddRow("MAINTENANCE WINDOW", utils.PtrString(schedule.MaintenanceWindow))
+		table.AddRow("MAINTENANCE WINDOW", schedule.MaintenanceWindow)
 		table.AddSeparator()
 
 		err := table.Display(p)

--- a/internal/cmd/server/os-update/schedule/describe/describe_test.go
+++ b/internal/cmd/server/os-update/schedule/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -65,7 +65,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiGetUpdateScheduleRequest)) serverupdate.ApiGetUpdateScheduleRequest {
-	request := testClient.GetUpdateSchedule(testCtx, testProjectId, testServerId, testScheduleId, testRegion)
+	request := testClient.DefaultAPI.GetUpdateSchedule(testCtx, testProjectId, testServerId, testScheduleId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -159,7 +159,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/schedule/list/list.go
+++ b/internal/cmd/server/os-update/schedule/list/list.go
@@ -9,7 +9,7 @@ import (
 	iaasClient "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -20,7 +20,6 @@ import (
 	iaasUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/iaas/utils"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -125,7 +124,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient) serverupdate.ApiListUpdateSchedulesRequest {
-	req := apiClient.ListUpdateSchedules(ctx, model.ProjectId, model.ServerId, model.Region)
+	req := apiClient.DefaultAPI.ListUpdateSchedules(ctx, model.ProjectId, model.ServerId, model.Region)
 	return req
 }
 
@@ -140,11 +139,11 @@ func outputResult(p *print.Printer, outputFormat, serverLabel string, schedules 
 		for i := range schedules {
 			s := schedules[i]
 			table.AddRow(
-				utils.PtrString(s.Id),
-				utils.PtrString(s.Name),
-				utils.PtrString(s.Enabled),
-				utils.PtrString(s.Rrule),
-				utils.PtrString(s.MaintenanceWindow),
+				s.Id,
+				s.Name,
+				s.Enabled,
+				s.Rrule,
+				s.MaintenanceWindow,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/server/os-update/schedule/list/list_test.go
+++ b/internal/cmd/server/os-update/schedule/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
@@ -56,7 +56,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiListUpdateSchedulesRequest)) serverupdate.ApiListUpdateSchedulesRequest {
-	request := testClient.ListUpdateSchedules(testCtx, testProjectId, testServerId, testRegion)
+	request := testClient.DefaultAPI.ListUpdateSchedules(testCtx, testProjectId, testServerId, testRegion)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -145,7 +145,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/server/os-update/schedule/update/update.go
+++ b/internal/cmd/server/os-update/schedule/update/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	cliErr "github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -16,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/serverosupdate/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -41,7 +40,7 @@ type inputModel struct {
 	ScheduleName      *string
 	Enabled           *bool
 	Rrule             *string
-	MaintenanceWindow *int64
+	MaintenanceWindow *int32
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -69,7 +68,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return err
 			}
 
-			currentSchedule, err := apiClient.GetUpdateScheduleExecute(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
+			currentSchedule, err := apiClient.DefaultAPI.GetUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region).Execute()
 			if err != nil {
 				params.Printer.Debug(print.ErrorLevel, "get current server os-update schedule: %v", err)
 				return err
@@ -102,7 +101,7 @@ func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(flags.UUIDFlag(), serverIdFlag, "s", "Server ID")
 
 	cmd.Flags().StringP(nameFlag, "n", "", "os-update schedule name")
-	cmd.Flags().Int64P(maintenanceWindowFlag, "d", defaultMaintenanceWindow, "Maintenance window (in hours, 1-24)")
+	cmd.Flags().Int32P(maintenanceWindowFlag, "d", defaultMaintenanceWindow, "Maintenance window (in hours, 1-24)")
 	cmd.Flags().BoolP(enabledFlag, "e", defaultEnabled, "Is the server os-update schedule enabled")
 	cmd.Flags().StringP(rruleFlag, "r", defaultRrule, "os-update RRULE (recurrence rule)")
 
@@ -123,7 +122,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 		ScheduleId:        scheduleId,
 		ScheduleName:      flags.FlagToStringPointer(p, cmd, nameFlag),
 		ServerId:          flags.FlagToStringValue(p, cmd, serverIdFlag),
-		MaintenanceWindow: flags.FlagToInt64Pointer(p, cmd, maintenanceWindowFlag),
+		MaintenanceWindow: flags.FlagToInt32Pointer(p, cmd, maintenanceWindowFlag),
 		Rrule:             flags.FlagToStringPointer(p, cmd, rruleFlag),
 		Enabled:           flags.FlagToBoolPointer(p, cmd, enabledFlag),
 	}
@@ -133,19 +132,19 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdate.APIClient, old serverupdate.UpdateSchedule) (serverupdate.ApiUpdateUpdateScheduleRequest, error) {
-	req := apiClient.UpdateUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
+	req := apiClient.DefaultAPI.UpdateUpdateSchedule(ctx, model.ProjectId, model.ServerId, model.ScheduleId, model.Region)
 
 	if model.MaintenanceWindow != nil {
-		old.MaintenanceWindow = model.MaintenanceWindow
+		old.MaintenanceWindow = *model.MaintenanceWindow
 	}
 	if model.Enabled != nil {
-		old.Enabled = model.Enabled
+		old.Enabled = *model.Enabled
 	}
 	if model.ScheduleName != nil {
-		old.Name = model.ScheduleName
+		old.Name = *model.ScheduleName
 	}
 	if model.Rrule != nil {
-		old.Rrule = model.Rrule
+		old.Rrule = *model.Rrule
 	}
 
 	req = req.UpdateUpdateSchedulePayload(serverupdate.UpdateUpdateSchedulePayload{
@@ -159,7 +158,7 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serverupdat
 
 func outputResult(p *print.Printer, outputFormat string, resp serverupdate.UpdateSchedule) error {
 	return p.OutputResult(outputFormat, resp, func() error {
-		p.Info("Updated server os-update schedule %s\n", utils.PtrString(resp.Id))
+		p.Info("Updated server os-update schedule %d\n", resp.Id)
 		return nil
 	})
 }

--- a/internal/cmd/server/os-update/schedule/update/update_test.go
+++ b/internal/cmd/server/os-update/schedule/update/update_test.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
@@ -12,24 +11,24 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 const (
 	testRegion     = "eu02"
-	testScheduleId = "5"
+	testScheduleId = int32(5)
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serverupdate.APIClient{}
+var testClient = &serverupdate.APIClient{DefaultAPI: &serverupdate.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServerId = uuid.NewString()
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
 	argValues := []string{
-		testScheduleId,
+		string(testScheduleId),
 	}
 	for _, mod := range mods {
 		mod(argValues)
@@ -60,12 +59,12 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Region:    testRegion,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		ScheduleId:        testScheduleId,
+		ScheduleId:        string(testScheduleId),
 		ServerId:          testServerId,
 		ScheduleName:      utils.Ptr("example-schedule-name"),
 		Enabled:           utils.Ptr(defaultEnabled),
 		Rrule:             utils.Ptr(defaultRrule),
-		MaintenanceWindow: utils.Ptr(int64(23)),
+		MaintenanceWindow: utils.Ptr(int32(23)),
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -74,13 +73,12 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureUpdateSchedule(mods ...func(schedule *serverupdate.UpdateSchedule)) *serverupdate.UpdateSchedule {
-	id, _ := strconv.ParseInt(testScheduleId, 10, 64)
 	schedule := &serverupdate.UpdateSchedule{
-		Name:              utils.Ptr("example-schedule-name"),
-		Id:                utils.Ptr(id),
-		Enabled:           utils.Ptr(defaultEnabled),
-		Rrule:             utils.Ptr(defaultRrule),
-		MaintenanceWindow: utils.Ptr(int64(23)),
+		Name:              "example-schedule-name",
+		Id:                testScheduleId,
+		Enabled:           defaultEnabled,
+		Rrule:             defaultRrule,
+		MaintenanceWindow: int32(23),
 	}
 	for _, mod := range mods {
 		mod(schedule)
@@ -90,10 +88,10 @@ func fixtureUpdateSchedule(mods ...func(schedule *serverupdate.UpdateSchedule)) 
 
 func fixturePayload(mods ...func(payload *serverupdate.UpdateUpdateSchedulePayload)) serverupdate.UpdateUpdateSchedulePayload {
 	payload := serverupdate.UpdateUpdateSchedulePayload{
-		Name:              utils.Ptr("example-schedule-name"),
-		Enabled:           utils.Ptr(defaultEnabled),
-		Rrule:             utils.Ptr("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
-		MaintenanceWindow: utils.Ptr(int64(23)),
+		Name:              "example-schedule-name",
+		Enabled:           defaultEnabled,
+		Rrule:             "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1",
+		MaintenanceWindow: int32(23),
 	}
 	for _, mod := range mods {
 		mod(&payload)
@@ -102,7 +100,7 @@ func fixturePayload(mods ...func(payload *serverupdate.UpdateUpdateSchedulePaylo
 }
 
 func fixtureRequest(mods ...func(request *serverupdate.ApiUpdateUpdateScheduleRequest)) serverupdate.ApiUpdateUpdateScheduleRequest {
-	request := testClient.UpdateUpdateSchedule(testCtx, testProjectId, testServerId, testScheduleId, testRegion)
+	request := testClient.DefaultAPI.UpdateUpdateSchedule(testCtx, testProjectId, testServerId, string(testScheduleId), testRegion)
 	request = request.UpdateUpdateSchedulePayload(fixturePayload())
 	for _, mod := range mods {
 		mod(&request)
@@ -259,7 +257,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serverupdate.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/flags/flag_to_value.go
+++ b/internal/pkg/flags/flag_to_value.go
@@ -207,6 +207,17 @@ func FlagWithDefaultToInt64Value(p *print.Printer, cmd *cobra.Command, flag stri
 	return value
 }
 
+// Returns the int32 value set on the flag. If no value is set, returns the flag's default value.
+// Returns 0 if the flag value can not be converted to int32 or if the flag does not exist.
+func FlagWithDefaultToInt32Value(p *print.Printer, cmd *cobra.Command, flag string) int32 {
+	value, err := cmd.Flags().GetInt32(flag)
+	if err != nil {
+		p.Debug(print.ErrorLevel, "convert flag with default to Int32 value: %v", err)
+		return 0
+	}
+	return value
+}
+
 // Returns the string value set on the flag. If no value is set, returns the flag's default value.
 // Returns nil if the flag value can not be converted to string or if the flag does not exist.
 func FlagWithDefaultToStringValue(p *print.Printer, cmd *cobra.Command, flag string) string {

--- a/internal/pkg/services/serverosupdate/client/client.go
+++ b/internal/pkg/services/serverosupdate/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serverupdate.APIClient, error) {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-354

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
