### PR TITLE
chore(serviceaccount): migrate to new sdk structure

### DIFF
--- a/docs/stackit_service-account_token_create.md
+++ b/docs/stackit_service-account_token_create.md
@@ -25,9 +25,9 @@ stackit service-account token create [flags]
 ### Options
 
 ```
-  -e, --email string   Service account email
-  -h, --help           Help for "stackit service-account token create"
-      --ttl-days int   How long (in days) the new access token is valid (default 90)
+  -e, --email string     Service account email
+  -h, --help             Help for "stackit service-account token create"
+      --ttl-days int32   How long (in days) the new access token is valid (default 90)
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.18.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2
-	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0
+	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,8 @@ github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0 h1:U3bm+RVHD
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.0/go.mod h1:BJeafbecuocdirGCAJ2Vz/rPSK/LRrB5lPBEacqd1eU=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2 h1:6C/iTPoYPCrZOc3JMmvyDNs4hm+JR5p9O3DIfFGgnbo=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2/go.mod h1:/OHYZXQb9KXDdZK5J9C2YS6DJUD2i6ednZ1rK7zpDZ0=
-github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0 h1:l1EDIlXce2C8JcbBDHVa6nZ4SjPTqmnALTgrhms+NKI=
-github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.12.0/go.mod h1:EXq8/J7t9p8zPmdIq+atuxyAbnQwxrQT18fI+Qpv98k=
+github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.0 h1:4/xfpcqHLkKkaVS/HOOIWa3n7Z/O0DysPc+/+FVSltE=
+github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.0/go.mod h1:xJNa86o89czK2o60+s46vz8+NSKDTbQduFGFaztJnsA=
 github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0 h1:TNZHrunhsXRbuqZcucLs2Gqy1sEyvabufM7pB5Tscmo=
 github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0/go.mod h1:fXq3TmVLb4JMSve989NFFViMFoYa83s7M3hJWgN6mdQ=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZcAMCC+p5hyTEkAyxqFwy39jFA=

--- a/internal/cmd/service-account/create/create.go
+++ b/internal/cmd/service-account/create/create.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -14,10 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 )
 
 const (
@@ -26,7 +25,7 @@ const (
 
 type inputModel struct {
 	*globalflags.GlobalFlagModel
-	Name *string
+	Name string
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -94,7 +93,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 
 	model := inputModel{
 		GlobalFlagModel: globalFlags,
-		Name:            flags.FlagToStringPointer(p, cmd, nameFlag),
+		Name:            flags.FlagToStringValue(p, cmd, nameFlag),
 	}
 
 	p.DebugInputModel(model)
@@ -102,7 +101,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiCreateServiceAccountRequest {
-	req := apiClient.CreateServiceAccount(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.CreateServiceAccount(ctx, model.ProjectId)
 	req = req.CreateServiceAccountPayload(serviceaccount.CreateServiceAccountPayload{
 		Name: model.Name,
 	})
@@ -115,7 +114,7 @@ func outputResult(p *print.Printer, outputFormat, projectLabel string, serviceAc
 	}
 
 	return p.OutputResult(outputFormat, serviceAccount, func() error {
-		p.Outputf("Created service account for project %q. Email: %s\n", projectLabel, utils.PtrString(serviceAccount.Email))
+		p.Outputf("Created service account for project %q. Email: %s\n", projectLabel, serviceAccount.Email)
 		return nil
 	})
 }

--- a/internal/cmd/service-account/create/create_test.go
+++ b/internal/cmd/service-account/create/create_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +19,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -40,7 +39,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			ProjectId: testProjectId,
 			Verbosity: globalflags.VerbosityDefault,
 		},
-		Name: utils.Ptr("example"),
+		Name: "example",
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -49,9 +48,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiCreateServiceAccountRequest)) serviceaccount.ApiCreateServiceAccountRequest {
-	request := testClient.CreateServiceAccount(testCtx, testProjectId)
+	request := testClient.DefaultAPI.CreateServiceAccount(testCtx, testProjectId)
 	request = request.CreateServiceAccountPayload(serviceaccount.CreateServiceAccountPayload{
-		Name: utils.Ptr("example"),
+		Name: "example",
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -90,7 +89,7 @@ func TestParseInput(t *testing.T) {
 					ProjectId: testProjectId,
 					Verbosity: globalflags.VerbosityDefault,
 				},
-				Name: utils.Ptr(""),
+				Name: "",
 			},
 		},
 		{
@@ -142,7 +141,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/delete/delete.go
+++ b/internal/cmd/service-account/delete/delete.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -91,6 +91,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiDeleteServiceAccountRequest {
-	req := apiClient.DeleteServiceAccount(ctx, model.ProjectId, model.Email)
+	req := apiClient.DefaultAPI.DeleteServiceAccount(ctx, model.ProjectId, model.Email)
 	return req
 }

--- a/internal/cmd/service-account/delete/delete_test.go
+++ b/internal/cmd/service-account/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -18,7 +18,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testEmail = "service-account-email-1234567@sa.stackit.cloud"
 
@@ -57,7 +57,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiDeleteServiceAccountRequest)) serviceaccount.ApiDeleteServiceAccountRequest {
-	request := testClient.DeleteServiceAccount(testCtx, testProjectId, testEmail)
+	request := testClient.DefaultAPI.DeleteServiceAccount(testCtx, testProjectId, testEmail)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -151,7 +151,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/get-jwks/get_jwks.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get JWKS: %w", err)
 			}
-			jwks := *resp.Keys
+			jwks := resp.Keys
 			if len(jwks) == 0 {
 				params.Printer.Info("Empty JWKS for service account %s\n", model.Email)
 				return nil
@@ -79,7 +79,7 @@ func parseInput(p *print.Printer, _ *cobra.Command, inputArgs []string) (*inputM
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiGetJWKSRequest {
-	req := apiClient.GetJWKS(ctx, model.Email)
+	req := apiClient.DefaultAPI.GetJWKS(ctx, model.Email)
 	return req
 }
 

--- a/internal/cmd/service-account/get-jwks/get_jwks_test.go
+++ b/internal/cmd/service-account/get-jwks/get_jwks_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
 
@@ -16,7 +16,7 @@ import (
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testEmail = "service-account-email-1234567@sa.stackit.cloud"
 
 func fixtureArgValues(mods ...func(argValues []string)) []string {
@@ -40,7 +40,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiGetJWKSRequest)) serviceaccount.ApiGetJWKSRequest {
-	request := testClient.GetJWKS(testCtx, testEmail)
+	request := testClient.DefaultAPI.GetJWKS(testCtx, testEmail)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -130,7 +130,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -86,7 +86,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			params.Printer.Info("Created key for service account %s with ID %q\n", model.ServiceAccountEmail, *resp.Id)
+			params.Printer.Outputf("Created key for service account %s with ID %q\n", model.ServiceAccountEmail, resp.Id)
 
 			key, err := json.MarshalIndent(resp, "", "  ")
 			if err != nil {
@@ -144,7 +144,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient, now time.Time) serviceaccount.ApiCreateServiceAccountKeyRequest {
-	req := apiClient.CreateServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail)
+	req := apiClient.DefaultAPI.CreateServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail)
 
 	var validUntil *time.Time
 	validUntil = nil

--- a/internal/cmd/service-account/key/create/create_test.go
+++ b/internal/cmd/service-account/key/create/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testNow = time.Now()
@@ -53,7 +53,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiCreateServiceAccountKeyRequest)) serviceaccount.ApiCreateServiceAccountKeyRequest {
-	request := testClient.CreateServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail)
+	request := testClient.DefaultAPI.CreateServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail)
 	request = request.CreateServiceAccountKeyPayload(serviceaccount.CreateServiceAccountKeyPayload{})
 	for _, mod := range mods {
 		mod(&request)
@@ -190,7 +190,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/key/delete/delete.go
+++ b/internal/cmd/service-account/key/delete/delete.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -112,6 +112,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiDeleteServiceAccountKeyRequest {
-	req := apiClient.DeleteServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
+	req := apiClient.DefaultAPI.DeleteServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
 	return req
 }

--- a/internal/cmd/service-account/key/delete/delete_test.go
+++ b/internal/cmd/service-account/key/delete/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -18,7 +18,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testKeyId = uuid.NewString()
@@ -60,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiDeleteServiceAccountKeyRequest)) serviceaccount.ApiDeleteServiceAccountKeyRequest {
-	request := testClient.DeleteServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
+	request := testClient.DefaultAPI.DeleteServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -174,7 +174,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/key/describe/describe.go
+++ b/internal/cmd/service-account/key/describe/describe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -104,7 +104,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiGetServiceAccountKeyRequest {
-	req := apiClient.GetServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
+	req := apiClient.DefaultAPI.GetServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
 	return req
 }
 

--- a/internal/cmd/service-account/key/describe/describe_test.go
+++ b/internal/cmd/service-account/key/describe/describe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -19,7 +19,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testKeyId = uuid.NewString()
@@ -61,7 +61,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiGetServiceAccountKeyRequest)) serviceaccount.ApiGetServiceAccountKeyRequest {
-	request := testClient.GetServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
+	request := testClient.DefaultAPI.GetServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -175,7 +175,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/key/list/list.go
+++ b/internal/cmd/service-account/key/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -17,7 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -68,18 +67,14 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list keys metadata: %w", err)
 			}
-			keys := *resp.Items
-			if len(keys) == 0 {
-				params.Printer.Info("No keys found for service account %s\n", model.ServiceAccountEmail)
-				return nil
-			}
+			keys := resp.Items
 
 			// Truncate output
 			if model.Limit != nil && len(keys) > int(*model.Limit) {
 				keys = keys[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, keys)
+			return outputResult(params.Printer, model.OutputFormat, model.ServiceAccountEmail, keys)
 		},
 	}
 
@@ -128,12 +123,17 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiListServiceAccountKeysRequest {
-	req := apiClient.ListServiceAccountKeys(ctx, model.ProjectId, model.ServiceAccountEmail)
+	req := apiClient.DefaultAPI.ListServiceAccountKeys(ctx, model.ProjectId, model.ServiceAccountEmail)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, keys []serviceaccount.ServiceAccountKeyListResponse) error {
+func outputResult(p *print.Printer, outputFormat, serviceAccountEmail string, keys []serviceaccount.ServiceAccountKeyListResponse) error {
 	return p.OutputResult(outputFormat, keys, func() error {
+		if len(keys) == 0 {
+			p.Outputf("No keys found for service account %s\n", serviceAccountEmail)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "ACTIVE", "CREATED_AT", "VALID_UNTIL")
 		for i := range keys {
@@ -143,9 +143,9 @@ func outputResult(p *print.Printer, outputFormat string, keys []serviceaccount.S
 				validUntil = k.ValidUntil.String()
 			}
 			table.AddRow(
-				utils.PtrString(k.Id),
-				utils.PtrString(k.Active),
-				utils.PtrString(k.CreatedAt),
+				k.Id,
+				k.Active,
+				k.CreatedAt,
 				validUntil,
 			)
 		}

--- a/internal/cmd/service-account/key/list/list_test.go
+++ b/internal/cmd/service-account/key/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 
@@ -52,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiListServiceAccountKeysRequest)) serviceaccount.ApiListServiceAccountKeysRequest {
-	request := testClient.ListServiceAccountKeys(testCtx, testProjectId, testServiceAccountEmail)
+	request := testClient.DefaultAPI.ListServiceAccountKeys(testCtx, testProjectId, testServiceAccountEmail)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -148,7 +148,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -159,8 +159,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat string
-		keys         []serviceaccount.ServiceAccountKeyListResponse
+		outputFormat        string
+		serviceAccountEmail string
+		keys                []serviceaccount.ServiceAccountKeyListResponse
 	}
 	tests := []struct {
 		name    string
@@ -190,7 +191,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.keys); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serviceAccountEmail, tt.args.keys); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/service-account/key/update/update.go
+++ b/internal/cmd/service-account/key/update/update.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -153,7 +153,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient, now time.Time) serviceaccount.ApiPartialUpdateServiceAccountKeyRequest {
-	req := apiClient.PartialUpdateServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
+	req := apiClient.DefaultAPI.PartialUpdateServiceAccountKey(ctx, model.ProjectId, model.ServiceAccountEmail, model.KeyId)
 
 	var validUntil *time.Time
 	validUntil = nil

--- a/internal/cmd/service-account/key/update/update_test.go
+++ b/internal/cmd/service-account/key/update/update_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testKeyId = uuid.NewString()
@@ -64,7 +64,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiPartialUpdateServiceAccountKeyRequest)) serviceaccount.ApiPartialUpdateServiceAccountKeyRequest {
-	request := testClient.PartialUpdateServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
+	request := testClient.DefaultAPI.PartialUpdateServiceAccountKey(testCtx, testProjectId, testServiceAccountEmail, testKeyId)
 	request = request.PartialUpdateServiceAccountKeyPayload(serviceaccount.PartialUpdateServiceAccountKeyPayload{})
 	for _, mod := range mods {
 		mod(&request)
@@ -254,7 +254,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/list/list.go
+++ b/internal/cmd/service-account/list/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/projectname"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -60,15 +59,12 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list service accounts: %w", err)
 			}
-			serviceAccounts := *resp.Items
-			if len(serviceAccounts) == 0 {
-				projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
-				if err != nil {
-					params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
-					projectLabel = model.ProjectId
-				}
-				params.Printer.Info("No service accounts found for project %q\n", projectLabel)
-				return nil
+			serviceAccounts := resp.Items
+
+			projectLabel, err := projectname.GetProjectName(ctx, params.Printer, params.CliVersion, cmd)
+			if err != nil {
+				params.Printer.Debug(print.ErrorLevel, "get project name: %v", err)
+				projectLabel = model.ProjectId
 			}
 
 			// Truncate output
@@ -76,7 +72,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				serviceAccounts = serviceAccounts[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, serviceAccounts)
+			return outputResult(params.Printer, model.OutputFormat, projectLabel, serviceAccounts)
 		},
 	}
 
@@ -112,19 +108,24 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiListServiceAccountsRequest {
-	req := apiClient.ListServiceAccounts(ctx, model.ProjectId)
+	req := apiClient.DefaultAPI.ListServiceAccounts(ctx, model.ProjectId)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, serviceAccounts []serviceaccount.ServiceAccount) error {
+func outputResult(p *print.Printer, outputFormat, projectLabel string, serviceAccounts []serviceaccount.ServiceAccount) error {
 	return p.OutputResult(outputFormat, serviceAccounts, func() error {
+		if len(serviceAccounts) == 0 {
+			p.Outputf("No service accounts found for project %q\n", projectLabel)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "EMAIL")
 		for i := range serviceAccounts {
 			account := serviceAccounts[i]
 			table.AddRow(
-				utils.PtrString(account.Id),
-				utils.PtrString(account.Email),
+				account.Id,
+				account.Email,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/service-account/list/list_test.go
+++ b/internal/cmd/service-account/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
@@ -49,7 +49,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiListServiceAccountsRequest)) serviceaccount.ApiListServiceAccountsRequest {
-	request := testClient.ListServiceAccounts(testCtx, testProjectId)
+	request := testClient.DefaultAPI.ListServiceAccounts(testCtx, testProjectId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -138,7 +138,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -150,6 +150,7 @@ func TestBuildRequest(t *testing.T) {
 func TestOutputResult(t *testing.T) {
 	type args struct {
 		outputFormat    string
+		projectLabel    string
 		serviceAccounts []serviceaccount.ServiceAccount
 	}
 	tests := []struct {
@@ -180,7 +181,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serviceAccounts); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.projectLabel, tt.args.serviceAccounts); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/service-account/token/create/create.go
+++ b/internal/cmd/service-account/token/create/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -16,7 +16,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 )
 
 const (
@@ -30,7 +29,7 @@ type inputModel struct {
 	*globalflags.GlobalFlagModel
 
 	ServiceAccountEmail string
-	TTLDays             *int64
+	TTLDays             int32
 }
 
 func NewCmd(params *types.CmdParams) *cobra.Command {
@@ -87,7 +86,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 
 func configureFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(serviceAccountEmailFlag, "e", "", "Service account email")
-	cmd.Flags().Int64(ttlDaysFlag, defaultTTLDays, "How long (in days) the new access token is valid")
+	cmd.Flags().Int32(ttlDaysFlag, defaultTTLDays, "How long (in days) the new access token is valid")
 
 	err := flags.MarkFlagsRequired(cmd, serviceAccountEmailFlag)
 	cobra.CheckErr(err)
@@ -107,7 +106,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 		}
 	}
 
-	ttlDays := flags.FlagWithDefaultToInt64Value(p, cmd, ttlDaysFlag)
+	ttlDays := flags.FlagWithDefaultToInt32Value(p, cmd, ttlDaysFlag)
 	if ttlDays < 1 {
 		return nil, &errors.FlagValidationError{
 			Flag:    serviceAccountEmailFlag,
@@ -118,7 +117,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 	model := inputModel{
 		GlobalFlagModel:     globalFlags,
 		ServiceAccountEmail: email,
-		TTLDays:             &ttlDays,
+		TTLDays:             ttlDays,
 	}
 
 	p.DebugInputModel(model)
@@ -126,7 +125,7 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiCreateAccessTokenRequest {
-	req := apiClient.CreateAccessToken(ctx, model.ProjectId, model.ServiceAccountEmail)
+	req := apiClient.DefaultAPI.CreateAccessToken(ctx, model.ProjectId, model.ServiceAccountEmail)
 	req = req.CreateAccessTokenPayload(serviceaccount.CreateAccessTokenPayload{
 		TtlDays: model.TTLDays,
 	})
@@ -134,14 +133,14 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceacco
 }
 
 func outputResult(p *print.Printer, outputFormat, serviceAccountEmail string, token *serviceaccount.AccessToken) error {
-	if token == nil {
-		return fmt.Errorf("token is nil")
-	}
-
 	return p.OutputResult(outputFormat, token, func() error {
-		p.Outputf("Created access token for service account %s. Token ID: %s\n\n", serviceAccountEmail, utils.PtrString(token.Id))
-		p.Outputf("Valid until: %s\n", utils.PtrString(token.ValidUntil))
-		p.Outputf("Token: %s\n", utils.PtrString(token.Token))
+		if token == nil {
+			return fmt.Errorf("token is nil")
+		}
+
+		p.Outputf("Created access token for service account %s. Token ID: %s\n\n", serviceAccountEmail, token.Id)
+		p.Outputf("Valid until: %s\n", token.ValidUntil)
+		p.Outputf("Token: %s\n", token.Token)
 		return nil
 	})
 }

--- a/internal/cmd/service-account/token/create/create_test.go
+++ b/internal/cmd/service-account/token/create/create_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
+
+	"github.com/stackitcloud/stackit-cli/internal/pkg/globalflags"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testparams"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/testutils"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,11 +19,11 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testTTLDaysString = "90"
-var testTTLDays = int64(90)
+var testTTLDays = int32(90)
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -45,7 +44,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 			Verbosity: globalflags.VerbosityDefault,
 		},
 		ServiceAccountEmail: testServiceAccountEmail,
-		TTLDays:             utils.Ptr(testTTLDays),
+		TTLDays:             testTTLDays,
 	}
 	for _, mod := range mods {
 		mod(model)
@@ -54,9 +53,9 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiCreateAccessTokenRequest)) serviceaccount.ApiCreateAccessTokenRequest {
-	request := testClient.CreateAccessToken(testCtx, testProjectId, testServiceAccountEmail)
+	request := testClient.DefaultAPI.CreateAccessToken(testCtx, testProjectId, testServiceAccountEmail)
 	request = request.CreateAccessTokenPayload(serviceaccount.CreateAccessTokenPayload{
-		TtlDays: utils.Ptr(int64(testTTLDays)),
+		TtlDays: testTTLDays,
 	})
 	for _, mod := range mods {
 		mod(&request)
@@ -148,7 +147,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/cmd/service-account/token/list/list.go
+++ b/internal/cmd/service-account/token/list/list.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -14,10 +17,6 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/service-account/client"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/tables"
-	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 )
 
 const (
@@ -72,18 +71,14 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list tokens metadata: %w", err)
 			}
-			tokensMetadata := *resp.Items
-			if len(tokensMetadata) == 0 {
-				params.Printer.Info("No tokens found for service account with email %q\n", model.ServiceAccountEmail)
-				return nil
-			}
+			tokensMetadata := resp.Items
 
 			// Truncate output
 			if model.Limit != nil && len(tokensMetadata) > int(*model.Limit) {
 				tokensMetadata = tokensMetadata[:*model.Limit]
 			}
 
-			return outputResult(params.Printer, model.OutputFormat, tokensMetadata)
+			return outputResult(params.Printer, model.OutputFormat, model.ServiceAccountEmail, tokensMetadata)
 		},
 	}
 
@@ -132,21 +127,26 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiListAccessTokensRequest {
-	req := apiClient.ListAccessTokens(ctx, model.ProjectId, model.ServiceAccountEmail)
+	req := apiClient.DefaultAPI.ListAccessTokens(ctx, model.ProjectId, model.ServiceAccountEmail)
 	return req
 }
 
-func outputResult(p *print.Printer, outputFormat string, tokensMetadata []serviceaccount.AccessTokenMetadata) error {
+func outputResult(p *print.Printer, outputFormat, serviceAccountEmail string, tokensMetadata []serviceaccount.AccessTokenMetadata) error {
 	return p.OutputResult(outputFormat, tokensMetadata, func() error {
+		if len(tokensMetadata) == 0 {
+			p.Outputf("No tokens found for service account with email %q\n", serviceAccountEmail)
+			return nil
+		}
+
 		table := tables.NewTable()
 		table.SetHeader("ID", "ACTIVE", "CREATED_AT", "VALID_UNTIL")
 		for i := range tokensMetadata {
 			t := tokensMetadata[i]
 			table.AddRow(
-				utils.PtrString(t.Id),
-				utils.PtrString(t.Active),
-				utils.PtrString(t.CreatedAt),
-				utils.PtrString(t.ValidUntil),
+				t.Id,
+				t.Active,
+				t.CreatedAt,
+				t.ValidUntil,
 			)
 		}
 		err := table.Display(p)

--- a/internal/cmd/service-account/token/list/list_test.go
+++ b/internal/cmd/service-account/token/list/list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -20,7 +20,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 
@@ -52,7 +52,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiListAccessTokensRequest)) serviceaccount.ApiListAccessTokensRequest {
-	request := testClient.ListAccessTokens(testCtx, testProjectId, testServiceAccountEmail)
+	request := testClient.DefaultAPI.ListAccessTokens(testCtx, testProjectId, testServiceAccountEmail)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -148,7 +148,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)
@@ -159,8 +159,9 @@ func TestBuildRequest(t *testing.T) {
 
 func TestOutputResult(t *testing.T) {
 	type args struct {
-		outputFormat   string
-		tokensMetadata []serviceaccount.AccessTokenMetadata
+		outputFormat        string
+		serviceAccountEmail string
+		tokensMetadata      []serviceaccount.AccessTokenMetadata
 	}
 	tests := []struct {
 		name    string
@@ -190,7 +191,7 @@ func TestOutputResult(t *testing.T) {
 	params := testparams.NewTestParams()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.tokensMetadata); (err != nil) != tt.wantErr {
+			if err := outputResult(params.Printer, tt.args.outputFormat, tt.args.serviceAccountEmail, tt.args.tokensMetadata); (err != nil) != tt.wantErr {
 				t.Errorf("outputResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/cmd/service-account/token/revoke/revoke.go
+++ b/internal/cmd/service-account/token/revoke/revoke.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/utils"
 
 	"github.com/spf13/cobra"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 const (
@@ -115,6 +115,6 @@ func parseInput(p *print.Printer, cmd *cobra.Command, inputArgs []string) (*inpu
 }
 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *serviceaccount.APIClient) serviceaccount.ApiDeleteAccessTokenRequest {
-	req := apiClient.DeleteAccessToken(ctx, model.ProjectId, model.ServiceAccountEmail, model.TokenId)
+	req := apiClient.DefaultAPI.DeleteAccessToken(ctx, model.ProjectId, model.ServiceAccountEmail, model.TokenId)
 	return req
 }

--- a/internal/cmd/service-account/token/revoke/revoke_test.go
+++ b/internal/cmd/service-account/token/revoke/revoke_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 var projectIdFlag = globalflags.ProjectIdFlag
@@ -18,7 +18,7 @@ var projectIdFlag = globalflags.ProjectIdFlag
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
-var testClient = &serviceaccount.APIClient{}
+var testClient = &serviceaccount.APIClient{DefaultAPI: &serviceaccount.DefaultAPIService{}}
 var testProjectId = uuid.NewString()
 var testServiceAccountEmail = "my-service-account-1234567@sa.stackit.cloud"
 var testTokenId = uuid.NewString()
@@ -60,7 +60,7 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 }
 
 func fixtureRequest(mods ...func(request *serviceaccount.ApiDeleteAccessTokenRequest)) serviceaccount.ApiDeleteAccessTokenRequest {
-	request := testClient.DeleteAccessToken(testCtx, testProjectId, testServiceAccountEmail, testTokenId)
+	request := testClient.DefaultAPI.DeleteAccessToken(testCtx, testProjectId, testServiceAccountEmail, testTokenId)
 	for _, mod := range mods {
 		mod(&request)
 	}
@@ -174,7 +174,7 @@ func TestBuildRequest(t *testing.T) {
 
 			diff := cmp.Diff(request, tt.expectedRequest,
 				cmp.AllowUnexported(tt.expectedRequest),
-				cmpopts.EquateComparable(testCtx),
+				cmpopts.EquateComparable(testCtx, serviceaccount.DefaultAPIService{}),
 			)
 			if diff != "" {
 				t.Fatalf("Data does not match: %s", diff)

--- a/internal/pkg/services/service-account/client/client.go
+++ b/internal/pkg/services/service-account/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 
 	"github.com/spf13/viper"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 )
 
 func ConfigureClient(p *print.Printer, cliVersion string) (*serviceaccount.APIClient, error) {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-354

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
