### PR TITLE
fix(iaas): safely check resp.NetworkInterface for nil

### DIFF
--- a/internal/pkg/services/iaas/utils/utils.go
+++ b/internal/pkg/services/iaas/utils/utils.go
@@ -39,8 +39,8 @@ func GetPublicIP(ctx context.Context, apiClient iaas.DefaultAPI, projectId, regi
 		return "", "", fmt.Errorf("get public ip: %w", err)
 	}
 	associatedResourceId := ""
-	if resp.NetworkInterface.IsSet() {
-		associatedResourceId = *resp.NetworkInterface.Get()
+	if networkInterface := resp.NetworkInterface.Get(); networkInterface != nil {
+		associatedResourceId = *networkInterface
 	}
 	return *resp.Ip, associatedResourceId, nil
 }

--- a/internal/pkg/services/iaas/utils/utils_test.go
+++ b/internal/pkg/services/iaas/utils/utils_test.go
@@ -263,6 +263,17 @@ func TestGetPublicIp(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "nil network interface",
+			args: args{
+				getPublicIpResp: &iaas.PublicIp{
+					Ip:               utils.Ptr("1.2.3.4"),
+					NetworkInterface: *iaas.NewNullableString(nil),
+				},
+			},
+			wantPublicIp:           "1.2.3.4",
+			wantAssociatedResource: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
NullableString.IsSet() returns true even if the value is nil:

```
func (v *NullableString) UnmarshalJSON(src []byte) error {
	v.isSet = true
	return json.Unmarshal(src, &v.value)
}
```

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
