### PR TITLE
fix(sqlserverflex): fix instance create without --acl flag

### DIFF
--- a/internal/cmd/beta/sqlserverflex/instance/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create.go
@@ -217,6 +217,10 @@ func buildRequest(ctx context.Context, model *inputModel, apiClient sqlserverfle
 		return req, err
 	}
 
+	if model.ACL == nil {
+		model.ACL = make([]string, 0)
+	}
+
 	req = req.CreateInstancePayload(sqlserverflex.CreateInstancePayload{
 		Name: model.InstanceName,
 		Network: sqlserverflex.CreateInstancePayloadNetwork{

--- a/internal/cmd/beta/sqlserverflex/instance/create/create_test.go
+++ b/internal/cmd/beta/sqlserverflex/instance/create/create_test.go
@@ -419,6 +419,35 @@ func TestBuildRequest(t *testing.T) {
 			},
 			isValid: false,
 		},
+		{
+			description: "nil acl",
+			model: fixtureInputModel(
+				func(model *inputModel) {
+					model.ACL = nil
+				}),
+			listFlavorsResp: &sqlserverflex.ListFlavorsResponse{
+				Flavors: []sqlserverflex.ListFlavors{
+					{
+						Id:     testFlavorId,
+						Cpu:    int64(2),
+						Memory: int64(4),
+					},
+				},
+			},
+			listStoragesResp: &sqlserverflex.ListStoragesResponse{
+				StorageClasses: []sqlserverflex.FlavorStorageClassesStorageClass{{
+					Class: "storage-class",
+				}},
+				StorageRange: sqlserverflex.FlavorStorageRange{
+					Min: 10,
+					Max: 100,
+				},
+			},
+			isValid: true,
+			expectedRequest: testClient.DefaultAPI.CreateInstance(testCtx, testProjectId, testRegion).CreateInstancePayload(fixturePayload(func(payload *sqlserverflex.CreateInstancePayload) {
+				payload.Network.Acl = make([]string, 0)
+			})),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
SSD3RD-10751

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
