### PR TITLE
fix(sqlserverflex): add user wait handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.0
 	github.com/stackitcloud/stackit-sdk-go/services/serviceenablement v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0
-	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1
+	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.17.0
 	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/mod v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -650,8 +650,8 @@ github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0 h1:JWAFnskRbNKT8x62pZ
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.9.0/go.mod h1:jMlBoXqrPNX5nXbo6oT7exalqilw1jiLPoIp4Cn0CdI=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0 h1:eu9PhRdL2GkXpHtf4NN9YBCUYcARdvAwq+g/FW4hmi4=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.0/go.mod h1:TbqmZhLMofmfl+HhVl6oHYcI3zvXTm1vRjN3A/fOkM4=
-github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1 h1:pjFVw2Tc0cSfAzmyZRiLknuKSADs7nPXNUyrM216CwQ=
-github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.16.1/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
+github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.17.0 h1:skiTu1l1H0gumo9kosp5fSzrjWDZWcUM5pBH6aqUaG8=
+github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.17.0/go.mod h1:AiUoMAqQcOlMgDtkVJlqI7P/VGD5xjN3dYjERGnwN/M=
 github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0 h1:LMgbzhPunuelsIsfyEj/5O/aYfNcg/eGHsnZ7AZOhYg=
 github.com/stackitcloud/stackit-sdk-go/services/vpn v0.14.0/go.mod h1:toIjQk1dhxdUFVyCWJJja0w/0nFpDid8MWX0ukQfvfo=
 github.com/stbenjam/no-sprintf-host-port v0.3.1 h1:AyX7+dxI4IdLBPtDbsGAyqiTSLpCP9hWRrXQDU4Cm/g=

--- a/internal/cmd/beta/sqlserverflex/user/create/create.go
+++ b/internal/cmd/beta/sqlserverflex/user/create/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v3api"
+	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v3api/wait"
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
@@ -18,6 +19,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/sqlserverflex/client"
 	sqlserverflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/sqlserverflex/utils"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 )
 
 const (
@@ -88,6 +90,17 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("create SQLServer Flex user: %w", err)
 			}
 
+			// Wait for async operation, if async mode not enabled
+			if !model.Async {
+				err := spinner.Run(params.Printer, "Creating SQLServer Flex user", func() error {
+					_, err = wait.CreateUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId, resp.Id).WaitWithContext(ctx)
+					return err
+				})
+				if err != nil {
+					return fmt.Errorf("wait for SQLServer Flex user creation: %w", err)
+				}
+			}
+
 			return outputResult(params.Printer, model, instanceLabel, resp)
 		},
 	}
@@ -137,7 +150,12 @@ func outputResult(p *print.Printer, model *inputModel, instanceLabel string, use
 		if user == nil {
 			return fmt.Errorf("user response is empty")
 		}
-		p.Outputf("Created user for instance %q. User ID: %d\n\n", instanceLabel, user.Id)
+
+		operationState := "Created"
+		if model.Async {
+			operationState = "Triggered creation of"
+		}
+		p.Outputf("%s user for instance %q. User ID: %d\n\n", operationState, instanceLabel, user.Id)
 		p.Outputf("Username: %s\n", user.Username)
 		p.Outputf("Password: %s\n", user.Password)
 		if len(user.Roles) != 0 {

--- a/internal/cmd/beta/sqlserverflex/user/delete/delete.go
+++ b/internal/cmd/beta/sqlserverflex/user/delete/delete.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/stackitcloud/stackit-cli/internal/pkg/types"
 
+	"github.com/spf13/cobra"
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v3api"
+	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v3api/wait"
+
 	"github.com/stackitcloud/stackit-cli/internal/pkg/args"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/errors"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/examples"
@@ -15,9 +19,7 @@ import (
 	"github.com/stackitcloud/stackit-cli/internal/pkg/print"
 	"github.com/stackitcloud/stackit-cli/internal/pkg/services/sqlserverflex/client"
 	sqlserverflexUtils "github.com/stackitcloud/stackit-cli/internal/pkg/services/sqlserverflex/utils"
-
-	"github.com/spf13/cobra"
-	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v3api"
+	"github.com/stackitcloud/stackit-cli/internal/pkg/spinner"
 )
 
 const (
@@ -85,7 +87,22 @@ func NewCmd(params *types.CmdParams) *cobra.Command {
 				return fmt.Errorf("delete SQLServer Flex user: %w", err)
 			}
 
-			params.Printer.Info("Deleted user %q of instance %q\n", userLabel, instanceLabel)
+			// Wait for async operation, if async mode not enabled
+			if !model.Async {
+				err := spinner.Run(params.Printer, "Deleting SQLServer Flex user", func() error {
+					_, err = wait.DeleteUserWaitHandler(ctx, apiClient.DefaultAPI, model.ProjectId, model.Region, model.InstanceId, model.UserId).WaitWithContext(ctx)
+					return err
+				})
+				if err != nil {
+					return fmt.Errorf("wait for SQLServer Flex user deletion: %w", err)
+				}
+			}
+
+			operationState := "Deleted"
+			if model.Async {
+				operationState = "Triggered deletion of"
+			}
+			params.Printer.Info("%s user %q of instance %q\n", operationState, userLabel, instanceLabel)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description
Adds wait handlers to sqlserverflex user create and delete
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITCLI-438

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
