### PR TITLE
fix(json): service-account key create now supports json and yaml output

### DIFF
--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -86,7 +86,7 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			params.Printer.OutputResult(model.OutputFormat, resp, func() error {
+			return params.Printer.OutputResult(model.OutputFormat, resp, func() error {
 				params.Printer.Outputf("Created key for service account %s with ID %q\n", model.ServiceAccountEmail, resp.Id)
 
 				key, err := json.MarshalIndent(resp, "", "  ")
@@ -96,8 +96,6 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				params.Printer.Outputln(string(key))
 				return nil
 			})
-
-			return nil
 		},
 	}
 

--- a/internal/cmd/service-account/key/create/create.go
+++ b/internal/cmd/service-account/key/create/create.go
@@ -86,13 +86,17 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("create service account key: %w", err)
 			}
 
-			params.Printer.Outputf("Created key for service account %s with ID %q\n", model.ServiceAccountEmail, resp.Id)
+			params.Printer.OutputResult(model.OutputFormat, resp, func() error {
+				params.Printer.Outputf("Created key for service account %s with ID %q\n", model.ServiceAccountEmail, resp.Id)
 
-			key, err := json.MarshalIndent(resp, "", "  ")
-			if err != nil {
-				return fmt.Errorf("marshal key: %w", err)
-			}
-			params.Printer.Outputln(string(key))
+				key, err := json.MarshalIndent(resp, "", "  ")
+				if err != nil {
+					return fmt.Errorf("marshal key: %w", err)
+				}
+				params.Printer.Outputln(string(key))
+				return nil
+			})
+
 			return nil
 		},
 	}


### PR DESCRIPTION
https://github.com/stackitcloud/stackit-cli/issues/1527

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
