### PR TITLE
chore(serviceenablement): switch to new sdk structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.3.8
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
-	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7
+	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2 h1:6C/iTPoYP
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2/go.mod h1:/OHYZXQb9KXDdZK5J9C2YS6DJUD2i6ednZ1rK7zpDZ0=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0 h1:l1EDIlXce2C8JcbBDHVa6nZ4SjPTqmnALTgrhms+NKI=
 github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0/go.mod h1:EXq8/J7t9p8zPmdIq+atuxyAbnQwxrQT18fI+Qpv98k=
-github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7 h1:M2PYLF8k3zmAwYWSKfUiCTNTXr7ROGuJganVVEQA3YI=
-github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.2.7/go.mod h1:jitkQuP2K/SH63Qor0C4pcqz1GDCy/lK2H4t8/VDse4=
+github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0 h1:TNZHrunhsXRbuqZcucLs2Gqy1sEyvabufM7pB5Tscmo=
+github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0/go.mod h1:fXq3TmVLb4JMSve989NFFViMFoYa83s7M3hJWgN6mdQ=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZcAMCC+p5hyTEkAyxqFwy39jFA=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0/go.mod h1:jMlBoXqrPNX5nXbo6oT7exalqilw1jiLPoIp4Cn0CdI=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0 h1:QoKyQPe8FqDqJLNgE5uRlZ/y1c1GUxjV1DDLu5QEBD8=

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -99,7 +99,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			exists, err := skeUtils.ClusterExists(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.ClusterName)
 			if err != nil {
 				// Check if the project is enabled
-				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
+				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient.DefaultAPI, model.ProjectId, model.Region)
 				if enabledErr != nil {
 					return fmt.Errorf("check if project is enabled failed: %w", enabledErr)
 				}

--- a/internal/cmd/ske/cluster/list/list.go
+++ b/internal/cmd/ske/cluster/list/list.go
@@ -73,7 +73,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			resp, err := req.Execute()
 			if err != nil {
 				// Check if SKE is enabled for this project
-				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient, model.ProjectId, model.Region)
+				enabled, enabledErr := serviceEnablementUtils.ProjectEnabled(ctx, serviceEnablementApiClient.DefaultAPI, model.ProjectId, model.Region)
 				if enabledErr != nil {
 					return fmt.Errorf("check if project is enabled failed: %w", enabledErr)
 				}

--- a/internal/cmd/ske/describe/describe.go
+++ b/internal/cmd/ske/describe/describe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -75,7 +75,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceenablement.APIClient) serviceenablement.ApiGetServiceStatusRegionalRequest {
-	req := apiClient.GetServiceStatusRegional(ctx, model.Region, model.ProjectId, skeUtils.SKEServiceId)
+	req := apiClient.DefaultAPI.GetServiceStatusRegional(ctx, model.Region, model.ProjectId, skeUtils.SKEServiceId)
 	return req
 }
 

--- a/internal/cmd/ske/describe/describe_test.go
+++ b/internal/cmd/ske/describe/describe_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	serviceEnablementUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/service-enablement/utils"
@@ -19,9 +19,10 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceenablement.APIClient{}
+var testClient = &serviceenablement.APIClient{DefaultAPI: &serviceenablement.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -49,7 +50,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceenablement.ApiGetServiceStatusRegionalRequest)) serviceenablement.ApiGetServiceStatusRegionalRequest {
-	request := testClient.GetServiceStatusRegional(testCtx, testRegion, testProjectId, serviceEnablementUtils.SKEServiceId) //nolint:staticcheck //command will be removed in a later update
+	request := testClient.DefaultAPI.GetServiceStatusRegional(testCtx, testRegion, testProjectId, serviceEnablementUtils.SKEServiceId) //nolint:staticcheck //command will be removed in a later update
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -125,7 +126,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceenablement.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/ske/disable/disable.go
+++ b/internal/cmd/ske/disable/disable.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/wait"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api/wait"
 )
 
 type inputModel struct {
@@ -71,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Disabling SKE", func() error {
-					_, err = wait.DisableServiceWaitHandler(ctx, apiClient, model.Region, model.ProjectId, utils.SKEServiceId).WaitWithContext(ctx)
+					_, err = wait.DisableServiceWaitHandler(ctx, apiClient.DefaultAPI, model.Region, model.ProjectId, utils.SKEServiceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -105,6 +105,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceenablement.APIClient) serviceenablement.ApiDisableServiceRegionalRequest {
-	req := apiClient.DisableServiceRegional(ctx, model.Region, model.ProjectId, utils.SKEServiceId)
+	req := apiClient.DefaultAPI.DisableServiceRegional(ctx, model.Region, model.ProjectId, utils.SKEServiceId)
 	return req
 }

--- a/internal/cmd/ske/disable/disable_test.go
+++ b/internal/cmd/ske/disable/disable_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceenablement.APIClient{}
+var testClient = &serviceenablement.APIClient{DefaultAPI: &serviceenablement.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -47,7 +48,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceenablement.ApiDisableServiceRegionalRequest)) serviceenablement.ApiDisableServiceRegionalRequest {
-	request := testClient.DisableServiceRegional(testCtx, testRegion, testProjectId, utils.SKEServiceId)
+	request := testClient.DefaultAPI.DisableServiceRegional(testCtx, testRegion, testProjectId, utils.SKEServiceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -122,7 +123,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceenablement.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/ske/enable/enable.go
+++ b/internal/cmd/ske/enable/enable.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/wait"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api/wait"
 )
 
 type inputModel struct {
@@ -71,7 +71,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Enabling SKE", func() error {
-					_, err = wait.EnableServiceWaitHandler(ctx, apiClient, model.Region, model.ProjectId, utils.SKEServiceId).WaitWithContext(ctx)
+					_, err = wait.EnableServiceWaitHandler(ctx, apiClient.DefaultAPI, model.Region, model.ProjectId, utils.SKEServiceId).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {
@@ -105,6 +105,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceenablement.APIClient) serviceenablement.ApiEnableServiceRegionalRequest {
-	req := apiClient.EnableServiceRegional(ctx, model.Region, model.ProjectId, utils.SKEServiceId)
+	req := apiClient.DefaultAPI.EnableServiceRegional(ctx, model.Region, model.ProjectId, utils.SKEServiceId)
 	return req
 }

--- a/internal/cmd/ske/enable/enable_test.go
+++ b/internal/cmd/ske/enable/enable_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 )
 
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceenablement.APIClient{}
+var testClient = &serviceenablement.APIClient{DefaultAPI: &serviceenablement.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
-var testRegion = "eu01"
+
+const testRegion = "eu01"
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -47,7 +48,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceenablement.ApiEnableServiceRegionalRequest)) serviceenablement.ApiEnableServiceRegionalRequest {
-	request := testClient.EnableServiceRegional(testCtx, testRegion, testProjectId, utils.SKEServiceId)
+	request := testClient.DefaultAPI.EnableServiceRegional(testCtx, testRegion, testProjectId, utils.SKEServiceId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -122,7 +123,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceenablement.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/service-enablement/client/client.go
+++ b/internal/pkg/services/service-enablement/client/client.go
@@ -7,9 +7,9 @@ import (
 	genericclient "github.com/stackitcloud/stackit-cli/internal/pkg/generic-client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serviceenablement.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServiceEnablementCustomEndpointKey), true, genericclient.CreateApiClient[*serviceenablement.APIClient](serviceenablement.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.ServiceEnablementCustomEndpointKey), false, serviceenablement.NewAPIClient)
 }

--- a/internal/pkg/services/service-enablement/utils/utils.go
+++ b/internal/pkg/services/service-enablement/utils/utils.go
@@ -5,19 +5,15 @@ import (
 	"net/http"
 
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
 )
 
 const (
 	SKEServiceId = "cloud.stackit.ske"
 )
 
-type ServiceEnablementClient interface {
-	GetServiceStatusRegionalExecute(ctx context.Context, region, projectId, serviceId string) (*serviceenablement.ServiceStatus, error)
-}
-
-func ProjectEnabled(ctx context.Context, apiClient ServiceEnablementClient, projectId, region string) (bool, error) {
-	project, err := apiClient.GetServiceStatusRegionalExecute(ctx, region, projectId, SKEServiceId)
+func ProjectEnabled(ctx context.Context, apiClient serviceenablement.DefaultAPI, projectId, region string) (bool, error) {
+	project, err := apiClient.GetServiceStatusRegional(ctx, region, projectId, SKEServiceId).Execute()
 	if err != nil {
 		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
 		if !ok {

--- a/internal/pkg/services/service-enablement/utils/utils_test.go
+++ b/internal/pkg/services/service-enablement/utils/utils_test.go
@@ -7,83 +7,96 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
+	serviceenablement "github.com/stackitcloud/stackit-sdk-go/services/serviceenablement/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
+
+const testRegion = "eu01"
 
 var (
 	testProjectId = uuid.NewString()
-	testRegion    = "eu01"
 )
 
-type serviceEnableClientMocked struct {
+type mockSettings struct {
 	serviceDisabled       bool
 	getServiceStatusFails bool
 	getServiceStatusResp  *serviceenablement.ServiceStatus
 }
 
-func (m *serviceEnableClientMocked) GetServiceStatusRegionalExecute(_ context.Context, _, _, _ string) (*serviceenablement.ServiceStatus, error) {
-	if m.getServiceStatusFails {
-		return nil, fmt.Errorf("could not get service status")
+func newServiceEnableClientMock(m mockSettings) serviceenablement.DefaultAPI {
+	return serviceenablement.DefaultAPIServiceMock{
+		GetServiceStatusRegionalExecuteMock: utils.Ptr(func(_ serviceenablement.ApiGetServiceStatusRegionalRequest) (*serviceenablement.ServiceStatus, error) {
+			if m.getServiceStatusFails {
+				return nil, fmt.Errorf("could not get service status")
+			}
+			if m.serviceDisabled {
+				return nil, &oapierror.GenericOpenAPIError{StatusCode: 404}
+			}
+			return m.getServiceStatusResp, nil
+		}),
 	}
-	if m.serviceDisabled {
-		return nil, &oapierror.GenericOpenAPIError{StatusCode: 404}
-	}
-	return m.getServiceStatusResp, nil
 }
 
 func TestProjectEnabled(t *testing.T) {
 	tests := []struct {
-		description     string
-		serviceDisabled bool
-		getProjectFails bool
-		getProjectResp  *serviceenablement.ServiceStatus
-		isValid         bool
-		expectedOutput  bool
+		description    string
+		mockSettings   mockSettings
+		isValid        bool
+		expectedOutput bool
 	}{
 		{
-			description:    "project enabled",
-			getProjectResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_ENABLED.Ptr()},
+			description: "project enabled",
+			mockSettings: mockSettings{
+				getServiceStatusResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_ENABLED.Ptr()},
+			},
 			isValid:        true,
 			expectedOutput: true,
 		},
 		{
-			description:     "project disabled (404)",
-			serviceDisabled: true,
-			isValid:         true,
-			expectedOutput:  false,
-		},
-		{
-			description:    "project disabled 1",
-			getProjectResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_ENABLING.Ptr()},
+			description: "project disabled (404)",
+			mockSettings: mockSettings{
+				serviceDisabled: true,
+			},
 			isValid:        true,
 			expectedOutput: false,
 		},
 		{
-			description:    "project disabled 2",
-			getProjectResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_DISABLING.Ptr()},
+			description: "project disabled 1",
+			mockSettings: mockSettings{
+				getServiceStatusResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_ENABLING.Ptr()},
+			},
 			isValid:        true,
 			expectedOutput: false,
 		},
 		{
-			description:    "project disabled 3",
-			getProjectResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_DISABLING.Ptr()},
+			description: "project disabled 2",
+			mockSettings: mockSettings{
+				getServiceStatusResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_DISABLING.Ptr()},
+			},
 			isValid:        true,
 			expectedOutput: false,
 		},
 		{
-			description:     "get clusters fails",
-			getProjectFails: true,
-			isValid:         false,
+			description: "project disabled 3",
+			mockSettings: mockSettings{
+				getServiceStatusResp: &serviceenablement.ServiceStatus{State: serviceenablement.SERVICESTATUSSTATE_DISABLING.Ptr()},
+			},
+			isValid:        true,
+			expectedOutput: false,
+		},
+		{
+			description: "get clusters fails",
+			mockSettings: mockSettings{
+				getServiceStatusFails: true,
+			},
+			isValid: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			client := &serviceEnableClientMocked{
-				serviceDisabled:       tt.serviceDisabled,
-				getServiceStatusFails: tt.getProjectFails,
-				getServiceStatusResp:  tt.getProjectResp,
-			}
+			client := newServiceEnableClientMock(tt.mockSettings)
 
 			output, err := ProjectEnabled(context.Background(), client, testRegion, testProjectId)
 

--- a/internal/pkg/services/ske/client/client.go
+++ b/internal/pkg/services/ske/client/client.go
@@ -10,5 +10,5 @@ import (
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*ske.APIClient, error) {
-	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.SKECustomEndpointKey), false, genericclient.CreateApiClient[*ske.APIClient](ske.NewAPIClient))
+	return genericclient.ConfigureClientGeneric(p, cliVersion, viper.GetString(config.SKECustomEndpointKey), false, ske.NewAPIClient)
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-354

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
