### PR TITLE
feat(ske): bump sdk version and add load balancer extension support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0
-	github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0
+	github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1
 	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0
 	github.com/zalando/go-keyring v0.2.8

--- a/go.sum
+++ b/go.sum
@@ -648,8 +648,8 @@ github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0 h1:TNZH
 github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0/go.mod h1:fXq3TmVLb4JMSve989NFFViMFoYa83s7M3hJWgN6mdQ=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZcAMCC+p5hyTEkAyxqFwy39jFA=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0/go.mod h1:jMlBoXqrPNX5nXbo6oT7exalqilw1jiLPoIp4Cn0CdI=
-github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0 h1:QoKyQPe8FqDqJLNgE5uRlZ/y1c1GUxjV1DDLu5QEBD8=
-github.com/stackitcloud/stackit-sdk-go/services/ske v1.11.0/go.mod h1:KhVYCR58wETqdI7Quwhe3OR3BhB2T/b7DzaMsfDnr8g=
+github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0 h1:eu9PhRdL2GkXpHtf4NN9YBCUYcARdvAwq+g/FW4hmi4=
+github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0/go.mod h1:TbqmZhLMofmfl+HhVl6oHYcI3zvXTm1vRjN3A/fOkM4=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1 h1:pjFVw2Tc0cSfAzmyZRiLknuKSADs7nPXNUyrM216CwQ=
 github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
 github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0 h1:LMgbzhPunuelsIsfyEj/5O/aYfNcg/eGHsnZ7AZOhYg=

--- a/internal/cmd/ske/cluster/create/create.go
+++ b/internal/cmd/ske/cluster/create/create.go
@@ -134,7 +134,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Creating cluster", func() error {
-					_, err = wait.CreateOrUpdateClusterWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, name).WaitWithContext(ctx)
+					_, err = wait.CreateClusterWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, name).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {

--- a/internal/cmd/ske/cluster/create/create_test.go
+++ b/internal/cmd/ske/cluster/create/create_test.go
@@ -55,7 +55,7 @@ var testPayload = &ske.CreateOrUpdateClusterPayload{
 			},
 			AvailabilityZones: []string{"eu01-3"},
 			Cri: &ske.CRI{
-				Name:                 utils.Ptr("containerd"),
+				Name:                 ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 				AdditionalProperties: map[string]any{},
 			},
 			AdditionalProperties: map[string]any{},

--- a/internal/cmd/ske/cluster/update/update.go
+++ b/internal/cmd/ske/cluster/update/update.go
@@ -96,7 +96,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 			// Wait for async operation, if async mode not enabled
 			if !model.Async {
 				err := spinner.Run(params.Printer, "Updating cluster", func() error {
-					_, err = wait.CreateOrUpdateClusterWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, name).WaitWithContext(ctx)
+					_, err = wait.UpdateClusterWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, name).WaitWithContext(ctx)
 					return err
 				})
 				if err != nil {

--- a/internal/cmd/ske/cluster/update/update_test.go
+++ b/internal/cmd/ske/cluster/update/update_test.go
@@ -54,7 +54,7 @@ var testPayload = ske.CreateOrUpdateClusterPayload{
 			},
 			AvailabilityZones: []string{"eu01-3"},
 			Cri: &ske.CRI{
-				Name:                 utils.Ptr("containerd"),
+				Name:                 ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 				AdditionalProperties: map[string]any{},
 			},
 			AdditionalProperties: map[string]any{},

--- a/internal/cmd/ske/options/machine_images/machine_images_test.go
+++ b/internal/cmd/ske/options/machine_images/machine_images_test.go
@@ -186,7 +186,7 @@ func TestOutputResult(t *testing.T) {
 								{
 									Cri: []ske.CRI{
 										{
-											Name: utils.Ptr("containerd"),
+											Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 										},
 									},
 									ExpirationDate: utils.Ptr(time.Now()),

--- a/internal/pkg/services/ske/utils/utils.go
+++ b/internal/pkg/services/ske/utils/utils.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultNodepoolCRI              = "containerd"
+	defaultNodepoolCRI              = ske.NAMEOFTHECRILIBRARY_CONTAINERD
 	defaultNodepoolMachineImageName = "flatcar"
 	defaultNodepoolMaxUnavailable   = 0
 	defaultNodepoolMinimum          = 1
@@ -128,7 +128,7 @@ func getDefaultPayloadNodepool(resp *ske.ProviderOptions) (*ske.Nodepool, error)
 	output := &ske.Nodepool{
 		AvailabilityZones: availabilityZones,
 		Cri: &ske.CRI{
-			Name: utils.Ptr(defaultNodepoolCRI),
+			Name: new(defaultNodepoolCRI),
 		},
 		Machine: ske.Machine{
 			Type: machineType,
@@ -137,13 +137,13 @@ func getDefaultPayloadNodepool(resp *ske.ProviderOptions) (*ske.Nodepool, error)
 			},
 		},
 		// there must be as many nodes as availability zones are given
-		MaxSurge:       utils.Ptr(int32(azLen)),
-		MaxUnavailable: utils.Ptr(int32(defaultNodepoolMaxUnavailable)),
+		MaxSurge:       new(int32(azLen)),
+		MaxUnavailable: new(int32(defaultNodepoolMaxUnavailable)),
 		Maximum:        int32(azLen),
 		Minimum:        int32(defaultNodepoolMinimum),
 		Name:           defaultNodepoolName,
 		Volume: ske.Volume{
-			Type: utils.Ptr(defaultNodepoolVolumeType),
+			Type: new(defaultNodepoolVolumeType),
 			Size: int32(defaultNodepoolVolumeSize),
 		},
 	}

--- a/internal/pkg/services/ske/utils/utils_test.go
+++ b/internal/pkg/services/ske/utils/utils_test.go
@@ -164,10 +164,7 @@ func fixtureProviderOptions(mods ...func(*ske.ProviderOptions)) *ske.ProviderOpt
 						Version: utils.Ptr("1.2.3"),
 						Cri: []ske.CRI{
 							{
-								Name: utils.Ptr("docker"),
-							},
-							{
-								Name: utils.Ptr("containerd"),
+								Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 							},
 						},
 					},
@@ -176,10 +173,7 @@ func fixtureProviderOptions(mods ...func(*ske.ProviderOptions)) *ske.ProviderOpt
 						Version: utils.Ptr("3.2.1"),
 						Cri: []ske.CRI{
 							{
-								Name: utils.Ptr("docker"),
-							},
-							{
-								Name: utils.Ptr("containerd"),
+								Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 							},
 						},
 					},
@@ -193,7 +187,7 @@ func fixtureProviderOptions(mods ...func(*ske.ProviderOptions)) *ske.ProviderOpt
 						Version: utils.Ptr("4.4.4"),
 						Cri: []ske.CRI{
 							{
-								Name: utils.Ptr("containerd"),
+								Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 							},
 						},
 					},
@@ -216,7 +210,7 @@ func fixtureProviderOptions(mods ...func(*ske.ProviderOptions)) *ske.ProviderOpt
 						Version: utils.Ptr("4.4.4"),
 						Cri: []ske.CRI{
 							{
-								Name: utils.Ptr("containerd"),
+								Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 							},
 						},
 					},
@@ -228,11 +222,7 @@ func fixtureProviderOptions(mods ...func(*ske.ProviderOptions)) *ske.ProviderOpt
 					{
 						State:   utils.Ptr("supported"),
 						Version: utils.Ptr("4.4.4"),
-						Cri: []ske.CRI{
-							{
-								Name: utils.Ptr("docker"),
-							},
-						},
+						Cri:     []ske.CRI{},
 					},
 				},
 			},
@@ -263,7 +253,7 @@ func fixtureGetDefaultPayload(mods ...func(*ske.CreateOrUpdateClusterPayload)) *
 					"eu01-3",
 				},
 				Cri: &ske.CRI{
-					Name: utils.Ptr("containerd"),
+					Name: ske.NAMEOFTHECRILIBRARY_CONTAINERD.Ptr(),
 				},
 				Machine: ske.Machine{
 					Type: "b1.2",


### PR DESCRIPTION


## Description
Updates the ske SDK to support the new Load Balancer Extension
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

Relates to STACKITCLI-432

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
