### PR TITLE
fix: fix auth flow when creating project with access token

### DIFF
--- a/internal/cmd/project/create/create.go
+++ b/internal/cmd/project/create/create.go
@@ -148,29 +148,9 @@ func parseInput(p *print.Printer, cmd *cobra.Command, _ []string) (*inputModel, 
 func buildRequest(ctx context.Context, model *inputModel, apiClient *resourcemanager.APIClient) (resourcemanager.ApiCreateProjectRequest, error) {
 	req := apiClient.DefaultAPI.CreateProject(ctx)
 
-	authFlow, err := auth.GetAuthFlow()
+	email, err := auth.GetAuthEmail()
 	if err != nil {
-		return req, fmt.Errorf("get authentication flow: %w", err)
-	}
-	var email string
-	switch authFlow {
-	case auth.AUTH_FLOW_SERVICE_ACCOUNT_TOKEN:
-		email, err = auth.GetAuthField(auth.SERVICE_ACCOUNT_EMAIL)
-		if err != nil {
-			return req, fmt.Errorf("get email of the service account that was used to authenticate: %w", err)
-		}
-	case auth.AUTH_FLOW_SERVICE_ACCOUNT_KEY:
-		email, err = auth.GetAuthField(auth.SERVICE_ACCOUNT_EMAIL)
-		if err != nil {
-			return req, fmt.Errorf("get email of the service account that was used to authenticate: %w", err)
-		}
-	case auth.AUTH_FLOW_USER_TOKEN:
-		email, err = auth.GetAuthField(auth.USER_EMAIL)
-		if err != nil {
-			return req, fmt.Errorf("get your user email from configuration: %w", err)
-		}
-	default:
-		return req, fmt.Errorf("the configured authentication flow (%s) is not supported, please report this issue", authFlow)
+		return req, fmt.Errorf("get email of authenticated user: %w", err)
 	}
 
 	if email == "" {

--- a/internal/cmd/project/create/create_test.go
+++ b/internal/cmd/project/create/create_test.go
@@ -2,6 +2,9 @@ package create
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,6 +27,15 @@ var testClient = &resourcemanager.APIClient{DefaultAPI: &resourcemanager.Default
 var testParentId = uuid.NewString()
 var testNetworkAreaId = uuid.NewString()
 var testEmail = "email"
+
+// buildTestJWT creates an unsigned JWT token containing the given email claim.
+// getEmailFromToken uses ParseUnverified, so no real signing key is needed.
+func buildTestJWT(email string) string {
+	header, _ := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	payload, _ := json.Marshal(map[string]string{"email": email})
+	enc := base64.RawURLEncoding
+	return fmt.Sprintf("%s.%s.fakesig", enc.EncodeToString(header), enc.EncodeToString(payload))
+}
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
@@ -193,6 +205,7 @@ func TestBuildRequest(t *testing.T) {
 		authFlow        auth.AuthFlow
 		sa_email        *string
 		user_email      *string
+		accessToken     *string
 		expectedRequest resourcemanager.ApiCreateProjectRequest
 		isValid         bool
 	}{
@@ -217,6 +230,13 @@ func TestBuildRequest(t *testing.T) {
 			model:           fixtureInputModel(),
 			authFlow:        auth.AUTH_FLOW_USER_TOKEN,
 			user_email:      utils.Ptr(testEmail),
+			expectedRequest: fixtureRequest(),
+			isValid:         true,
+		},
+		{
+			description:     "access_token_env_var_no_stored_auth_flow",
+			model:           fixtureInputModel(),
+			accessToken:     utils.Ptr(buildTestJWT(testEmail)),
 			expectedRequest: fixtureRequest(),
 			isValid:         true,
 		},
@@ -295,6 +315,9 @@ func TestBuildRequest(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to set user email in storage: %v", err)
 				}
+			}
+			if tt.accessToken != nil {
+				t.Setenv("STACKIT_ACCESS_TOKEN", *tt.accessToken)
 			}
 			request, err := buildRequest(testCtx, tt.model, testClient)
 			if err != nil {

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -134,6 +134,9 @@ func UserSessionExpired() (bool, error) {
 }
 
 func GetAccessToken() (string, error) {
+	if accessToken := os.Getenv(envAccessTokenName); accessToken != "" {
+		return accessToken, nil
+	}
 	accessToken, err := GetAuthField(ACCESS_TOKEN)
 	if err != nil {
 		return "", fmt.Errorf("get %s: %w", ACCESS_TOKEN, err)

--- a/internal/pkg/auth/auth_test.go
+++ b/internal/pkg/auth/auth_test.go
@@ -335,3 +335,68 @@ func TestInitKeyFlow(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAccessToken_EnvVar(t *testing.T) {
+	const envValue = "token-from-env"
+	const storedValue = "stored-token"
+
+	tests := []struct {
+		description   string
+		envToken      string
+		storedToken   string
+		expectedToken string
+		isValid       bool
+	}{
+		{
+			description:   "env var set and no stored token",
+			envToken:      envValue,
+			expectedToken: envValue,
+			isValid:       true,
+		},
+		{
+			description:   "env var set and stored token present",
+			envToken:      envValue,
+			storedToken:   storedValue,
+			expectedToken: envValue,
+			isValid:       true,
+		},
+		{
+			description:   "env var not set and stored token present",
+			storedToken:   storedValue,
+			expectedToken: storedValue,
+			isValid:       true,
+		},
+		{
+			description: "env var not set and no stored token",
+			isValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			keyring.MockInit()
+			if tt.envToken != "" {
+				t.Setenv(envAccessTokenName, tt.envToken)
+			}
+			if tt.storedToken != "" {
+				if err := SetAuthField(ACCESS_TOKEN, tt.storedToken); err != nil {
+					t.Fatalf("Failed to set stored token: %v", err)
+				}
+				if err := SetAuthFlow(AUTH_FLOW_SERVICE_ACCOUNT_TOKEN); err != nil {
+					t.Fatalf("Failed to set auth flow: %v", err)
+				}
+			}
+
+			got, err := GetAccessToken()
+			if err != nil {
+				if !tt.isValid {
+					return
+				}
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectedToken != got {
+				t.Errorf("expected token %q, got %q", tt.expectedToken, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Fixes the auth flow for creating projects to be able to use STACKIT_ACCESS_TOKEN for project creation
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

Relates to STACKITTPR-761 and #1478 

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
