### PR TITLE
fix(network): fix nil pointer dereference when dns name servers are n…

### DIFF
--- a/internal/cmd/network/update/update.go
+++ b/internal/cmd/network/update/update.go
@@ -180,8 +180,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	var payloadIPv6 *iaas.UpdateNetworkIPv6Body
 
 	if model.IPv6DnsNameServers != nil || model.NoIPv6Gateway || model.IPv6Gateway != nil {
-		payloadIPv6 = &iaas.UpdateNetworkIPv6Body{
-			Nameservers: *model.IPv6DnsNameServers,
+		payloadIPv6 = &iaas.UpdateNetworkIPv6Body{}
+
+		if model.IPv6DnsNameServers != nil {
+			payloadIPv6.Nameservers = *model.IPv6DnsNameServers
 		}
 
 		if model.NoIPv6Gateway {
@@ -192,8 +194,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient *iaas.APICli
 	}
 
 	if model.IPv4DnsNameServers != nil || model.NoIPv4Gateway || model.IPv4Gateway != nil {
-		payloadIPv4 = &iaas.UpdateNetworkIPv4Body{
-			Nameservers: *model.IPv4DnsNameServers,
+		payloadIPv4 = &iaas.UpdateNetworkIPv4Body{}
+
+		if model.IPv4DnsNameServers != nil {
+			payloadIPv4.Nameservers = *model.IPv4DnsNameServers
 		}
 
 		if model.NoIPv4Gateway {

--- a/internal/cmd/network/update/update_test.go
+++ b/internal/cmd/network/update/update_test.go
@@ -80,12 +80,10 @@ func fixtureInputModel(mods ...func(model *inputModel)) *inputModel {
 	return model
 }
 
-func fixtureRequest(mods ...func(request *iaas.ApiPartialUpdateNetworkRequest)) iaas.ApiPartialUpdateNetworkRequest {
+func fixtureRequest(mods ...func(payload *iaas.PartialUpdateNetworkPayload)) iaas.ApiPartialUpdateNetworkRequest {
 	request := testClient.DefaultAPI.PartialUpdateNetwork(testCtx, testProjectId, testRegion, testNetworkId)
-	request = request.PartialUpdateNetworkPayload(fixturePayload())
-	for _, mod := range mods {
-		mod(&request)
-	}
+	payload := fixturePayload(mods...)
+	request = request.PartialUpdateNetworkPayload(payload)
 	return request
 }
 
@@ -318,6 +316,28 @@ func TestBuildRequest(t *testing.T) {
 			description:     "base",
 			model:           fixtureInputModel(),
 			expectedRequest: fixtureRequest(),
+		},
+		{
+			description: "not setting IPv4DnsNameServers does not result in nil pointer dereference",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.IPv4DnsNameServers = nil
+				model.IPv4Gateway = new("1.1.1.1")
+			}),
+			expectedRequest: fixtureRequest(func(payload *iaas.PartialUpdateNetworkPayload) {
+				payload.Ipv4.Nameservers = nil
+				payload.Ipv4.Gateway = *iaas.NewNullableString(new("1.1.1.1"))
+			}),
+		},
+		{
+			description: "not setting IPv6DnsNameServers does not result in nil pointer dereference",
+			model: fixtureInputModel(func(model *inputModel) {
+				model.IPv6DnsNameServers = nil
+				model.IPv6Gateway = new("1.1.1.1")
+			}),
+			expectedRequest: fixtureRequest(func(payload *iaas.PartialUpdateNetworkPayload) {
+				payload.Ipv6.Nameservers = nil
+				payload.Ipv6.Gateway = *iaas.NewNullableString(new("1.1.1.1"))
+			}),
 		},
 	}
 


### PR DESCRIPTION
…ot set during update

## Description
Fixes a nil pointer dereference when no dns servers are configured for the update.
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
